### PR TITLE
fix(using_as): Add test so that proper type is returned.

### DIFF
--- a/exercises/conversions/using_as.rs
+++ b/exercises/conversions/using_as.rs
@@ -3,6 +3,7 @@
 // It also helps with renaming imports.
 //
 // The goal is to make sure that the division does not fail to compile
+// and returns the proper type.
 
 // I AM NOT DONE
 
@@ -16,4 +17,14 @@ fn average(values: &[f64]) -> f64 {
 fn main() {
     let values = [3.5, 0.3, 13.0, 11.7];
     println!("{}", average(&values));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_proper_type_and_value() {
+        assert_eq!(average(&[3.5, 0.3, 13.0, 11.7]), 7.125);
+    }
 }

--- a/info.toml
+++ b/info.toml
@@ -787,7 +787,7 @@ what you've learned :)"""
 [[exercises]]
 name = "using_as"
 path = "exercises/conversions/using_as.rs"
-mode = "compile"
+mode = "test"
 hint = """
 Use the `as` operator to cast one of the operands in the last line of the
 `average` function into the expected return type."""


### PR DESCRIPTION
It was pretty easy (at least for me), to get this to compile but return an incorrect value. I've added a test to ensure the proper type is used.

Using a `usize` cast:
<img width="754" alt="Screen Shot 2020-08-31 at 12 54 02 PM" src="https://user-images.githubusercontent.com/772937/91764410-1b0ce480-eb8c-11ea-99b2-2082ae3d0d79.png">

Using `f64`:
<img width="692" alt="Screen Shot 2020-08-31 at 12 53 41 PM" src="https://user-images.githubusercontent.com/772937/91764404-18aa8a80-eb8c-11ea-824e-35921ae82c60.png">

Seems like the test is helpful to avoid that.