### PR TITLE
fix: update iterator and macro text for typos and clarity

### DIFF
--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -2,7 +2,7 @@
 
 Rust's macro system is very powerful, but also kind of difficult to wrap your
 head around. We're not going to teach you how to write your own fully-featured
-modules, instead we'll show you how to use and create them.
+macros. Instead, we'll show you how to use and create them.
 
 #### Book Sections
 

--- a/exercises/standard_library_types/iterators2.rs
+++ b/exercises/standard_library_types/iterators2.rs
@@ -1,8 +1,10 @@
 // iterators2.rs
-// In this module, you'll learn some of unique advantages that iterators can offer
-// Step 1. Complete the `capitalize_first` function to pass the first two cases
-// Step 2. Apply the `capitalize_first` function to a vector of strings, ensuring that it returns a vector of strings as well
-// Step 3. Apply the `capitalize_first` function again to a list, but try and ensure it returns a single string
+// In this module, you'll learn some of unique advantages that iterators can offer.
+// Step 1. Complete the `capitalize_first` function to pass the first two cases.
+// Step 2. Apply the `capitalize_first` function to a vector of strings.
+//         Ensure that it returns a vector of strings as well.
+// Step 3. Apply the `capitalize_first` function again to a list.
+//         Try to ensure it returns a single string.
 // As always, there are hints if you execute `rustlings hint iterators2`!
 
 // I AM NOT DONE

--- a/exercises/standard_library_types/iterators4.rs
+++ b/exercises/standard_library_types/iterators4.rs
@@ -3,13 +3,13 @@
 // I AM NOT DONE
 
 pub fn factorial(num: u64) -> u64 {
-    // Complete this function to return factorial of num
+    // Complete this function to return the factorial of num
     // Do not use:
     // - return
-    // For extra fun don't use:
+    // Try not to use:
     // - imperative style loops (for, while)
     // - additional variables
-    // For the most fun don't use:
+    // For an extra challenge, don't use:
     // - recursion
     // Execute `rustlings hint iterators4` for hints.
 }

--- a/info.toml
+++ b/info.toml
@@ -640,10 +640,10 @@ name = "iterators4"
 path = "exercises/standard_library_types/iterators4.rs"
 mode = "test"
 hint = """
-In an imperative language you might write a for loop to iterate through
-multiply the values into a mutable variable. Or you might write code more
-functionally with recursion and a match clause. But you can also use ranges
-and iterators to solve this in rust."""
+In an imperative language, you might write a for loop that updates 
+a mutable variable. Or, you might write code utilizing recursion 
+and a match clause. In Rust you can take another functional
+approach, computing the factorial elegantly with ranges and iterators."""
 
 # TRAITS
 


### PR DESCRIPTION
- /macros/README.md: Typo "modules" => "macros"
- iterators2.py: Reduce line length to <90-char width.
- iterators4.py: Update 'fun' => 'challenge' as per PR#177
- rustlings hint iterators4: improve clarity