### PR TITLE
chore: Clean up some formatting in exercises

### DIFF
--- a/exercises/functions/functions5.rs
+++ b/exercises/functions/functions5.rs
@@ -40,7 +40,7 @@ fn square(num: i32) -> i32 {
 
 // This is a really common error that can be fixed by removing one character.
 // It happens because Rust distinguishes between expressions and statements: expressions return
-// a value based on its operand, and statements simply return a () type which behaves just like `void` in C/C++ language. 
+// a value based on its operand, and statements simply return a () type which behaves just like `void` in C/C++ language.
 // We want to return a value of `i32` type from the `square` function, but it is returning a `()` type...
 // They are not the same. There are two solutions:
 // 1. Add a `return` ahead of `num * num;`

--- a/exercises/if/if1.rs
+++ b/exercises/if/if1.rs
@@ -1,6 +1,6 @@
 // if1.rs
 
-pub fn bigger(a: i32, b:i32) -> i32 {
+pub fn bigger(a: i32, b: i32) -> i32 {
     // Complete this function to return the bigger number!
     // Do not use:
     // - return

--- a/exercises/modules/modules2.rs
+++ b/exercises/modules/modules2.rs
@@ -1,7 +1,7 @@
 // modules2.rs
 // Make me compile! Scroll down for hints :)
 
-mod delicious_snacks { 
+mod delicious_snacks {
     use self::fruits::PEAR as fruit;
     use self::veggies::CUCUMBER as veggie;
 
@@ -17,9 +17,11 @@ mod delicious_snacks {
 }
 
 fn main() {
-    println!("favorite snacks: {} and {}",
-             delicious_snacks::fruit,
-             delicious_snacks::veggie);
+    println!(
+        "favorite snacks: {} and {}",
+        delicious_snacks::fruit,
+        delicious_snacks::veggie
+    );
 }
 
 

--- a/exercises/move_semantics/move_semantics1.rs
+++ b/exercises/move_semantics/move_semantics1.rs
@@ -11,7 +11,6 @@ fn main() {
     vec1.push(88);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
-
 }
 
 fn fill_vec(vec: Vec<i32>) -> Vec<i32> {

--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -12,7 +12,6 @@ fn main() {
     vec1.push(88);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
-
 }
 
 fn fill_vec(vec: Vec<i32>) -> Vec<i32> {

--- a/exercises/move_semantics/move_semantics3.rs
+++ b/exercises/move_semantics/move_semantics3.rs
@@ -13,7 +13,6 @@ fn main() {
     vec1.push(88);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
-
 }
 
 fn fill_vec(vec: Vec<i32>) -> Vec<i32> {

--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -13,7 +13,6 @@ fn main() {
     vec1.push(88);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
-
 }
 
 // `fill_vec()` no longer take `vec: Vec<i32>` as argument

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -38,8 +38,8 @@ fn main() {
 
 
 
-// While you could use a destructuring `let` for the tuple here, try 
-// indexing into it instead, as explained in the last example of the 
+// While you could use a destructuring `let` for the tuple here, try
+// indexing into it instead, as explained in the last example of the
 // Data Types -> The Tuple Type section of the book:
 // https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type
 // Now you have another tool in your toolbox!

--- a/exercises/standard_library_types/arc1.rs
+++ b/exercises/standard_library_types/arc1.rs
@@ -13,8 +13,7 @@ fn main() {
     let mut joinhandles = Vec::new();
 
     for offset in 0..8 {
-        joinhandles.push(
-        thread::spawn(move || {
+        joinhandles.push(thread::spawn(move || {
             let mut i = offset;
             let mut sum = 0;
             while i < child_numbers.len() {

--- a/exercises/standard_library_types/iterators3.rs
+++ b/exercises/standard_library_types/iterators3.rs
@@ -23,8 +23,7 @@ pub struct NotDivisibleError {
 // This function should calculate `a` divided by `b` if `a` is
 // evenly divisible by b.
 // Otherwise, it should return a suitable error.
-pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {
-}
+pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {}
 
 #[cfg(test)]
 mod tests {
@@ -40,7 +39,7 @@ mod tests {
     fn test_not_divisible() {
         assert_eq!(
             divide(81, 6),
-            Err(DivisionError::NotDivisible(NotDivisibleError{
+            Err(DivisionError::NotDivisible(NotDivisibleError {
                 dividend: 81,
                 divisor: 6
             }))

--- a/exercises/test3.rs
+++ b/exercises/test3.rs
@@ -7,8 +7,12 @@
 // you think each value is. That is, add either `string_slice` or `string`
 // before the parentheses on each line. If you're right, it will compile!
 
-fn string_slice(arg: &str) { println!("{}", arg); }
-fn string(arg: String) { println!("{}", arg); }
+fn string_slice(arg: &str) {
+    println!("{}", arg);
+}
+fn string(arg: String) {
+    println!("{}", arg);
+}
 
 fn main() {
     ("blue");


### PR DESCRIPTION
I noticed some formatting that isn't consistent with the `rustfmt` style and tried my best to run it on the files in the exercises directory (which does fail for files that can't compile!), which just caught some minor whitespace things here and there.

Note: also can't just apply `rustfmt` blindly because of the blank lines that lead to the hint comments
