### PR TITLE
fix(test1): Swap assertion parameter order

### DIFF
--- a/exercises/test1.rs
+++ b/exercises/test1.rs
@@ -16,6 +16,6 @@ fn verify_test() {
     let price1 = calculate_price(55);
     let price2 = calculate_price(40);
 
-    assert_eq!(price1, 55);
-    assert_eq!(price2, 80);
+    assert_eq!(55, price1);
+    assert_eq!(80, price2);
 }


### PR DESCRIPTION
`Expected` should come before `actual`, other wise it leads to confusing compiler messages, e.g.
```
note: expected type `()`
         found type `{integer}`
```
There may be other tests that need updating, but this is as far as I am through the Rustlings course right now :) 