### PR TITLE
fix(generics2): Guide students to the answer

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -724,8 +724,10 @@ name = "generics2"
 path = "exercises/generics/generics2.rs"
 mode = "test"
 hint = """
-Think carefully about what we need to do here. Currently we are wrapping only values of
-type 'u32'. Maybe we need to update the explicit references to this data type somehow?
+Currently we are wrapping only values of type 'u32'. 
+Maybe we could update the explicit references to this data type somehow?
+
+If you are still stuck https://doc.rust-lang.org/stable/book/ch10-01-syntax.html#in-method-definitions
 """
 
 [[exercises]]


### PR DESCRIPTION
... rather than leaving them in the dark.  It doesn't matter how much I "Think carefully about what we need to do here." if I don't already understand, (and have memorised) ch10 of The Rust Book. Even if one understand the concept of generic types, expecting the student to determine the specific Rust grammar from first principles, might be considered to be asking a little too much.