### PR TITLE
remove struct2 hint comment

### DIFF
--- a/exercises/structs/structs2.rs
+++ b/exercises/structs/structs2.rs
@@ -1,6 +1,5 @@
 // structs2.rs
 // Address all the TODOs to make the tests pass!
-// No hints, just do it!
 
 // I AM NOT DONE
 


### PR DESCRIPTION
There was a hint added for struct2 by https://github.com/rust-lang/rustlings/pull/355, so this comment is misleading.