### PR TITLE
if2 exercise and option1 fix

### DIFF
--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -1,0 +1,36 @@
+// if2.rs
+
+// Step 1: Make me compile!
+// Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
+// Execute the command `rustlings hint if2` if you want a hint :)
+
+// I AM NOT DONE
+
+pub fn fizz_if_foo(fizzish: &str) -> &str {
+    if fizzish == "fizz" {
+        "foo"
+    } else {
+        1
+    }
+}
+
+// No test changes needed!
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foo_for_fizz() {
+        assert_eq!(fizz_if_foo("fizz"), "foo")
+    }
+
+    #[test]
+    fn bar_for_fuzz() {
+        assert_eq!(fizz_if_foo("fuzz"), "bar")
+    }
+
+    #[test]
+    fn default_to_baz() {
+        assert_eq!(fizz_if_foo("literally anything"), "baz")
+    }
+}

--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -18,6 +18,6 @@ fn main() {
             ((iter * 5) + 2) / (4 * 16)
         };
 
-        numbers[iter] = number_to_add;
+        numbers[iter as usize] = number_to_add;
     }
 }

--- a/info.toml
+++ b/info.toml
@@ -87,6 +87,15 @@ Remember in Rust that:
 - `if`/`else` conditionals are expressions
 - Each condition is followed by a `{}` block."""
 
+[[exercises]]
+name = "if2"
+path = "exercises/if/if2.rs"
+mode = "test"
+hint = """
+For that first compiler error, it's important in Rust that each conditional
+block return the same type! To get the tests passing, you will need a couple
+conditions checking different input values."""
+
 # FUNCTIONS
 
 [[exercises]]


### PR DESCRIPTION
This PR implements two things: 

1. A new `if2` exercise that shows the type of compiler message you get if your conditional branches don't return the same type as well as the usage of `else if`
2. A small change to the option1 exercise that I think makes it very confusing (no problem dropping this one if there's disagreement here). 