### PR TITLE
fix(arc1): Passively introduce attributes

### DIFF
--- a/exercises/standard_library_types/arc1.rs
+++ b/exercises/standard_library_types/arc1.rs
@@ -6,6 +6,7 @@
 
 // I AM NOT DONE
 
+#![forbid(unused_imports)] // Do not change this, (or the next) line.
 use std::sync::Arc;
 use std::thread;
 


### PR DESCRIPTION
Ensure that std::sync::Arc is actually used, as this exercise can be compiled using things already learnt in previous exercises.