### PR TITLE
fix(installation): Update the MinRustVersion

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -53,7 +53,7 @@ function vercomp($v1, $v2) {
 }
 
 $rustVersion = $(rustc --version).Split(" ")[1]
-$minRustVersion = "1.31"
+$minRustVersion = "1.39"
 if ((vercomp $rustVersion $minRustVersion) -eq 2) {
     Write-Host "WARNING: Rust version is too old: $rustVersion - needs at least $minRustVersion"
     Write-Host "Please update Rust with 'rustup update'"

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ function vercomp() {
 }
 
 RustVersion=$(rustc --version | cut -d " " -f 2)
-MinRustVersion=1.31
+MinRustVersion=1.39
 vercomp $RustVersion $MinRustVersion
 if [ $? -eq 2 ]
 then


### PR DESCRIPTION
closes (sort of?) #577

The addition of --show-output when exercises are run in test mode in #422 means that rustlings no longer works properly on rustc < 1.39.