### PR TITLE
Be nicer when rustlings isn't run from the right directory.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use notify::DebouncedEvent;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::ffi::OsStr;
 use std::io::BufRead;
+use std::path::Path;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 use syntect::easy::HighlightFile;
@@ -45,6 +46,14 @@ fn main() {
         println!(r#" |_|   \__,_|___/\__|_|_|_| |_|\__, |___/ "#);
         println!(r#"                               |___/      "#);
         println!();
+    }
+
+    if !Path::new("info.toml").exists() {
+        println!(
+            "{} must be run from the rustlings directory",
+            std::env::current_exe().unwrap().to_str().unwrap()
+        );
+        std::process::exit(1);
     }
 
     if let Some(matches) = matches.subcommand_matches("run") {


### PR DESCRIPTION
Before, rustlings would panic if it wasn't in the right directory. It
took me a minute to figure out why, and this wasn't my first intro to
Rust. It would probably help new users if they saw a helpful message
instead of a stack trace.
