### PR TITLE
fix watch command path execution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn watch() -> notify::Result<()> {
     let (tx, rx) = channel();
 
     let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(2))?;
-    watcher.watch("./exercises", RecursiveMode::Recursive)?;
+    watcher.watch(Path::new("./exercises"), RecursiveMode::Recursive)?;
 
     let _ignored = verify(None);
 


### PR DESCRIPTION
@hades32 @guttume could you test whether this works on windows by checking out the branch locally and running `cargo run watch`?