### PR TITLE
Fix missing space in the hint for errorsn.rs

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -501,7 +501,7 @@ mode = "test"
 hint = """
 First hint: To figure out what type should go where the ??? is, take a look
 at the test helper function `test_with_str`, since it returns whatever
-`read_and_validate` returns and`test_with_str` has its signature fully
+`read_and_validate` returns and `test_with_str` has its signature fully
 specified.
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6342851/80261689-cb755400-8693-11ea-8c8f-10de2b1b699b.png)
