### PR TITLE
fix(option1): Add test for prematurely passing exercise

### DIFF
--- a/exercises/error_handling/option1.rs
+++ b/exercises/error_handling/option1.rs
@@ -4,7 +4,7 @@
 // on `None`. Handle this in a more graceful way than calling `unwrap`!
 // Scroll down for hints :)
 
-fn main() {
+pub fn pop_too_much() -> bool {
     let mut list = vec![3];
 
     let last = list.pop().unwrap();
@@ -15,9 +15,18 @@ fn main() {
         "The second-to-last item in the list is {:?}",
         second_to_last
     );
+    true
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    #[test]
+    fn should_not_panic() {
+        assert!(pop_too_much(), true);
+    }
+}
 
 
 

--- a/info.toml
+++ b/info.toml
@@ -192,7 +192,7 @@ mode = "test"
 
 [[exercises]]
 path = "exercises/error_handling/option1.rs"
-mode = "compile"
+mode = "test"
 
 [[exercises]]
 path = "exercises/error_handling/result1.rs"


### PR DESCRIPTION
Fixes the bug referenced in #160, but does not address the larger feature work referenced by the issue.