### PR TITLE
Remove type when passing in a struct to an enum

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -53,7 +53,7 @@ mod tests {
         };
         state.process(Message::ChangeColor((255, 0, 255)));
         state.process(Message::Echo(String::from("hello world")));
-        state.process(Message::Move(Point { x: 10, y: 15 }));
+        state.process(Message::Move { x: 10, y: 15 });
         state.process(Message::Quit);
 
         assert_eq!(state.color, (255, 0, 255));


### PR DESCRIPTION
I am fairly new to Rust and I was doing this exercise and noticed that the default test had an issue where it was defining the type being passed to the enum as a struct. Test was failing and the compiler advised to remove the type of Point. When it was removed test ran successfully.