### PR TITLE
chore: add explanatory comment to clippy1

### DIFF
--- a/exercises/clippy/clippy1.rs
+++ b/exercises/clippy/clippy1.rs
@@ -2,6 +2,8 @@
 // The Clippy tool is a collection of lints to analyze your code
 // so you can catch common mistakes and improve your Rust code.
 //
+// For these exercises the code will fail to compile when there are clippy warnings
+// check clippy's suggestions from the output to solve the exercise.
 // Execute `rustlings hint clippy1` for hints :)
 
 // I AM NOT DONE


### PR DESCRIPTION
I noticed while investigating [#300 ](https://github.com/rust-lang/rustlings/issues/300) that it's a little jarring when transitioning to the `Mode::Clippy` exercises, as it's not immediately clear that the code fails to compile due to clippy warnings.

I have added comments to clippy1 to clarify the compilation failures are from clippy.