### PR TITLE
docs: Add uninstall info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ rustlings hint myExercise1
 
 After every couple of sections, there will be a quiz that'll test your knowledge on a bunch of sections at once. These quizzes are found in `exercises/quizN.rs`.
 
+## Continuing On
+
+Once you've completed Rustlings, put your new knowledge to good use! Continue practicing your Rust skills by building your own projects, contributing to Rustlings, or finding other open-source projects to contribute to.
+
+If you'd like to uninstall Rustlings, you can do so by invoking cargo and removing the rustlings directory:
+
+    cargo uninstall rustlings
+	rm -r rustlings/ # or on Windows: rmdir /s rustlings
+
 ## Completion
 
 Rustlings isn't done; there are a couple of sections that are very experimental and don't have proper documentation. These include:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ Once you've completed Rustlings, put your new knowledge to good use! Continue pr
 
 If you'd like to uninstall Rustlings, you can do so by invoking cargo and removing the rustlings directory:
 
-    cargo uninstall rustlings
-	rm -r rustlings/ # or on Windows: rmdir /s rustlings
+```bash
+cargo uninstall rustlings
+rm -r rustlings/ # or on Windows: rmdir /s rustlings
+```
 
 ## Completion
 


### PR DESCRIPTION
Resolves #459.

Encourages the reader in terms of what to do after completing Rustlings, and then provides clear uninstallation instructions, if they'd like to do so.