### PR TITLE
refactor: exercise evaluation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+#[macro_use]
+mod ui;
+
 mod exercise;
 mod run;
 mod verify;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,5 @@
 use crate::exercise::{Exercise, Mode};
 use crate::verify::test;
-use console::{style, Emoji};
 use indicatif::ProgressBar;
 
 pub fn run(exercise: &Exercise) -> Result<(), ()> {
@@ -11,42 +10,41 @@ pub fn run(exercise: &Exercise) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn compile_and_run(exercise: &Exercise) -> Result<(), ()> {
+fn compile_and_run(exercise: &Exercise) -> Result<(), ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {}...", exercise).as_str());
     progress_bar.enable_steady_tick(100);
 
-    let compilecmd = exercise.compile();
+    let compilation_result = exercise.compile();
+    let compilation = match compilation_result {
+        Ok(compilation) => compilation,
+        Err(output) => {
+            progress_bar.finish_and_clear();
+            warn!(
+                "Compilation of {} failed!, Compiler error message:\n",
+                exercise
+            );
+            println!("{}", output.stderr);
+            return Err(());
+        }
+    };
+
     progress_bar.set_message(format!("Running {}...", exercise).as_str());
-    if compilecmd.status.success() {
-        let runcmd = exercise.run();
-        progress_bar.finish_and_clear();
+    let result = compilation.run();
+    progress_bar.finish_and_clear();
 
-        if runcmd.status.success() {
-            println!("{}", String::from_utf8_lossy(&runcmd.stdout));
-            let formatstr = format!("{} Successfully ran {}", Emoji("✅", "✓"), exercise);
-            println!("{}", style(formatstr).green());
-            exercise.clean();
+    match result {
+        Ok(output) => {
+            println!("{}", output.stdout);
+            success!("Successfully ran {}", exercise);
             Ok(())
-        } else {
-            println!("{}", String::from_utf8_lossy(&runcmd.stdout));
-            println!("{}", String::from_utf8_lossy(&runcmd.stderr));
+        }
+        Err(output) => {
+            println!("{}", output.stdout);
+            println!("{}", output.stderr);
 
-            let formatstr = format!("{} Ran {} with errors", Emoji("⚠️ ", "!"), exercise);
-            println!("{}", style(formatstr).red());
-            exercise.clean();
+            warn!("Ran {} with errors", exercise);
             Err(())
         }
-    } else {
-        progress_bar.finish_and_clear();
-        let formatstr = format!(
-            "{} Compilation of {} failed! Compiler error message:\n",
-            Emoji("⚠️ ", "!"),
-            exercise
-        );
-        println!("{}", style(formatstr).red());
-        println!("{}", String::from_utf8_lossy(&compilecmd.stderr));
-        exercise.clean();
-        Err(())
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,23 @@
+macro_rules! warn {
+    ($fmt:literal, $ex:expr) => {{
+        use console::{style, Emoji};
+        let formatstr = format!($fmt, $ex);
+        println!(
+            "{} {}",
+            style(Emoji("⚠️ ", "!")).red(),
+            style(formatstr).red()
+        );
+    }};
+}
+
+macro_rules! success {
+    ($fmt:literal, $ex:expr) => {{
+        use console::{style, Emoji};
+        let formatstr = format!($fmt, $ex);
+        println!(
+            "{} {}",
+            style(Emoji("✅", "✓")).green(),
+            style(formatstr).green()
+        );
+    }};
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,11 +1,11 @@
 use crate::exercise::{Exercise, Mode, State};
-use console::{style, Emoji};
+use console::style;
 use indicatif::ProgressBar;
 
 pub fn verify<'a>(start_at: impl IntoIterator<Item = &'a Exercise>) -> Result<(), &'a Exercise> {
     for exercise in start_at {
         let compile_result = match exercise.mode {
-            Mode::Test => compile_and_test_interactively(&exercise),
+            Mode::Test => compile_and_test(&exercise, RunMode::Interactive),
             Mode::Compile => compile_only(&exercise),
         };
         if !compile_result.unwrap_or(false) {
@@ -15,8 +15,13 @@ pub fn verify<'a>(start_at: impl IntoIterator<Item = &'a Exercise>) -> Result<()
     Ok(())
 }
 
+enum RunMode {
+    Interactive,
+    NonInteractive,
+}
+
 pub fn test(exercise: &Exercise) -> Result<(), ()> {
-    compile_and_test(exercise, true)?;
+    compile_and_test(exercise, RunMode::NonInteractive)?;
     Ok(())
 }
 
@@ -24,69 +29,64 @@ fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {}...", exercise).as_str());
     progress_bar.enable_steady_tick(100);
-    let compile_output = exercise.compile();
+    let compilation_result = exercise.compile();
     progress_bar.finish_and_clear();
-    if compile_output.status.success() {
-        let formatstr = format!("{} Successfully compiled {}!", Emoji("✅", "✓"), exercise);
-        println!("{}", style(formatstr).green());
-        exercise.clean();
-        Ok(prompt_for_completion(&exercise))
-    } else {
-        let formatstr = format!(
-            "{} Compilation of {} failed! Compiler error message:\n",
-            Emoji("⚠️ ", "!"),
-            exercise
-        );
-        println!("{}", style(formatstr).red());
-        println!("{}", String::from_utf8_lossy(&compile_output.stderr));
-        exercise.clean();
-        Err(())
+
+    match compilation_result {
+        Ok(_) => {
+            success!("Successfully compiled {}!", exercise);
+            Ok(prompt_for_completion(&exercise))
+        }
+        Err(output) => {
+            warn!(
+                "Compilation of {} failed! Compiler error message:\n",
+                exercise
+            );
+            println!("{}", output.stderr);
+            Err(())
+        }
     }
 }
 
-fn compile_and_test_interactively(exercise: &Exercise) -> Result<bool, ()> {
-    compile_and_test(exercise, false)
-}
-
-fn compile_and_test(exercise: &Exercise, skip_prompt: bool) -> Result<bool, ()> {
+fn compile_and_test(exercise: &Exercise, run_mode: RunMode) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Testing {}...", exercise).as_str());
     progress_bar.enable_steady_tick(100);
 
-    let compile_output = exercise.compile();
-    if compile_output.status.success() {
-        progress_bar.set_message(format!("Running {}...", exercise).as_str());
+    let compilation_result = exercise.compile();
 
-        let runcmd = exercise.run();
-        progress_bar.finish_and_clear();
-
-        if runcmd.status.success() {
-            let formatstr = format!("{} Successfully tested {}!", Emoji("✅", "✓"), exercise);
-            println!("{}", style(formatstr).green());
-            exercise.clean();
-            Ok(skip_prompt || prompt_for_completion(exercise))
-        } else {
-            let formatstr = format!(
-                "{} Testing of {} failed! Please try again. Here's the output:",
-                Emoji("⚠️ ", "!"),
+    let compilation = match compilation_result {
+        Ok(compilation) => compilation,
+        Err(output) => {
+            progress_bar.finish_and_clear();
+            warn!(
+                "Compiling of {} failed! Please try again. Here's the output:",
                 exercise
             );
-            println!("{}", style(formatstr).red());
-            println!("{}", String::from_utf8_lossy(&runcmd.stdout));
-            exercise.clean();
+            println!("{}", output.stderr);
+            return Err(());
+        }
+    };
+
+    let result = compilation.run();
+    progress_bar.finish_and_clear();
+
+    match result {
+        Ok(_) => {
+            if let RunMode::Interactive = run_mode {
+                Ok(prompt_for_completion(&exercise))
+            } else {
+                Ok(true)
+            }
+        }
+        Err(output) => {
+            warn!(
+                "Testing of {} failed! Please try again. Here's the output:",
+                exercise
+            );
+            println!("{}", output.stdout);
             Err(())
         }
-    } else {
-        progress_bar.finish_and_clear();
-        let formatstr = format!(
-            "{} Compiling of {} failed! Please try again. Here's the output:",
-            Emoji("⚠️ ", "!"),
-            exercise
-        );
-        println!("{}", style(formatstr).red());
-        println!("{}", String::from_utf8_lossy(&compile_output.stderr));
-        exercise.clean();
-        Err(())
     }
 }
 


### PR DESCRIPTION
After working a bit on #270, I realized that it'd be useful to first perform a minor refactor of exercise evaluation.

* Now we have standard methods to compile + execute that return `Result`s.
* Success/failure messages are standardized.