### PR TITLE
fixed test name

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -315,7 +315,7 @@ mod test {
     #[test]
     fn test_exercise_with_output() {
         let exercise = Exercise {
-            name: "finished_exercise".into(),
+            name: "exercise_with_output".into(),
             path: PathBuf::from("tests/fixture/success/testSuccess.rs"),
             mode: Mode::Test,
             hint: String::new(),


### PR DESCRIPTION
Looks like this was copied from the previous test without renaming. This test is currently failing `cargo test` and ticket https://github.com/rust-lang/rustlings/issues/542 has been raised.