### PR TITLE
feat: Added exercises/enums

### DIFF
--- a/exercises/enums/README.md
+++ b/exercises/enums/README.md
@@ -1,0 +1,4 @@
+For this exercise check out the sections:
+- [Defining an Enum](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html) 
+
+of the Rust Book.

--- a/exercises/enums/enums1.rs
+++ b/exercises/enums/enums1.rs
@@ -1,0 +1,45 @@
+// enums1.rs
+// Make me compile by adding my favorite fruit in the enum definition :)
+// Hints can be found below
+
+#[derive(Debug)]
+enum Fruit {
+    Banana,
+    Apple,
+    Pear,
+    // Add another fruit here
+}
+
+fn main() {
+    println!("The writer likes like {:#?}", Fruit::Mango);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Look at the syntax of how the fruit is being printed to figure out what to
+// add to the enum.  (HINT: I really like Mangos)

--- a/exercises/enums/enums2.rs
+++ b/exercises/enums/enums2.rs
@@ -1,0 +1,50 @@
+// enums2.rs
+// Make me compile by putting your favorite fruit in the print statement :)
+// Hints can be found below
+
+// For extra challenge add your favorite fruit to the enum and print that :) 
+
+#[derive(Debug)]
+enum Fruit {
+    Banana,
+    Apple,
+    Pear,
+    Mango
+}
+
+fn main() {
+    // Assign this variable to your favorite fruit
+    // let fruit = ???;
+    println!("I like {:#?}", favorite);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Rust uses a certain sytax for getting a particular value from an enum. You
+// can find enums in the "Enums and Pattern Matching" section of the Rust Book,
+// starting on page 113

--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -1,0 +1,61 @@
+// enums3.rs
+// Try making an enum to immitate these structs
+
+// Tuple Struct
+struct FruitBasketRecipient(String);
+
+// Classic Struct
+struct FruitBasketSize {
+    depth: i32,
+    width: i32,
+}
+
+// Unit Struct
+struct FruitBasketEmpty;
+
+// Complete this definition so the file compiles
+#[derive(Debug)]
+enum FruitBasket {
+}
+
+fn main() {
+    // These do not need to be touched :) but the file will not compile if the
+    // elements of the enum have not been defines
+    let recipient = FruitBasket::Recipient(String::from("John Doe"));
+    println!("The fruit basket says: {:#?}", recipient);
+
+    let size = FruitBasket::Size{depth:3, width:4};
+    println!("The manual for the fruit basket says: {:#?}", size);
+
+    let is_empty = FruitBasket::Empty;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Rust can store many different types of values in an enum, check out the 
+// 'Enum Values' Subsection of the Enum chapter for more info

--- a/info.toml
+++ b/info.toml
@@ -118,6 +118,20 @@ mode = "compile"
 path = "exercises/test3.rs"
 mode = "compile"
 
+# ENUMS
+
+[[exercises]]
+path = "exercises/enums/enums1.rs"
+mode = "compile"
+
+[[exercises]]
+path = "exercises/enums/enums2.rs"
+mode = "compile"
+
+[[exercises]]
+path = "exercises/enums/enums3.rs"
+mode = "compile"
+
 # MODULES
 
 [[exercises]]


### PR DESCRIPTION
Added 3 new exercises for enums, `enums{1-3}.rs`. Enums were used in some of the exercises but never taught. These 3 exercises cover putting elements into an enum, referencing elements in an enum, and a few of the types of elements you can have in an enum. All exercises closely follow the book and as such should be a good intro before the later lessons that use them.