### PR TITLE
feat(try_from_into): Add insufficient length test

### DIFF
--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -127,4 +127,10 @@ mod tests {
         let v = vec![0, 0, 0, 0];
         let _ = Color::try_from(&v[..]).unwrap();
     }
+    #[test]
+    #[should_panic]
+    fn test_slice_insufficient_length() {
+        let v = vec![0, 0];
+        let _ = Color::try_from(&v[..]).unwrap();
+    }
 }


### PR DESCRIPTION
It seems to me like if we're already testing for an overly long slice, we might as well check for one that is too short as well.