### PR TITLE
fix(primitive_types4): Fail on a slice covering the wrong area

### DIFF
--- a/exercises/primitive_types/README.md
+++ b/exercises/primitive_types/README.md
@@ -6,3 +6,4 @@ compiler. In this section, we'll go through the most important ones.
 #### Book Sections
 
 - [Data Types](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html)
+- [The Slice Type](https://doc.rust-lang.org/stable/book/ch04-03-slices.html)

--- a/exercises/primitive_types/primitive_types4.rs
+++ b/exercises/primitive_types/primitive_types4.rs
@@ -2,17 +2,36 @@
 // Get a slice out of Array a where the ??? is so that the `if` statement
 // returns true. Scroll down for hints!!
 
+#[test]
 fn main() {
     let a = [1, 2, 3, 4, 5];
 
     let nice_slice = ???
 
-    if nice_slice == [2, 3, 4] {
-        println!("Nice slice!");
-    } else {
-        println!("Not quite what I was expecting... I see: {:?}", nice_slice);
-    }
+    assert_eq!([2, 3, 4], nice_slice)
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/info.toml
+++ b/info.toml
@@ -66,7 +66,7 @@ mode = "compile"
 
 [[exercises]]
 path = "exercises/primitive_types/primitive_types4.rs"
-mode = "compile"
+mode = "test"
 
 [[exercises]]
 path = "exercises/primitive_types/primitive_types5.rs"


### PR DESCRIPTION
I noticed this issue and it seems like a similar one was raised/fixed in #160 this way. This is my first contribution to this repo (or any Rust project) so let me know if I messed up or need to fix anything!

---
This commit converts primitive_types4 to a test and asserts that the
slice given is equal to the expected slice.

The intent of the primitive_types4 exercise appears to be to ensure the
user understands inclusive and exclusive bounds as well as slice syntax.
`rustlings` commands using `compile` do not verify that a specific
println is reached and, in the case of `watch` and `verify` (but not
`run`), they do not output the `println`s at all.

This fix is semantically similar to #198. It does not take a stance on
the correct way to handle this for all exercises; see #127. There are
likely other exercises whose intent are masked by this issue.