### PR TITLE
fix(enums): Add link to chapter on pattern syntax

### DIFF
--- a/exercises/enums/README.md
+++ b/exercises/enums/README.md
@@ -5,3 +5,4 @@ Rust allows you to define a type called `enums` which allow you to enumerate pos
 #### Book Sections
 
 - [Enums](https://doc.rust-lang.org/book/ch06-00-enums.html)
+- [Pattern syntax](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html)


### PR DESCRIPTION
After being stuck on exercise enums3.rs for about an hour or two, having read the entire chapter on enums 2-3 times, and still being unable to complete the exercise, i started broadening my reading. I finally found the answer in the rust docs via google.