### PR TITLE
Enable test for exercise test4

### DIFF
--- a/exercises/test4.rs
+++ b/exercises/test4.rs
@@ -7,8 +7,13 @@
 
 // I AM NOT DONE
 
-fn main() {
-    if my_macro!("world!") != "Hello world!" {
-        panic!("Oh no! Wrong output!");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_my_macro() {
+        assert_eq!(my_macro!("world!"), "Hello world!");
     }
 }
+

--- a/exercises/test4.rs
+++ b/exercises/test4.rs
@@ -12,8 +12,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_my_macro() {
+    fn test_my_macro_world() {
         assert_eq!(my_macro!("world!"), "Hello world!");
     }
-}
 
+    #[test]
+    fn test_my_macro_goodbye() {
+        assert_eq!(my_macro!("goodbye!"), "Hello goodbye!");
+    }
+}

--- a/info.toml
+++ b/info.toml
@@ -369,7 +369,7 @@ The way macros are written, it wants to see something between each
 [[exercises]]
 name = "test4"
 path = "exercises/test4.rs"
-mode = "compile"
+mode = "test"
 hint = "No hints this time ;)"
 
 # MOVE SEMANTICS


### PR DESCRIPTION
Enable test mode for exercise test4.rs, and add a new test case. This exercise was easy to "pass" by e.g. writing a macro which returned a constant string literal, unless you ran `main` and looked at the output.