### PR TITLE
fix(structs1): Adjust wording

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -227,7 +227,7 @@ mode = "test"
 hint = """
 Rust has more than one type of struct. Three actually, all variants are used to package related data together.
 There are normal (or classic) structs. These are named collections of related data stored in fields.
-Tuple structs are asically just named tuples.
+Tuple structs are basically just named tuples.
 Finally, Unit structs. These don't have and fields and are useful for generics.
 
 In this exercise you need to complete and implement one of each kind.

--- a/info.toml
+++ b/info.toml
@@ -228,7 +228,7 @@ hint = """
 Rust has more than one type of struct. Three actually, all variants are used to package related data together.
 There are normal (or classic) structs. These are named collections of related data stored in fields.
 Tuple structs are asically just named tuples.
-Finaly, Unit structs. These are field-less and are useful for generics.
+Finally, Unit structs. These don't have and fields and are useful for generics.
 
 In this exercise you need to complete and implement one of each kind.
 Read more about structs in The Book: https://doc.rust-lang.org/book/ch05-01-defining-structs.html"""

--- a/info.toml
+++ b/info.toml
@@ -225,12 +225,13 @@ name = "structs1"
 path = "exercises/structs/structs1.rs"
 mode = "test"
 hint = """
-Rust has more than one type of struct. Both variants are used to package related data together.
-On the one hand, there are normal, or classic, structs. These are named collections of related data stored in fields.
-The other variant is tuple structs. Basically just named tuples.
-In this exercise you need to implement one of each kind.
+Rust has more than one type of struct. Three actually, all variants are used to package related data together.
+There are normal (or classic) structs. These are named collections of related data stored in fields.
+Tuple structs are asically just named tuples.
+Finaly, Unit structs. These are field-less and are useful for generics.
 
-Read more about structs in The Book: https://doc.rust-lang.org/stable/book/ch05-00-structs.html"""
+In this exercise you need to complete and implement one of each kind.
+Read more about structs in The Book: https://doc.rust-lang.org/book/ch05-01-defining-structs.html"""
 
 [[exercises]]
 name = "structs2"


### PR DESCRIPTION
The hint for structs1 improperly stated that there are 2 types of structs. Updated to clarify there are 3.

I changed the link to the page related to the exercise directly, though the one previous link is not necessarily wrong as it is one page before the link I prefer.