### PR TITLE
chore: Minor text updates

### DIFF
--- a/default_out.txt
+++ b/default_out.txt
@@ -9,7 +9,7 @@ Let's make sure you're up to speed:
 - You have installed Rust language support for your editor
 - You have locally installed the `rustlings` command by running:
 
-cargo install --path .
+cargo install --force --path .
 
 If you've done all of this (or even most of it), congrats! You're ready
 to start working with Rust.

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,6 @@ fn main() {
         let text = fs::read_to_string("default_out.txt").unwrap();
         println!("{}", text);
     }
-
-    println!("\x1b[0m");
 }
 
 fn watch(exercises: &[Exercise]) -> notify::Result<()> {


### PR DESCRIPTION
- Make the default rustlings executable text consistent with the README and install script by adding `--force`.

- Remove a missed highlighting character from Issue #133.