### PR TITLE
fix(vec1): Have test compare every element in a and v

### DIFF
--- a/exercises/collections/vec1.rs
+++ b/exercises/collections/vec1.rs
@@ -20,6 +20,6 @@ mod tests {
     #[test]
     fn test_array_and_vec_similarity() {
         let (a, v) = array_and_vec();
-        assert!(a.iter().zip(v.iter()).all(|(x, y)| x == y));
+        assert_eq!(a, v[..]);
     }
 }


### PR DESCRIPTION
The previous test would stop comparing elements in array a and vec v upon reaching the last element of either. This resulted in the test passing even if v did not contain all the elements in a. This change to the test fixes that bug and should only pass if all the elements in a and v are present and equal.