### PR TITLE
Add not passing integration test

### DIFF
--- a/tests/fixture/failure/testNotPassed.rs
+++ b/tests/fixture/failure/testNotPassed.rs
@@ -1,0 +1,4 @@
+#[test]
+fn not_passing() {
+    assert!(false);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -77,6 +77,16 @@ fn run_single_test_failure() {
 }
 
 #[test]
+fn run_single_test_not_passed() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["r", "testNotPassed.rs"])
+        .current_dir("tests/fixture/failure/")
+        .assert()
+        .code(1);
+}
+
+#[test]
 fn run_single_test_no_filename() {
     Command::cargo_bin("rustlings")
         .unwrap()


### PR DESCRIPTION
A previous version didn't run tests inside exercises. This pull request introduces one more test to cover such situation