### PR TITLE
docs: Update `Invoke-WebRequest` to `Start-BitsTransfer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Set-ExecutionPolicy RemoteSigned
 Then, you can run:
 
 ```ps
-Start-BitsTransfer https://git.io/rustlings-win | Select-Object -ExpandProperty Content | Out-File $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
+Start-BitsTransfer -Source https://git.io/rustlings-win -Destination $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
 ```
 
 To install Rustlings. Same as on MacOS/Linux, you will have access to the `rustlings` command after it.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Set-ExecutionPolicy RemoteSigned
 Then, you can run:
 
 ```ps
-Invoke-WebRequest https://git.io/rustlings-win | Select-Object -ExpandProperty Content | Out-File $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
+Start-BitsTransfer https://git.io/rustlings-win | Select-Object -ExpandProperty Content | Out-File $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
 ```
 
 To install Rustlings. Same as on MacOS/Linux, you will have access to the `rustlings` command after it.


### PR DESCRIPTION
To run `Invoke-WebRequest` you have to have the Internet Explorer Feature enabled, and you must have opened Internet Explorer at least once, which some people may not have (me for example).
If you don't you will receive an error and the install will fail. 
This also simplifies the download command (imo).
`Start-BitsTransfer` is a drop in replacement which doesn't need you to have internet explorer enabled.


_apologies if the commit naming is wrong, i wasn't sure what commit type this would fall under._