### PR TITLE
Fixes the irrefutable let pattern warning in `structs1.rs`

### DIFF
--- a/exercises/structs/structs1.rs
+++ b/exercises/structs/structs1.rs
@@ -7,7 +7,8 @@ struct ColorClassicStruct {
 
 struct ColorTupleStruct(/* TODO: Something goes here */);
 
-struct ColorUnitStruct;
+#[derive(Debug)]
+struct UnitStruct;
 
 #[cfg(test)]
 mod tests {
@@ -35,12 +36,9 @@ mod tests {
     #[test]
     fn unit_structs() {
         // TODO: Instantiate a unit struct!
-        // let green =
+        // let unit_struct =
+        let message = format!("{:?}s are fun!", unit_struct);
 
-        if let ColorUnitStruct = green {
-            assert!(true);
-        } else {
-            assert!(false);
-        }
+        assert_eq!(message, "UnitStructs are fun!");
     }
 }


### PR DESCRIPTION
PR https://github.com/rust-lang/rustlings/pull/163 accidentally introduced an error using some versions of the Rust compiler where the compiler would (rightly!) complain about an irrefutable let pattern. I have no idea why this did not occur in all versions of the compiler, but here is a way around it.