### PR TITLE
fix(structs3): Small adjustment of variable name

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -29,7 +29,7 @@ impl Package {
         // Something goes here...
     }
 
-    fn get_fees(&self, cents_per_kg: i32) -> ??? {
+    fn get_fees(&self, cents_per_gram: i32) -> ??? {
         // Something goes here... (beware of grams to kg conversion)
     }
 }
@@ -62,10 +62,10 @@ mod tests {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Spain");
 
-        let cents_per_kg = ???;
+        let cents_per_gram = ???;
 
         let package = Package::new(sender_country, recipient_country, 1500);
 
-        assert_eq!(package.get_fees(cents_per_kg), 4500);
+        assert_eq!(package.get_fees(cents_per_gram), 4500);
     }
 }

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -30,7 +30,7 @@ impl Package {
     }
 
     fn get_fees(&self, cents_per_gram: i32) -> ??? {
-        // Something goes here... (beware of grams to kg conversion)
+        // Something goes here... 
     }
 }
 


### PR DESCRIPTION
A small follow-up to PR #432, where the price of kg was changed to price per gram to avoid usage of floats. The variable identifier should therefore also be changed, because `cents_per_kg` would indicate 3/1000 and not 3.