### PR TITLE
fix(run): makes `run` never prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fsevent"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +360,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "notify"
 version = "4.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +380,14 @@ dependencies = [
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -405,7 +426,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -613,6 +637,7 @@ dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,6 +875,7 @@ dependencies = [
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
+"checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 "checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -873,7 +899,9 @@ dependencies = [
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "3572d71f13ea8ed41867accd971fd564aa75934cf7a1fae03ddb8c74a8a49943"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ path = "src/main.rs"
 
 [dev-dependencies]
 assert_cmd = "0.11.0"
+predicates = "1.0.1"
 glob = "0.3.0"

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,9 +5,7 @@ use indicatif::ProgressBar;
 
 pub fn run(exercise: &Exercise) -> Result<(), ()> {
     match exercise.mode {
-        Mode::Test => {
-            test(exercise)?;
-        }
+        Mode::Test => test(exercise)?,
         Mode::Compile => compile_and_run(exercise)?,
     }
     Ok(())

--- a/tests/fixture/state/finished_exercise.rs
+++ b/tests/fixture/state/finished_exercise.rs
@@ -1,0 +1,5 @@
+// fake_exercise
+
+fn main() {
+
+}

--- a/tests/fixture/state/info.toml
+++ b/tests/fixture/state/info.toml
@@ -1,0 +1,11 @@
+[[exercises]]
+name = "pending_exercise"
+path = "pending_exercise.rs"
+mode = "compile"
+hint = """"""
+
+[[exercises]]
+name = "pending_test_exercise"
+path = "pending_test_exercise.rs"
+mode = "test"
+hint = """"""

--- a/tests/fixture/state/pending_test_exercise.rs
+++ b/tests/fixture/state/pending_test_exercise.rs
@@ -1,0 +1,4 @@
+// I AM NOT DONE
+
+#[test]
+fn it_works() {}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use glob::glob;
+use predicates::boolean::PredicateBooleanExt;
 use std::fs::File;
 use std::io::Read;
 use std::process::Command;
@@ -135,4 +136,26 @@ fn all_exercises_require_confirmation() {
             path
         ));
     }
+}
+
+#[test]
+fn run_compile_exercise_does_not_prompt() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["r", "pending_exercise"])
+        .current_dir("tests/fixture/state")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("I AM NOT DONE").not());
+}
+
+#[test]
+fn run_test_exercise_does_not_prompt() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["r", "pending_test_exercise"])
+        .current_dir("tests/fixture/state")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("I AM NOT DONE").not());
 }


### PR DESCRIPTION
`watch` and `verify` do prompt the user to actively move to the
next exercise. This change fixes `run` to never prompt. Previously
it was inconsistent between "test" and "compile" exercises.

BREAKING CHANGE: we again change the behavior of the `run` command