### PR TITLE
fix(quiz3): Second test is for odd numbers, not even.

### DIFF
--- a/exercises/tests/tests3.rs
+++ b/exercises/tests/tests3.rs
@@ -20,7 +20,7 @@ mod tests {
     }
 
     #[test]
-    fn is_false_when_even() {
+    fn is_false_when_odd() {
         assert!();
     }
 }


### PR DESCRIPTION
The second test is meant to test passing an odd result, so let's make the name reflect that.