### PR TITLE
watch: clears terminal before entering loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,9 @@ fn main() {
     }
 
     if matches.subcommand_matches("watch").is_some() {
+        /* Clears the terminal with an ANSI escape code.
+           Works in UNIX and newer Windows terminals. */
+        println!("\x1Bc");
         watch(&exercises).unwrap();
     }
 


### PR DESCRIPTION
Fixes #146 

If someone is sliding in and out of "watch" mode, it can make it hard
to tell which error messages are still relevant. This patch resolves
that by clearing the terminal entirely before entering watch's loop.

Note that the escape character is chosen for compatibility reasons, because different shells/terminals can change which commands they accept or have installed, betting on what other commands are in use to collect data seems risky, and just expecting them to implement ANSI escape code sequences is more reliable. This seems especially true since Windows is seeking more UNIX compatibility in its terminals going forward, even though it doesn't implement the POSIX standard per se.