### PR TITLE
Exercise order: string before struct

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -52,7 +52,7 @@ because we want to assign a different typed value to an existing variable. Somet
 you may also like to reuse existing variable names because you are just converting
 values to different types like in this exercise.
 Fortunately Rust has a powerful solution to this problem: 'Shadowing'!
-You can read more about 'Shadowing' in the book's section 'Variables and Mutability': 
+You can read more about 'Shadowing' in the book's section 'Variables and Mutability':
 https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#shadowing
 Try to solve this exercise afterwards using this technique."""
 
@@ -61,13 +61,13 @@ name = "variables6"
 path = "exercises/variables/variables6.rs"
 mode = "compile"
 hint = """
-We know about variables and mutability, but there is another important type of 
-variable available; constants. 
-Constants are always immutable and they are declared with keyword 'const' rather 
+We know about variables and mutability, but there is another important type of
+variable available; constants.
+Constants are always immutable and they are declared with keyword 'const' rather
 then keyword 'let'.
 Constants types must also always be annotated.
 
-Read more about constants under 'Differences Between Variables and Constants' in the book's section 'Variables and Mutability': 
+Read more about constants under 'Differences Between Variables and Constants' in the book's section 'Variables and Mutability':
 https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
 """
 
@@ -218,42 +218,6 @@ Data Types -> The Tuple Type section of the book:
 https://doc.rust-lang.org/book/ch03-02-data-types.html#the-tuple-type
 Now you have another tool in your toolbox!"""
 
-# STRUCTS
-
-[[exercises]]
-name = "structs1"
-path = "exercises/structs/structs1.rs"
-mode = "test"
-hint = """
-Rust has more than one type of struct. Both variants are used to package related data together.
-On the one hand, there are normal, or classic, structs. These are named collections of related data stored in fields.
-The other variant is tuple structs. Basically just named tuples.
-In this exercise you need to implement one of each kind.
-
-Read more about structs in The Book: https://doc.rust-lang.org/stable/book/ch05-00-structs.html"""
-
-[[exercises]]
-name = "structs2"
-path = "exercises/structs/structs2.rs"
-mode = "test"
-hint = """
-Creating instances of structs is easy, all you need to do is assign some values to its fields. 
-There is however some shortcuts that can be taken when instantiating structs. 
-Have a look in The Book, to find out more: https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax"""
-
-[[exercises]]
-name = "structs3"
-path = "exercises/structs/structs3.rs"
-mode = "test"
-hint = """
-The new method needs to panic if the weight is physically impossible :), how do we do that in Rust?
-
-For is_international: What makes a package international? Seems related to the places it goes through right?
-
-For calculate_transport_fees: Bigger is more expensive usually, we don't have size, but something may fit the bill here :)
-
-Have a look in The Book, to find out more about method implementations: https://doc.rust-lang.org/book/ch05-03-method-syntax.html"""
-
 # STRINGS
 
 [[exercises]]
@@ -276,6 +240,42 @@ hint = """
 Yes, it would be really easy to fix this by just changing the value bound to `word` to be a
 string slice instead of a `String`, wouldn't it?? There is a way to add one character to line
 9, though, that will coerce the `String` into a string slice."""
+
+# STRUCTS
+
+[[exercises]]
+name = "structs1"
+path = "exercises/structs/structs1.rs"
+mode = "test"
+hint = """
+Rust has more than one type of struct. Both variants are used to package related data together.
+On the one hand, there are normal, or classic, structs. These are named collections of related data stored in fields.
+The other variant is tuple structs. Basically just named tuples.
+In this exercise you need to implement one of each kind.
+
+Read more about structs in The Book: https://doc.rust-lang.org/stable/book/ch05-00-structs.html"""
+
+[[exercises]]
+name = "structs2"
+path = "exercises/structs/structs2.rs"
+mode = "test"
+hint = """
+Creating instances of structs is easy, all you need to do is assign some values to its fields.
+There is however some shortcuts that can be taken when instantiating structs.
+Have a look in The Book, to find out more: https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax"""
+
+[[exercises]]
+name = "structs3"
+path = "exercises/structs/structs3.rs"
+mode = "test"
+hint = """
+The new method needs to panic if the weight is physically impossible :), how do we do that in Rust?
+
+For is_international: What makes a package international? Seems related to the places it goes through right?
+
+For calculate_transport_fees: Bigger is more expensive usually, we don't have size, but something may fit the bill here :)
+
+Have a look in The Book, to find out more about method implementations: https://doc.rust-lang.org/book/ch05-03-method-syntax.html"""
 
 # TEST 2
 
@@ -682,8 +682,8 @@ name = "iterators4"
 path = "exercises/standard_library_types/iterators4.rs"
 mode = "test"
 hint = """
-In an imperative language, you might write a for loop that updates 
-a mutable variable. Or, you might write code utilizing recursion 
+In an imperative language, you might write a for loop that updates
+a mutable variable. Or, you might write code utilizing recursion
 and a match clause. In Rust you can take another functional
 approach, computing the factorial elegantly with ranges and iterators."""
 
@@ -703,10 +703,10 @@ name = "traits2"
 path = "exercises/traits/traits2.rs"
 mode = "test"
 hint = """
-Notice how the trait takes ownership of 'self',and returns `Self'. 
+Notice how the trait takes ownership of 'self',and returns `Self'.
 Try mutating the incoming string vector.
 
-Vectors provide suitable methods for adding an element at the end. See 
+Vectors provide suitable methods for adding an element at the end. See
 the documentation at: https://doc.rust-lang.org/std/vec/struct.Vec.html"""
 
 # Generics
@@ -724,7 +724,7 @@ name = "generics2"
 path = "exercises/generics/generics2.rs"
 mode = "test"
 hint = """
-Currently we are wrapping only values of type 'u32'. 
+Currently we are wrapping only values of type 'u32'.
 Maybe we could update the explicit references to this data type somehow?
 
 If you are still stuck https://doc.rust-lang.org/stable/book/ch10-01-syntax.html#in-method-definitions
@@ -735,7 +735,7 @@ name = "generics3"
 path = "exercises/generics/generics3.rs"
 mode = "test"
 hint = """
-To find the best solution to this challenge you're going to need to think back to your 
+To find the best solution to this challenge you're going to need to think back to your
 knowledge of traits, specifically Trait Bound Syntax -  you may also need this: "use std::fmt::Display;"
 
 This is definitely harder than the last two exercises! You need to think about not only making the


### PR DESCRIPTION
The struct exercises rely on knowledge learned in the string exercises, so should follow rather than precede them.