### PR TITLE
fix(test2): name of type String and &str

### DIFF
--- a/exercises/test2.rs
+++ b/exercises/test2.rs
@@ -2,7 +2,7 @@
 // This is a test for the following sections:
 // - Strings
 
-// Ok, here are a bunch of values-- some are `Strings`, some are `&strs`. Your
+// Ok, here are a bunch of values-- some are `String`s, some are `&str`s. Your
 // task is to call one of these two functions on each value depending on what
 // you think each value is. That is, add either `string_slice` or `string`
 // before the parentheses on each line. If you're right, it will compile!


### PR DESCRIPTION
I know this is quite boring, but while we are putting backticks, it's good to be more accurate.