### PR TITLE
fix confusing comment in conversions/try_from_into.rs

### DIFF
--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -45,7 +45,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_bad_convert() {
-        // Test that John is returned when bad string is provided
+        // Test that error is returned when bad string is provided
         let p = Person::try_from("");
         assert!(p.is_err());
     }


### PR DESCRIPTION
There is a confusing comment in conversions/try_from_into.rs due to the copy/paste from from_into.rs task. Fixed it.