### PR TITLE
feat(watch): show hint while watching

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -2,14 +2,14 @@ use crate::exercise::{Exercise, Mode, State};
 use console::{style, Emoji};
 use indicatif::ProgressBar;
 
-pub fn verify<'a>(start_at: impl IntoIterator<Item = &'a Exercise>) -> Result<(), ()> {
+pub fn verify<'a>(start_at: impl IntoIterator<Item = &'a Exercise>) -> Result<(), &'a Exercise> {
     for exercise in start_at {
-        let is_done = match exercise.mode {
-            Mode::Test => compile_and_test_interactively(&exercise)?,
-            Mode::Compile => compile_only(&exercise)?,
+        let compile_result = match exercise.mode {
+            Mode::Test => compile_and_test_interactively(&exercise),
+            Mode::Compile => compile_only(&exercise),
         };
-        if !is_done {
-            return Err(());
+        if !compile_result.unwrap_or(false) {
+            return Err(exercise);
         }
     }
     Ok(())


### PR DESCRIPTION
`rustlings hint ...` command is not convenient when doing exercises with `rustlings watch`.  
This PR makes it possible for user to type `hint` while running `watch`  and get hint text for exercise which is currently failing.
e.g.
```rust
...
  --> exercises/variables/variables1.rs:13:36
   |
13 |     println!("x has the value {}", x);
   |                                    ^ not found in this scope

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0425`.

type 'hint' to get help:
hint
Hint: The declaration on line 12 is missing a keyword that is needed in Rust
to create a new variable binding.
```  