### PR TITLE
fix(option1): Fix arguments passed to assert! macro

### DIFF
--- a/exercises/error_handling/option1.rs
+++ b/exercises/error_handling/option1.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[test]
     fn should_not_panic() {
-        assert!(pop_too_much(), true);
+        assert!(pop_too_much());
     }
 }
 


### PR DESCRIPTION
@Zazcallabah pointed out that the second argument passed to `assert!` didn't make much sense in this context. This PR removes that second argument to clarify what is being asserted / tested in this exercise.