### PR TITLE
chore: Add Powershell reminder (PR #373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will install Rustlings and give you access to the `rustlings` command. Run 
 
 ## Windows
 
-First, set `ExecutionPolicy` to `RemoteSigned`:
+In Powershell, set `ExecutionPolicy` to `RemoteSigned`:
 
 ```ps
 Set-ExecutionPolicy RemoteSigned


### PR DESCRIPTION
Emphasizes that the Windows commands in the README only work in Powershell, not in cmd (in response to PR #373 ).