### PR TITLE
Start verification at most recently modified file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn watch() -> notify::Result<()> {
     let _ignored = verify(None);
 
     loop {
-        match rx.recv() {     
+        match rx.recv() {
             Ok(event) => match event {
                 DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
                     if b.extension() == Some(OsStr::new("rs")) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,7 @@ fn watch() -> notify::Result<()> {
             Ok(event) => match event {
                 DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
                     if b.extension() == Some(OsStr::new("rs")) {
-                        println!("----------**********----------");
-                        println!();
+                        println!("----------**********----------\n");
                         let _ignored = verify(Some(b.as_path().to_str().unwrap()));
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,10 +84,12 @@ fn watch() -> notify::Result<()> {
     let _ignored = verify(None);
 
     loop {
-        match rx.recv() {
+        match rx.recv() {     
             Ok(event) => match event {
                 DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
                     if b.extension() == Some(OsStr::new("rs")) {
+                        println!("----------**********----------");
+                        println!();
                         let _ignored = verify(Some(b.as_path().to_str().unwrap()));
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
     }
 
     if matches.subcommand_matches("verify").is_some() {
-        match verify() {
+        match verify(None) {
             Ok(_) => {}
             Err(_) => std::process::exit(1),
         }
@@ -81,14 +81,14 @@ fn watch() -> notify::Result<()> {
     let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(2))?;
     watcher.watch("./exercises", RecursiveMode::Recursive)?;
 
-    let _ignored = verify();
+    let _ignored = verify(None);
 
     loop {
         match rx.recv() {
             Ok(event) => match event {
                 DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
                     if b.extension() == Some(OsStr::new("rs")) {
-                        let _ignored = verify();
+                        let _ignored = verify(Some(b.as_path().to_str().unwrap()));
                     }
                 }
                 _ => {}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -5,10 +5,22 @@ use std::fs;
 use std::process::Command;
 use toml::Value;
 
-pub fn verify() -> Result<(), ()> {
+pub fn verify(start_at: Option<&str>) -> Result<(), ()> {
     let toml: Value = fs::read_to_string("info.toml").unwrap().parse().unwrap();
     let tomlvec: &Vec<Value> = toml.get("exercises").unwrap().as_array().unwrap();
+    let mut hit_start_at = false;
+
     for i in tomlvec {
+        let path = i.get("path").unwrap().as_str().unwrap();
+
+        if let Some(start_at) = start_at {
+            if start_at.ends_with(path) {
+                hit_start_at = true;
+            } else if !hit_start_at {
+                continue;
+            }
+        }
+
         match i.get("mode").unwrap().as_str().unwrap() {
             "test" => test(i.get("path").unwrap().as_str().unwrap())?,
             "compile" => compile_only(i.get("path").unwrap().as_str().unwrap())?,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -22,8 +22,8 @@ pub fn verify(start_at: Option<&str>) -> Result<(), ()> {
         }
 
         match i.get("mode").unwrap().as_str().unwrap() {
-            "test" => test(i.get("path").unwrap().as_str().unwrap())?,
-            "compile" => compile_only(i.get("path").unwrap().as_str().unwrap())?,
+            "test" => test(path)?,
+            "compile" => compile_only(path)?,
             _ => (),
         }
     }


### PR DESCRIPTION
When in `watch` mode, it's a pain to have to wait for all previous exercises to compile before the one you just saved compiles...so now it skips compiling any files up and to the one most recently saved.