### PR TITLE
Fix(watch): Check if changed exercise file exists before calling verify.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn watch(exercises: &[Exercise]) -> notify::Result<()> {
         match rx.recv() {
             Ok(event) => match event {
                 DebouncedEvent::Create(b) | DebouncedEvent::Chmod(b) | DebouncedEvent::Write(b) => {
-                    if b.extension() == Some(OsStr::new("rs")) {
+                    if b.extension() == Some(OsStr::new("rs")) && b.exists() {
                         println!("----------**********----------\n");
                         let filepath = b.as_path().canonicalize().unwrap();
                         let exercise = exercises


### PR DESCRIPTION
Prevent a panic if the file triggering the watch event is gone. 