### PR TITLE
fix: Update rustlings version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "rustlings"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
I've noticed this in my changed files while going through the exercises.