### PR TITLE
Fix link to Arc<T> in the book

### DIFF
--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -45,7 +45,7 @@ fn main() {
 // to **immutable** data. But we want to *change* the number of `jobs_completed`
 // so we'll need to also use another type that will only allow one thread to
 // mutate the data at a time. Take a look at this section of the book:
-// https://doc.rust-lang.org/stable/book/second-edition/ch16-03-shared-state.html#atomic-reference-counting-with-arct
+// https://doc.rust-lang.org/stable/book/ch16-03-shared-state.html#atomic-reference-counting-with-arct
 // and keep scrolling if you'd like more hints :)
 
 


### PR DESCRIPTION
Screenshot for context:

![outdated](https://user-images.githubusercontent.com/1688456/59157106-dd3d1100-8a59-11e9-8b98-603b93b2425d.png)
