### PR TITLE
Watch for file creation events in watch mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use crate::verify::verify;
 use clap::{crate_version, App, Arg, SubCommand};
 use notify::DebouncedEvent;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::ffi::OsStr;
 use std::io::BufRead;
 use std::sync::mpsc::channel;
 use std::time::Duration;
@@ -85,8 +86,10 @@ fn watch() -> notify::Result<()> {
     loop {
         match rx.recv() {
             Ok(event) => match event {
-                DebouncedEvent::Chmod(_) | DebouncedEvent::Write(_) => {
-                    let _ignored = verify();
+                DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
+                    if b.extension() == Some(OsStr::new("rs")) {
+                        let _ignored = verify();
+                    }
                 }
                 _ => {}
             },


### PR DESCRIPTION
Currently watch mode only watches for `DebouncedEvent::Chmod` and `DebouncedEvent::Write`. There are some edge cases where these events wont be called even when a file is modified.

For example, if the user is using vim with swap files enabled, it seems like only a `Remove` and then `Create` event is called for the rust file. Usually this is okay because there will also be a swp file being modified, but if the user has their swap files placed in a different directory, `rustlings watch` does not work.

This fixes the issue by also listening for the `Create` event, and only triggering for .rs files (so swp file changes are ignored).

I'm guessing that this may be related to #111, as I ran into the same issue and started looking into why watch wasn't working.