### PR TITLE
Small fixes to primitive_types6.rs

### DIFF
--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -8,7 +8,7 @@
 #[test]
 fn indexing_tuple() {
     let numbers = (1, 2, 3);
-    /// Replace below ??? with the tuple indexing syntax.
+    // Replace below ??? with the tuple indexing syntax.
     let second = ???;
 
     assert_eq!(2, second,

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -11,6 +11,6 @@ fn indexing_tuple() {
     /// Replace below ??? with the tuple indexing syntax.
     let second = ???;
 
-    assert_eq!(2, second
+    assert_eq!(2, second,
         "This is not the 2nd number in the tuple!")
 }


### PR DESCRIPTION
It appears that #548 (thanks for the new test!) introduced a parse error and warning when the actual exercise is completed correctly.  These commits correct the parse error (missing comma) and remove the potentially distracting `unused doc comment` warning.

Output when the `let second = ???;` is corrected:
```
⚠️  Compiling of exercises/primitive_types/primitive_types6.rs failed! Please try again. Here's the output:
error: no rules expected the token `"This is not the 2nd number in the tuple!"`
  --> exercises/primitive_types/primitive_types6.rs:15:9
   |
14 |     assert_eq!(2, second
   |                         - help: missing comma here
15 |         "This is not the 2nd number in the tuple!")
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call

warning: unused doc comment
  --> exercises/primitive_types/primitive_types6.rs:11:5
   |
11 |     /// Replace below ??? with the tuple indexing syntax.
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
12 |     let second = numbers.1;
   |     ----------------------- rustdoc does not generate documentation for statements
   |
   = note: `#[warn(unused_doc_comments)]` on by default

error: aborting due to previous error; 1 warning emitted
```
