### PR TITLE
fix(installation): Fix rustlings installation check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,10 +94,9 @@ git checkout -q tags/$Version
 echo "Installing the 'rustlings' executable..."
 cargo install --force --path .
 
-if [ -x "$(rustlings)" ]
+if ! [ -x "$(command -v rustlings)" ]
 then
     echo "WARNING: Please check that you have '~/.cargo/bin' in your PATH environment variable!"
 fi
 
 echo "All done! Run 'rustlings' to get started."
-


### PR DESCRIPTION
fixes #147 

I did some quick testing with the `-x` check:

```sh
if [ -x "$(notrustlings)" ]
then
    echo "notrustlings does not exist"
else
    echo "notrustlings appears to exist!"
    notrustlings
fi
```

which produced:

```
./test.sh: line 12: notrustlings: command not found
notrustlings appears to exist!
./test.sh: line 17: notrustlings: command not found
```

(consistent with comments in issue)

Using `if ! [ -x "$(command -v <command>)" ]` appears to be the standard way to perform this type of check.