### PR TITLE
fix: measurement mismatch in structs3.rs

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -29,8 +29,8 @@ impl Package {
         // Something goes here...
     }
 
-    fn get_fees(&self, cents_per_kg: i32) -> ??? {
-        // Something goes here... (beware of grams to kg conversion)
+    fn get_fees(&self, cents_per_gram: i32) -> i32 {
+        // Something goes here...
     }
 }
 
@@ -62,10 +62,10 @@ mod tests {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Spain");
 
-        let cents_per_kg = ???;
+        let cents_per_gram = ???;
 
         let package = Package::new(sender_country, recipient_country, 1500);
 
-        assert_eq!(package.get_fees(cents_per_kg), 4500);
+        assert_eq!(package.get_fees(cents_per_gram), 4500);
     }
 }


### PR DESCRIPTION
Since the previous change where floats were replaced with integers, the `get_fees` function started to feel weird. The tests imply that we multiply **cents_per_kg** by **weight_in_grams** which is not logical.

This change just renames variables. Now, there is the price in cents per **gram** and the weight in **grams**, thus not misleading those who do the exercise.

Discussed in #432 