### PR TITLE
feat(try_from_into): Add tests

### DIFF
--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -25,22 +25,19 @@ struct Color {
 // Tuple implementation
 impl TryFrom<(i16, i16, i16)> for Color {
     type Error = String;
-    fn try_from(tuple: (i16, i16, i16)) -> Result<Self, Self::Error> {
-    }
+    fn try_from(tuple: (i16, i16, i16)) -> Result<Self, Self::Error> {}
 }
 
 // Array implementation
 impl TryFrom<[i16; 3]> for Color {
     type Error = String;
-    fn try_from(arr: [i16; 3]) -> Result<Self, Self::Error> {
-    }
+    fn try_from(arr: [i16; 3]) -> Result<Self, Self::Error> {}
 }
 
 // Slice implementation
 impl TryFrom<&[i16]> for Color {
     type Error = String;
-    fn try_from(slice: &[i16]) -> Result<Self, Self::Error> {
-    }
+    fn try_from(slice: &[i16]) -> Result<Self, Self::Error> {}
 }
 
 fn main() {
@@ -76,6 +73,11 @@ mod tests {
         let _ = Color::try_from((-1, -10, -256)).unwrap();
     }
     #[test]
+    #[should_panic]
+    fn test_tuple_sum() {
+        let _ = Color::try_from((-1, 255, 255)).unwrap();
+    }
+    #[test]
     fn test_tuple_correct() {
         let c: Color = (183, 65, 14).try_into().unwrap();
         assert_eq!(c.red, 183);
@@ -92,6 +94,11 @@ mod tests {
     #[should_panic]
     fn test_array_out_of_range_negative() {
         let _: Color = [-10, -256, -1].try_into().unwrap();
+    }
+    #[test]
+    #[should_panic]
+    fn test_array_sum() {
+        let _: Color = [-1, 255, 255].try_into().unwrap();
     }
     #[test]
     fn test_array_correct() {
@@ -111,6 +118,12 @@ mod tests {
     #[should_panic]
     fn test_slice_out_of_range_negative() {
         let arr = [-256, -1, -10];
+        let _ = Color::try_from(&arr[..]).unwrap();
+    }
+    #[test]
+    #[should_panic]
+    fn test_slice_sum() {
+        let arr = [-1, 255, 255];
         let _ = Color::try_from(&arr[..]).unwrap();
     }
     #[test]

--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -4,7 +4,7 @@
 // You can read more about it at https://doc.rust-lang.org/std/convert/trait.TryFrom.html
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct Color {
     red: u8,
     green: u8,
@@ -63,87 +63,93 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic]
     fn test_tuple_out_of_range_positive() {
-        let _ = Color::try_from((256, 1000, 10000)).unwrap();
+        assert!(Color::try_from((256, 1000, 10000)).is_err());
     }
     #[test]
-    #[should_panic]
     fn test_tuple_out_of_range_negative() {
-        let _ = Color::try_from((-1, -10, -256)).unwrap();
+        assert!(Color::try_from((-1, -10, -256)).is_err());
     }
     #[test]
-    #[should_panic]
     fn test_tuple_sum() {
-        let _ = Color::try_from((-1, 255, 255)).unwrap();
+        assert!(Color::try_from((-1, 255, 255)).is_err());
     }
     #[test]
     fn test_tuple_correct() {
-        let c: Color = (183, 65, 14).try_into().unwrap();
-        assert_eq!(c.red, 183);
-        assert_eq!(c.green, 65);
-        assert_eq!(c.blue, 14);
+        let c: Result<Color, String> = (183, 65, 14).try_into();
+        assert_eq!(
+            c,
+            Ok(Color {
+                red: 183,
+                green: 65,
+                blue: 14
+            })
+        );
     }
-
     #[test]
-    #[should_panic]
     fn test_array_out_of_range_positive() {
-        let _: Color = [1000, 10000, 256].try_into().unwrap();
+        let c: Color = [1000, 10000, 256].try_into();
+        assert!(c.is_err());
     }
     #[test]
-    #[should_panic]
     fn test_array_out_of_range_negative() {
-        let _: Color = [-10, -256, -1].try_into().unwrap();
+        let c: Color = [-10, -256, -1].try_into();
+        assert!(c.is_err());
     }
     #[test]
-    #[should_panic]
     fn test_array_sum() {
-        let _: Color = [-1, 255, 255].try_into().unwrap();
+        let c: Color = [-1, 255, 255].try_into();
+        assert!(c.is_err());
     }
+    #[test]
     #[test]
     fn test_array_correct() {
-        let c: Color = [183, 65, 14].try_into().unwrap();
-        assert_eq!(c.red, 183);
-        assert_eq!(c.green, 65);
-        assert_eq!(c.blue, 14);
+        let c: Result<Color, String> = [183, 65, 14].try_into();
+        assert_eq!(
+            c,
+            Ok(Color {
+                red: 183,
+                green: 65,
+                blue: 14
+            })
+        );
     }
-
     #[test]
-    #[should_panic]
     fn test_slice_out_of_range_positive() {
         let arr = [10000, 256, 1000];
-        let _ = Color::try_from(&arr[..]).unwrap();
+        assert!(Color::try_from(&arr[..]).is_err());
     }
     #[test]
-    #[should_panic]
     fn test_slice_out_of_range_negative() {
         let arr = [-256, -1, -10];
-        let _ = Color::try_from(&arr[..]).unwrap();
+        assert!(Color::try_from(&arr[..]).is_err());
     }
     #[test]
-    #[should_panic]
     fn test_slice_sum() {
         let arr = [-1, 255, 255];
-        let _ = Color::try_from(&arr[..]).unwrap();
+        assert!(Color::try_from(&arr[..]).is_err());
     }
     #[test]
     fn test_slice_correct() {
         let v = vec![183, 65, 14];
-        let c = Color::try_from(&v[..]).unwrap();
-        assert_eq!(c.red, 183);
-        assert_eq!(c.green, 65);
-        assert_eq!(c.blue, 14);
+        let c: Result<Color, String> = Color::try_from(&v[..]);
+        assert_eq!(
+            c,
+            Ok(Color {
+                red: 183,
+                green: 65,
+                blue: 14
+            })
+        );
     }
     #[test]
-    #[should_panic]
     fn test_slice_excess_length() {
         let v = vec![0, 0, 0, 0];
-        let _ = Color::try_from(&v[..]).unwrap();
+        assert!(Color::try_from(&v[..]).is_err());
     }
     #[test]
-    #[should_panic]
     fn test_slice_insufficient_length() {
         let v = vec![0, 0];
-        let _ = Color::try_from(&v[..]).unwrap();
+        assert!(Color::try_from(&v[..]).is_err());
     }
 }


### PR DESCRIPTION
Hello everyone :smile:. I was trying to resolve the `try_from_into` exercise and found out that I passed all the tests if I sum up for example all elements in array and test if it is <= 765 or >= 0. But if we sum up `(255 + 255 + (-1))` it gives us a good result but the third value is negative, so we should not pass it.

I added 3 tests for each type to prevent users pass this type of errors.

Example for array:
```rust
// Array implementation
impl TryFrom<[i16; 3]> for Color {
    type Error = String;
    fn try_from(arr: [i16; 3]) -> Result<Self, Self::Error> {
        if arr[0] + arr[1] + arr[2] <= 765 && arr[0] + arr[1] + arr[2] >= 0 {
            let c = [arr[0] as u8, arr[1] as u8, arr[2] as u8];
            Ok(Color {
                red: c[0],
                green: c[1],
                blue: c[2],
            })
        } else {
            Err("NOP".to_string())
        }
    }
}
```
This code passes all the tests, but if we add test with [-1, 255, 255] it does not pass :+1:.
I'm open for discussion if it is not merge-able to correct ! :smiley: 