### PR TITLE
Suggest rustup update in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![crab pet](https://i.imgur.com/LbZJgmm.gif) 
+![crab pet](https://i.imgur.com/LbZJgmm.gif)
 
 # rustlings 🦀❤️
 
@@ -42,11 +42,16 @@ git checkout tags/1.0.0 # or whatever the latest version is (find out at https:/
 cargo install --force --path .
 ```
 
-Same as above, run `rustlings` to get started.
+If there are installation errors, ensure that your toolchain is up to date. For the latest, run:
+```bash
+rustup update
+```
+
+Then, same as above, run `rustlings` to get started.
 
 ## Doing exercises
 
-The exercises are sorted by topic and can be found in the subdirectory `rustlings/exercises/<topic>`. For every topic there is an additional README file with some resources to get you started on the topic. We really recommend that you have a look at them before you start. 
+The exercises are sorted by topic and can be found in the subdirectory `rustlings/exercises/<topic>`. For every topic there is an additional README file with some resources to get you started on the topic. We really recommend that you have a look at them before you start.
 
 The task is simple. Most exercises contain an error that keep it from compiling, and it's up to you to fix it! Some exercises are also ran as tests, but rustlings handles them all the same. To run the exercises in the recommended order, execute:
 


### PR DESCRIPTION
I'm pretty new to Rust. I tried installing rustlings for the first time and got this error:
```
$> cargo install --force --path .
error: `/Users/ajax/projects/rust/rustlings` is not a crate root; specify a crate to install from crates.io, or use --path or --git to specify an alternate source

Caused by:
  failed to parse manifest at `/Users/ajax/projects/rust/rustlings/Cargo.toml`

Caused by:
  editions are unstable

Caused by:
  feature `edition` is required

this Cargo does not support nightly features, but if you
switch to nightly channel you can add
`cargo-features = ["edition"]` to enable this feature
```

I'm not sure if the answer was to run `rustup update` but I noticed that I was running Rust 1.29.0, so updated to 1.36.0 and got it working. If there's a way to specify a minimum required version, pls let me know.

Lastly, the whitespace changes were automatic from my editor. What's the convention here for making such updates? Thanks!