### PR TITLE
fix: Update deps to version compatable with aarch64-pc-windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32.0"
-indicatif = "0.9.0"
-console = "0.6.2"
-notify = "4.0.0"
+indicatif = "0.10.3"
+console = "0.7.7"
+notify = "4.0.15"
 toml = "0.4.10"
 regex = "1.1.6"
 serde = {version = "1.0.10", features = ["derive"]}


### PR DESCRIPTION
Some of the versions of dependencies pulled in the older winapi / kernel32 libraries. Kernel32 is no longer needed as it's all in the new version of winapi. This did not work on windows aarch64 and thus prevent rustlings from working natively on devices like the Surface Pro X.