### PR TITLE
Show tests prints

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -802,7 +802,7 @@ name = "try_from_into"
 path = "exercises/conversions/try_from_into.rs"
 mode = "test"
 hint = """
-Follow the steps provided right before the `From` implementation.
+Follow the steps provided right before the `TryFrom` implementation.
 You can also use the example at https://doc.rust-lang.org/std/convert/trait.TryFrom.html"""
 
 [[exercises]]
@@ -819,4 +819,4 @@ mode = "test"
 hint = """
 The implementation of FromStr should return an Ok with a Person object,
 or an Err with a string if the string is not valid.
-This is a some like an `try_from_into` exercise."""
+This is almost like the `try_from_into` exercise."""

--- a/install.sh
+++ b/install.sh
@@ -102,12 +102,30 @@ Path=${1:-rustlings/}
 echo "Cloning Rustlings at $Path..."
 git clone -q https://github.com/rust-lang/rustlings $Path
 
+cd $Path
+
 Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']);")
 CargoBin="${CARGO_HOME:-$HOME/.cargo}/bin"
 
+if [[ -z ${Version} ]]
+then
+    echo "The latest tag version could not be fetched remotely."
+    echo "Using the local git repository..."
+    Version=$(ls -tr .git/refs/tags/ | tail -1)
+    if [[ -z ${Version}  ]]
+    then
+        echo "No valid tag version found"
+        echo "Rustlings will be installed using the master branch"
+        Version="master"
+    else
+        Version="tags/${Version}"
+    fi
+else
+    Version="tags/${Version}"
+fi
+
 echo "Checking out version $Version..."
-cd $Path
-git checkout -q tags/$Version
+git checkout -q ${Version}
 
 echo "Installing the 'rustlings' executable..."
 cargo install --force --path .

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,22 @@ fn main() {
         .version(crate_version!())
         .author("Olivia Hugger, Carol Nichols")
         .about("Rustlings is a collection of small exercises to get you used to writing and reading Rust code")
-        .subcommand(SubCommand::with_name("verify").alias("v").about("Verifies all exercises according to the recommended order"))
-        .subcommand(SubCommand::with_name("watch").alias("w").about("Reruns `verify` when files were edited"))
+        .arg(
+            Arg::with_name("verbose")
+                .short("V")
+                .long("verbose")
+                .help("Show tests' standard output")
+        )
+        .subcommand(
+            SubCommand::with_name("verify")
+                .alias("v")
+                .about("Verifies all exercises according to the recommended order")
+        )
+        .subcommand(
+            SubCommand::with_name("watch")
+                .alias("w")
+                .about("Reruns `verify` when files were edited")
+        )
         .subcommand(
             SubCommand::with_name("run")
                 .alias("r")
@@ -43,7 +57,7 @@ fn main() {
         )
         .get_matches();
 
-    if None == matches.subcommand_name() {
+    if matches.subcommand_name().is_none() {
         println!();
         println!(r#"       welcome to...                      "#);
         println!(r#"                 _   _ _                  "#);
@@ -105,22 +119,20 @@ fn main() {
         verify(&exercises).unwrap_or_else(|_| std::process::exit(1));
     }
 
-    if matches.subcommand_matches("watch").is_some() {
-        if watch(&exercises).is_ok() {
-            println!(
-                "{emoji} All exercises completed! {emoji}",
-                emoji = Emoji("🎉", "★")
-            );
-            println!("");
-            println!("We hope you enjoyed learning about the various aspects of Rust!");
-            println!(
-                "If you noticed any issues, please don't hesitate to report them to our repo."
-            );
-            println!("You can also contribute your own exercises to help the greater community!");
-            println!("");
-            println!("Before reporting an issue or contributing, please read our guidelines:");
-            println!("https://github.com/rust-lang/rustlings/blob/master/CONTRIBUTING.md");
-        }
+    if matches.subcommand_matches("watch").is_some() && watch(&exercises).is_ok() {
+        println!(
+            "{emoji} All exercises completed! {emoji}",
+            emoji = Emoji("🎉", "★")
+        );
+        println!();
+        println!("We hope you enjoyed learning about the various aspects of Rust!");
+        println!(
+            "If you noticed any issues, please don't hesitate to report them to our repo."
+        );
+        println!("You can also contribute your own exercises to help the greater community!");
+        println!();
+        println!("Before reporting an issue or contributing, please read our guidelines:");
+        println!("https://github.com/rust-lang/rustlings/blob/master/CONTRIBUTING.md");
     }
 
     if matches.subcommand_name().is_none() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,15 +2,22 @@ use crate::exercise::{Exercise, Mode};
 use crate::verify::test;
 use indicatif::ProgressBar;
 
-pub fn run(exercise: &Exercise) -> Result<(), ()> {
+// Invoke the rust compiler on the path of the given exercise,
+// and run the ensuing binary.
+// The verbose argument helps determine whether or not to show
+// the output from the test harnesses (if the mode of the exercise is test)
+pub fn run(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
     match exercise.mode {
-        Mode::Test => test(exercise)?,
+        Mode::Test => test(exercise, verbose)?,
         Mode::Compile => compile_and_run(exercise)?,
         Mode::Clippy => compile_and_run(exercise)?,
     }
     Ok(())
 }
 
+// Invoke the rust compiler on the path of the given exercise
+// and run the ensuing binary.
+// This is strictly for non-test binaries, so output is displayed
 fn compile_and_run(exercise: &Exercise) -> Result<(), ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {}...", exercise).as_str());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -124,16 +124,16 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
         Mode::Clippy => "The code is compiling, and 📎 Clippy 📎 is happy!",
     };
 
-    println!("");
+    println!();
     println!("🎉 🎉  {} 🎉 🎉", success_msg);
-    println!("");
+    println!();
 
     if let Some(output) = prompt_output {
         println!("Output:");
         println!("{}", separator());
         println!("{}", output);
         println!("{}", separator());
-        println!("");
+        println!();
     }
 
     println!("You can keep working on this exercise,");
@@ -141,12 +141,12 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
         "or jump into the next one by removing the {} comment:",
         style("`I AM NOT DONE`").bold()
     );
-    println!("");
+    println!();
     for context_line in context {
         let formatted_line = if context_line.important {
             format!("{}", style(context_line.line).bold())
         } else {
-            format!("{}", context_line.line)
+            context_line.line.to_string()
         };
 
         println!(

--- a/tests/fixture/success/testSuccess.rs
+++ b/tests/fixture/success/testSuccess.rs
@@ -1,4 +1,5 @@
 #[test]
 fn passing() {
+    println!("THIS TEST TOO SHALL PASS");
     assert!(true);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -159,3 +159,25 @@ fn run_test_exercise_does_not_prompt() {
         .code(0)
         .stdout(predicates::str::contains("I AM NOT DONE").not());
 }
+
+#[test]
+fn run_single_test_success_with_output() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["--nocapture", "r", "testSuccess"])
+        .current_dir("tests/fixture/success/")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("THIS TEST TOO SHALL PAS"));
+}
+
+#[test]
+fn run_single_test_success_without_output() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["r", "testSuccess"])
+        .current_dir("tests/fixture/success/")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("THIS TEST TOO SHALL PAS").not());
+}


### PR DESCRIPTION
This new feature can be accessed by invoking rustlings with `--nocapture`.

closes #262

**_MINOR CHANGES_**:
    * Documentation added to source code under [`src`](https://github.com/rust-lang/rustlings/tree/master/src)
    * Both unit and integration tests for `--nocapture` have been added.

**_BREAKING CHANGES_**:
The following function take a new boolean argument:
    * `run`
    * `verify`
    * `test`
    * `compile_and_test`

`compile_and_test` is the function that uses this new boolean argument to determine whether or not to display the output from the test harnesses.

Please feel free to reach out with any questions.

Thank you,

Abdou