### PR TITLE
chore: primitive_types6 mode changed to test

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -210,7 +210,7 @@ of the tuple. You can do it!!"""
 [[exercises]]
 name = "primitive_types6"
 path = "exercises/primitive_types/primitive_types6.rs"
-mode = "compile"
+mode = "test"
 hint = """
 While you could use a destructuring `let` for the tuple here, try
 indexing into it instead, as explained in the last example of the


### PR DESCRIPTION
primitive_types6 exercise was changed to test yesterday, but info.toml file wasn't updated.
I think this change should fix it.