### PR TITLE
Update line numbers in hints and outdated comment

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -90,7 +90,7 @@ name = "functions4"
 path = "exercises/functions/functions4.rs"
 mode = "compile"
 hint = """
-The error message points to line 12 and says it expects a type after the
+The error message points to line 14 and says it expects a type after the
 `->`. This is where the function's return type should be-- take a look at
 the `is_even` function for an example!"""
 

--- a/info.toml
+++ b/info.toml
@@ -214,7 +214,7 @@ mode = "compile"
 hint = """
 Yes, it would be really easy to fix this by just changing the value bound to `word` to be a
 string slice instead of a `String`, wouldn't it?? There is a way to add one character to line
-6, though, that will coerce the `String` into a string slice."""
+9, though, that will coerce the `String` into a string slice."""
 
 # TEST 2
 

--- a/info.toml
+++ b/info.toml
@@ -152,8 +152,8 @@ https://doc.rust-lang.org/book/ch04-03-slices.html
 and use the starting and ending indices of the items in the Array
 that you want to end up in the slice.
 
-If you're curious why the right hand of the `==` comparison does not
-have an ampersand for a reference since the left hand side is a
+If you're curious why the first argument of `assert_eq!` does not
+have an ampersand for a reference since the second argument is a
 reference, take a look at the Deref coercions section of the book:
 https://doc.rust-lang.org/book/ch15-02-deref.html"""
 


### PR DESCRIPTION
In functions4, the missing code is in line 14 in the latest version:
```rust
error: expected type, found `{`
  --> exercises/functions/functions4.rs:14:30
   |
14 | fn sale_price(price: i32) -> {
   |                              ^ expected type

error: aborting due to previous error
```
but the hint points to line 12. This is due to a recent change in 2cdd61294f0d9a53775ee24ad76435bec8a21e60.

Also includes similar updates for strings2 and primitive_types4.