### PR TITLE
fix(simplify): eliminating tuple in TODO enum

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -51,7 +51,7 @@ mod tests {
             position: Point { x: 0, y: 0 },
             color: (0, 0, 0),
         };
-        state.process(Message::ChangeColor((255, 0, 255)));
+        state.process(Message::ChangeColor(255, 0, 255));
         state.process(Message::Echo(String::from("hello world")));
         state.process(Message::Move(Point { x: 10, y: 15 }));
         state.process(Message::Quit);


### PR DESCRIPTION
Going back to what was initially intended by nyxton in order to simply exercise.
Using simple tuple type makes it much easier to understand and makes more sense as it keeps it simple. 
"Nesting" tuples makes it unusual and somehow complicated.