### PR TITLE
feat: Remind the user of the hint option

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -54,6 +54,7 @@ fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
         Err(output) => {
             warn!("Ran {} with errors", exercise);
             println!("{}", output.stdout);
+            println!("{}", output.stderr);
             return Err(());
         }
     };


### PR DESCRIPTION
Suggestion from AbdouSeck https://github.com/rust-lang/rustlings/issues/424#issuecomment-639870331 for when the student's code has errors.

(Works for me, but I haven't done extensive testing to check how this could impact other exercises, so this should be reviewed by someone more competent than me, before merging.) 