### PR TITLE
chore: Remove deprecated description from error_handling/errorsn.rs

### DIFF
--- a/exercises/error_handling/errorsn.rs
+++ b/exercises/error_handling/errorsn.rs
@@ -100,15 +100,12 @@ enum CreationError {
 
 impl fmt::Display for CreationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str((self as &dyn error::Error).description())
+        let description = match *self {
+            CreationError::Negative => "Number is negative",
+            CreationError::Zero => "Number is zero",
+        };
+        f.write_str(description)
     }
 }
 
-impl error::Error for CreationError {
-    fn description(&self) -> &str {
-        match *self {
-            CreationError::Negative => "Negative",
-            CreationError::Zero => "Zero",
-        }
-    }
-}
+impl error::Error for CreationError {}


### PR DESCRIPTION
When I was working on error_handling/errorsn.rs I notice that warning.

```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
   --> exercises/error_handling/errorsn.rs:103:49
    |
103 |         f.write_str((self as &dyn error::Error).description())
    |                                                 ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```