### PR TITLE
fix: line numbers in several exercises and hints

### DIFF
--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -1,5 +1,5 @@
 // move_semantics2.rs
-// Make me compile without changing line 10!
+// Make me compile without changing line 13!
 // Execute `rustlings hint move_semantics2` for hints :)
 
 // I AM NOT DONE

--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -1,6 +1,6 @@
 // threads1.rs
 // Make this compile! Execute `rustlings hint threads1` for hints :)
-// The idea is the thread spawned on line 19 is completing jobs while the main thread is
+// The idea is the thread spawned on line 21 is completing jobs while the main thread is
 // monitoring progress until 10 jobs are completed. If you see 6 lines
 // of "waiting..." and the program ends without timing out when running,
 // you've got it :)

--- a/info.toml
+++ b/info.toml
@@ -5,7 +5,7 @@ name = "variables1"
 path = "exercises/variables/variables1.rs"
 mode = "compile"
 hint = """
-Hint: The declaration on line 5 is missing a keyword that is needed in Rust
+Hint: The declaration on line 12 is missing a keyword that is needed in Rust
 to create a new variable binding."""
 
 [[exercises]]
@@ -15,7 +15,7 @@ mode = "compile"
 hint = """
 The compiler message is saying that Rust cannot infer the type that the
 variable binding `x` has with what is given here.
-What happens if you annotate line 5 with a type annotation?
+What happens if you annotate line 7 with a type annotation?
 What if you give x a value?
 What if you do both?
 What type should x be, anyway?
@@ -36,7 +36,7 @@ path = "exercises/variables/variables4.rs"
 mode = "compile"
 hint = """
 Oops! In this exercise, we have a variable binding that we've created on
-line 5, and we're trying to use it on line 6, but we haven't given it a
+line 7, and we're trying to use it on line 8, but we haven't given it a
 value. We can't print out something that isn't there; try giving x a value!
 This is an error that can cause bugs that's very easy to make in any
 programming language -- thankfully the Rust compiler has caught this for us!"""
@@ -365,8 +365,8 @@ name = "move_semantics1"
 path = "exercises/move_semantics/move_semantics1.rs"
 mode = "compile"
 hint = """
-So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 11,
-right? The fix for this is going to be adding one keyword, and the addition is NOT on line 11
+So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 13,
+right? The fix for this is going to be adding one keyword, and the addition is NOT on line 13
 where the error is."""
 
 [[exercises]]
@@ -375,8 +375,8 @@ path = "exercises/move_semantics/move_semantics2.rs"
 mode = "compile"
 hint = """
 So `vec0` is being *moved* into the function `fill_vec` when we call it on
-line 7, which means it gets dropped at the end of `fill_vec`, which means we
-can't use `vec0` again on line 10 (or anywhere else in `main` after the
+line 10, which means it gets dropped at the end of `fill_vec`, which means we
+can't use `vec0` again on line 13 (or anywhere else in `main` after the
 `fill_vec` call for that matter). We could fix this in a few ways, try them
 all!
 1. Make another, separate version of the data that's in `vec0` and pass that


### PR DESCRIPTION
The introduction of `I AM NOT DONE` shifted the lines of all exercises, which now need adjustment.