### PR TITLE
fix(option1): Don't add only zeros to the numbers array

### DIFF
--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut numbers: [Option<u16>; 5];
     for iter in 0..5 {
         let number_to_add: u16 = {
-            ((iter * 5) + 2) / (4 * 16)
+            ((iter * 1235) + 2) / (4 * 16)
         };
 
         numbers[iter as usize] = number_to_add;


### PR DESCRIPTION
If you decide to print the elements in `numbers`, it will display only zeros, which can be confusing.

This change makes the numbers a little bit bigger.

```
printing: 0
printing: 0
printing: 0
printing: 0
printing: 0

vs

printing: 0
printing: 19
printing: 38
printing: 57
printing: 77
```