### PR TITLE
fix(option2): Add TODO to comments

### DIFF
--- a/exercises/option/option2.rs
+++ b/exercises/option/option2.rs
@@ -5,7 +5,7 @@
 
 fn main() {
     let optional_value = Some(String::from("rustlings"));
-    // Make this an if let statement whose value is "Some" type
+    // TODO: Make this an if let statement whose value is "Some" type
     value = optional_value {
         println!("the value of optional value is: {}", value);
     } else {
@@ -17,7 +17,7 @@ fn main() {
         optional_values_vec.push(Some(x));
     }
 
-    // make this a while let statement - remember that vector.pop also adds another layer of Option<T>
+    // TODO: make this a while let statement - remember that vector.pop also adds another layer of Option<T>
     // You can stack `Option<T>`'s into while let and if let
     value = optional_values_vec.pop() {
         println!("current value: {}", value);


### PR DESCRIPTION
I think a simple add of "TODO" will make this exercise look more in line with the other exercises.
Other exercises included a "TODO" before when the programmer was expected to enter a solution.