### PR TITLE
fix(simplify): eliminating struct type in TODOenum

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -51,9 +51,9 @@ mod tests {
             position: Point { x: 0, y: 0 },
             color: (0, 0, 0),
         };
-        state.process(Message::ChangeColor((255, 0, 255)));
+        state.process(Message::ChangeColor(255, 0, 255));
         state.process(Message::Echo(String::from("hello world")));
-        state.process(Message::Move(Point { x: 10, y: 15 }));
+        state.process(Message::Move { x: 10, y: 15 });
         state.process(Message::Quit);
 
         assert_eq!(state.color, (255, 0, 255));


### PR DESCRIPTION
Going back to what was initially intended by nyxton in order to simply exercise.
Using simple types makes it much easier to understand, this way there is just destructuring nested structs and enums in match - which is already a lot.
"Nesting" struct in enum makes it unusual and somehow difficult.