### PR TITLE
chore: Fix a couple broken book links

### DIFF
--- a/exercises/error_handling/errorsn.rs
+++ b/exercises/error_handling/errorsn.rs
@@ -195,7 +195,7 @@ impl error::Error for CreationError {
 // can be returned from the same function because all errors act the same
 // since they all implement the `error::Error` trait.
 // Check out this section of the book:
-// https://doc.rust-lang.org/stable/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
+// https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
 
 
 

--- a/exercises/functions/README.md
+++ b/exercises/functions/README.md
@@ -4,4 +4,4 @@ Here, you'll learn how to write functions and how Rust's compiler can trace thin
 
 #### Book Sections
 
-- [How Functions Work](https://doc.rust-lang.org/stable/book/ch03-03-how-functions-work.html)
+- [How Functions Work](https://doc.rust-lang.org/book/ch03-03-how-functions-work.html)

--- a/exercises/if/README.md
+++ b/exercises/if/README.md
@@ -4,4 +4,4 @@
 
 #### Book Sections
 
-- [Control Flow - if expressions](https://doc.rust-lang.org/stable/book/ch03-05-control-flow.html#if-expressions)
+- [Control Flow - if expressions](https://doc.rust-lang.org/book/ch03-05-control-flow.html#if-expressions)

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -6,5 +6,5 @@ modules, instead we'll show you how to use and create them.
 
 #### Book Sections
 
-- [Macros](https://doc.rust-lang.org/stable/book/ch19-06-macros.html)
+- [Macros](https://doc.rust-lang.org/book/ch19-06-macros.html)
 - [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html)

--- a/exercises/modules/README.md
+++ b/exercises/modules/README.md
@@ -4,4 +4,4 @@ In this section we'll give you an introduction to Rust's module system.
 
 #### Book Sections
 
-- [The Module System](https://doc.rust-lang.org/stable/book/ch07-02-defining-modules-to-control-scope-and-privacy.html)
+- [The Module System](https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html)

--- a/exercises/move_semantics/README.md
+++ b/exercises/move_semantics/README.md
@@ -6,5 +6,5 @@ These exercises are adapted from [pnkfelix](https://github.com/pnkfelix)'s [Rust
 
 For this section, the book links are especially important.
 
-- [Ownership](https://doc.rust-lang.org/stable/book/ch04-01-what-is-ownership.html)
-- [Reference and borrowing](https://doc.rust-lang.org/stable/book/ch04-02-references-and-borrowing.html)
+- [Ownership](https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html)
+- [Reference and borrowing](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html)

--- a/exercises/primitive_types/primitive_types5.rs
+++ b/exercises/primitive_types/primitive_types5.rs
@@ -39,7 +39,7 @@ fn main() {
 
 
 // Take a look at the Data Types -> The Tuple Type section of the book:
-// https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type
-// Particularly the part about destructuring (second to last example in the section). 
+// https://doc.rust-lang.org/book/ch03-02-data-types.html#the-tuple-type
+// Particularly the part about destructuring (second to last example in the section).
 // You'll need to make a pattern to bind `name` and `age` to the appropriate parts
 // of the tuple. You can do it!!

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -38,8 +38,8 @@ fn main() {
 
 
 
-// While you could use a destructuring `let` for the tuple here, try 
-// indexing into it instead, as explained in the last example of the 
+// While you could use a destructuring `let` for the tuple here, try
+// indexing into it instead, as explained in the last example of the
 // Data Types -> The Tuple Type section of the book:
-// https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type
+// https://doc.rust-lang.org/book/ch03-02-data-types.html#the-tuple-type
 // Now you have another tool in your toolbox!

--- a/exercises/strings/README.md
+++ b/exercises/strings/README.md
@@ -6,4 +6,4 @@ to identify and create them, as well as use them.
 
 #### Book Sections
 
-- [Strings](https://doc.rust-lang.org/stable/book/ch08-02-strings.html)
+- [Strings](https://doc.rust-lang.org/book/ch08-02-strings.html)

--- a/exercises/tests/README.md
+++ b/exercises/tests/README.md
@@ -4,4 +4,4 @@ Going out of order from the book to cover tests -- many of the following exercis
 
 #### Book Sections
 
-- [Writing Tests](https://doc.rust-lang.org/stable/book/ch11-01-writing-tests.html)
+- [Writing Tests](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)

--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -45,7 +45,7 @@ fn main() {
 // to **immutable** data. But we want to *change* the number of `jobs_completed`
 // so we'll need to also use another type that will only allow one thread to
 // mutate the data at a time. Take a look at this section of the book:
-// https://doc.rust-lang.org/stable/book/ch16-03-shared-state.html#atomic-reference-counting-with-arct
+// https://doc.rust-lang.org/book/ch16-03-shared-state.html#atomic-reference-counting-with-arct
 // and keep scrolling if you'd like more hints :)
 
 

--- a/exercises/variables/README.md
+++ b/exercises/variables/README.md
@@ -4,4 +4,4 @@ Here you'll learn about simple variables.
 
 #### Book Sections
 
-- [Variables and Mutability](https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html)
+- [Variables and Mutability](https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html)


### PR DESCRIPTION
While I was fixing these, I figured maybe it's good to just use a consistent URL for book links: https://doc.rust-lang.org/book/

Is there a plan for what to do with this old 1.4.0 example that doesn't exist in the current version of the book? Perhaps at least include a disclaimer when recommending that folks check it out?

https://github.com/rust-lang/rustlings/blob/34e31232dfddde284a341c9609b33cd27d9d5724/exercises/threads/README.md#L1
