### PR TITLE
fix(installation): make fatal errors more obvious

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ -x "$(command -v git)" ]
 then
     echo "SUCCESS: Git is installed"
 else
-    echo "WARNING: Git does not seem to be installed."
+    echo "ERROR: Git does not seem to be installed."
     echo "Please download Git using your package manager or over https://git-scm.com/!"
     exit 1
 fi
@@ -16,7 +16,7 @@ if [ -x "$(command -v rustc)" ]
 then
     echo "SUCCESS: Rust is installed"
 else
-    echo "WARNING: Rust does not seem to be installed."
+    echo "ERROR: Rust does not seem to be installed."
     echo "Please download Rust using https://rustup.rs!"
     exit 1
 fi
@@ -25,7 +25,7 @@ if [ -x "$(command -v cargo)" ]
 then
     echo "SUCCESS: Cargo is installed"
 else
-    echo "WARNING: Cargo does not seem to be installed."
+    echo "ERROR: Cargo does not seem to be installed."
     echo "Please download Rust and Cargo using https://rustup.rs!"
     exit 1
 fi
@@ -75,7 +75,7 @@ MinRustVersion=1.31
 vercomp $RustVersion $MinRustVersion
 if [ $? -eq 2 ]
 then
-    echo "WARNING: Rust version is too old: $RustVersion - needs at least $MinRustVersion"
+    echo "ERROR: Rust version is too old: $RustVersion - needs at least $MinRustVersion"
     echo "Please update Rust with 'rustup update'"
     exit 1
 else


### PR DESCRIPTION
I initially ran the installation script without rust installed. The fact that the error message was labeled with WARNING made me unsure whether installation was successful or I needed to re-run after installing rust. There's an error code returned on fatal errors, but this change will make things clearer.