### PR TITLE
chore: Bump version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "rustlings"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
I think this may have been intended for inclusion in 4f0c5a8d49a9164f4174d82d86b0bbba40badc4e. The rls in VS Code is being pretty adamant about updating it, so I thought I'd PR the change :)