### PR TITLE
Add errors to exercises that compile without user changes

### DIFF
--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -16,7 +16,8 @@ fn main() {
 
 }
 
-fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
+// `fill_vec()` no longer take `vec: Vec<i32>` as argument
+fn fill_vec() -> Vec<i32> {
     let mut vec = vec;
 
     vec.push(22);

--- a/exercises/test2.rs
+++ b/exercises/test2.rs
@@ -17,6 +17,11 @@ mod tests {
 
     #[test]
     fn returns_twice_of_positive_numbers() {
-        assert_eq!(4, 4);
+        assert_eq!(times_two(4), ???);
+    }
+
+    #[test]
+    fn returns_twice_of_negative_numbers() {
+        // TODO write an assert for `times_two(-4)`
     }
 }


### PR DESCRIPTION
Hi !

I played a bit with rustlings, and I felt that some exercises were incorrect because they passed the tests without me needing to edit the files!

This gave me the feeling that the exercise was skiped! Especially when I use `rustlings watch`, it is easy to miss an exercise because the compilation error that is displayed is the one of the next exercise ...

It is easy to identify "broken" exercises with:

```bash
% find exercises -name "*.rs" | xargs -n 1 rustlings run
...
✅ Successfully ran exercises/move_semantics/move_semantics4.rs
✅ Successfully tested exercises/test2.rs
```

My suggestion is to make sure that these files trigger a compilation error by adding a simple syntax error (e.g. with `???` in the code that must change) so that our Rustacean can then play with it!