### PR TITLE
Update errors1.rs - Add Result type signature as it is difficult for new comers to understand Generics and Error all at once.

### DIFF
--- a/exercises/error_handling/errors1.rs
+++ b/exercises/error_handling/errors1.rs
@@ -63,7 +63,7 @@ mod tests {
 // `Option`.
 
 // To make this change, you'll need to:
-// - update the return type in the function signature to be a Result that
+// - update the return type in the function signature to be a Result<String, String> that
 //   could be the variants `Ok(String)` and `Err(String)`
 // - change the body of the function to return `Ok(stuff)` where it currently
 //   returns `Some(stuff)`


### PR DESCRIPTION
Add Result type signature as it is difficult for new comers to understand Generics and Error all at once.

At first, I tried `Result<String, Error>` and got this.
```bash
error[E0412]: cannot find type `Error` in this scope
 --> exercises/error_handling/errors1.rs:9:62
  |
9 | pub fn generate_nametag_text(name: String) -> Result<String, Error> {
  |                                                              ^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
  |
1 | use std::error::Error;
  |
1 | use std::fmt::Error;
  |
1 | use std::io::Error;
  |
```

In the book, it talks about `std::io::Error` with `Result` which is a bit confusing. See https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html

It took me a long time to understand that Result can take whatever type as a second argument.

Let me know your thoughts on how to improve this.