### PR TITLE
Make macros4 not compile by default

### DIFF
--- a/exercises/macros/macros4.rs
+++ b/exercises/macros/macros4.rs
@@ -6,10 +6,10 @@
 macro_rules! my_macro {
     () => {
         println!("Check out my macro!");
-    };
+    }
     ($val:expr) => {
         println!("Look at this other macro: {}", $val);
-    };
+    }
 }
 
 fn main() {


### PR DESCRIPTION
Did you mean this? I'm new to rust and this test passed right away, so unsure what the intention was.