### PR TITLE
feat(cli): Improve the list command with options, and then some

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -232,6 +232,16 @@ path = "{}.rs""#,
 
         State::Pending(context)
     }
+
+    // Check that the exercise looks to be solved using self.state()
+    // This is not the best way to check since
+    // the user can just remove the "I AM NOT DONE" string fromm the file
+    // without actually having solved anything.
+    // The only other way to truly check this would to compile and run
+    // the exercise; which would be both costly and counterintuitive
+    pub fn looks_done(&self) -> bool {
+        self.state() == State::Done
+    }
 }
 
 impl Display for Exercise {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use notify::DebouncedEvent;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::ffi::OsStr;
 use std::fs;
-use std::io;
+use std::io::{self, prelude::*};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc::channel;
@@ -58,6 +58,45 @@ fn main() {
             SubCommand::with_name("list")
                 .alias("l")
                 .about("Lists the exercises available in rustlings")
+                .arg(
+                    Arg::with_name("paths")
+                        .long("paths")
+                        .short("p")
+                        .conflicts_with("names")
+                        .help("Show only the paths of the exercises")
+                )
+                .arg(
+                    Arg::with_name("names")
+                        .long("names")
+                        .short("n")
+                        .conflicts_with("paths")
+                        .help("Show only the names of the exercises")
+                )
+                .arg(
+                    Arg::with_name("filter")
+                        .long("filter")
+                        .short("f")
+                        .takes_value(true)
+                        .empty_values(false)
+                        .help(
+                            "Provide a string to match the exercise names.\
+                            \nComma separated patterns are acceptable."
+                        )
+                )
+                .arg(
+                    Arg::with_name("unsolved")
+                        .long("unsolved")
+                        .short("u")
+                        .conflicts_with("solved")
+                        .help("Display only exercises not yet solved")
+                )
+                .arg(
+                    Arg::with_name("solved")
+                        .long("solved")
+                        .short("s")
+                        .conflicts_with("unsolved")
+                        .help("Display only exercises that have been solved")
+                )
         )
         .get_matches();
 
@@ -93,9 +132,51 @@ fn main() {
     let exercises = toml::from_str::<ExerciseList>(toml_str).unwrap().exercises;
     let verbose = matches.is_present("nocapture");
 
-    if matches.subcommand_matches("list").is_some() {
-        exercises.iter().for_each(|e| println!("{}", e.name));
+    // Handle the list command
+    if let Some(list_m) = matches.subcommand_matches("list") {
+        if ["paths", "names"].iter().all(|k| !list_m.is_present(k)) {
+            println!("{:<17}\t{:<46}\t{:<7}", "Name", "Path", "Status");
+        }
+        let filters = list_m.value_of("filter").unwrap_or_default().to_lowercase();
+        exercises.iter().for_each(|e| {
+            let fname = format!("{}", e.path.display());
+            let filter_cond = filters
+                .split(',')
+                .filter(|f| f.trim().len() > 0)
+                .any(|f| e.name.contains(&f) || fname.contains(&f));
+            let status = if e.looks_done() { "Done" } else { "Pending" };
+            let solve_cond = {
+                (e.looks_done() && list_m.is_present("solved"))
+                    || (!e.looks_done() && list_m.is_present("unsolved"))
+                    || (!list_m.is_present("solved") && !list_m.is_present("unsolved"))
+            };
+            if solve_cond && (filter_cond || !list_m.is_present("filter")) {
+                let line = if list_m.is_present("paths") {
+                    format!("{}\n", fname)
+                } else if list_m.is_present("names") {
+                    format!("{}\n", e.name)
+                } else {
+                    format!("{:<17}\t{:<46}\t{:<7}\n", e.name, fname, status)
+                };
+                // Somehow using println! leads to the binary panicking
+                // when its output is piped.
+                // So, we're handling a Broken Pipe error and exiting with 0 anyway
+                let stdout = std::io::stdout();
+                {
+                    let mut handle = stdout.lock();
+                    handle.write_all(line.as_bytes()).unwrap_or_else(|e| {
+                        match e.kind() {
+                            std::io::ErrorKind::BrokenPipe => std::process::exit(0),
+                            _ => std::process::exit(1),
+                        };
+                    });
+                }
+            }
+        });
+        std::process::exit(0);
     }
+
+    // Handle the run command
     if let Some(ref matches) = matches.subcommand_matches("run") {
         let name = matches.value_of("name").unwrap();
 
@@ -123,13 +204,18 @@ fn main() {
         println!("{}", exercise.hint);
     }
 
+    // Handle the verify command
     if matches.subcommand_matches("verify").is_some() {
         verify(&exercises, verbose).unwrap_or_else(|_| std::process::exit(1));
     }
 
+    // Handle the watch command
     if matches.subcommand_matches("watch").is_some() {
         if let Err(e) = watch(&exercises, verbose) {
-            println!("Error: Could not watch your progess. Error message was {:?}.", e);
+            println!(
+                "Error: Could not watch your progess. Error message was {:?}.",
+                e
+            );
             println!("Most likely you've run out of disk space or your 'inotify limit' has been reached.");
             std::process::exit(1);
         }
@@ -138,24 +224,24 @@ fn main() {
             emoji = Emoji("🎉", "★")
         );
         println!();
-        println!("+----------------------------------------------------+");     
-        println!("|          You made it to the Fe-nish line!          |");       
-        println!("+--------------------------  ------------------------+");       
+        println!("+----------------------------------------------------+");
+        println!("|          You made it to the Fe-nish line!          |");
+        println!("+--------------------------  ------------------------+");
         println!("                          \\/                         ");
-        println!("     ▒▒          ▒▒▒▒▒▒▒▒      ▒▒▒▒▒▒▒▒          ▒▒   ");        
-        println!("   ▒▒▒▒  ▒▒    ▒▒        ▒▒  ▒▒        ▒▒    ▒▒  ▒▒▒▒ ");        
-        println!("   ▒▒▒▒  ▒▒  ▒▒            ▒▒            ▒▒  ▒▒  ▒▒▒▒ ");        
-        println!(" ░░▒▒▒▒░░▒▒  ▒▒            ▒▒            ▒▒  ▒▒░░▒▒▒▒ ");        
-        println!("   ▓▓▓▓▓▓▓▓  ▓▓      ▓▓██  ▓▓  ▓▓██      ▓▓  ▓▓▓▓▓▓▓▓ ");        
-        println!("     ▒▒▒▒    ▒▒      ████  ▒▒  ████      ▒▒░░  ▒▒▒▒   ");      
-        println!("       ▒▒  ▒▒▒▒▒▒        ▒▒▒▒▒▒        ▒▒▒▒▒▒  ▒▒     ");    
-        println!("         ▒▒▒▒▒▒▒▒▒▒▓▓▓▓▓▓▒▒▒▒▒▒▒▒▓▓▒▒▓▓▒▒▒▒▒▒▒▒       ");  
+        println!("     ▒▒          ▒▒▒▒▒▒▒▒      ▒▒▒▒▒▒▒▒          ▒▒   ");
+        println!("   ▒▒▒▒  ▒▒    ▒▒        ▒▒  ▒▒        ▒▒    ▒▒  ▒▒▒▒ ");
+        println!("   ▒▒▒▒  ▒▒  ▒▒            ▒▒            ▒▒  ▒▒  ▒▒▒▒ ");
+        println!(" ░░▒▒▒▒░░▒▒  ▒▒            ▒▒            ▒▒  ▒▒░░▒▒▒▒ ");
+        println!("   ▓▓▓▓▓▓▓▓  ▓▓      ▓▓██  ▓▓  ▓▓██      ▓▓  ▓▓▓▓▓▓▓▓ ");
+        println!("     ▒▒▒▒    ▒▒      ████  ▒▒  ████      ▒▒░░  ▒▒▒▒   ");
+        println!("       ▒▒  ▒▒▒▒▒▒        ▒▒▒▒▒▒        ▒▒▒▒▒▒  ▒▒     ");
+        println!("         ▒▒▒▒▒▒▒▒▒▒▓▓▓▓▓▓▒▒▒▒▒▒▒▒▓▓▒▒▓▓▒▒▒▒▒▒▒▒       ");
         println!("           ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒         ");
         println!("             ▒▒▒▒▒▒▒▒▒▒██▒▒▒▒▒▒██▒▒▒▒▒▒▒▒▒▒           ");
-        println!("           ▒▒  ▒▒▒▒▒▒▒▒▒▒██████▒▒▒▒▒▒▒▒▒▒  ▒▒         ");  
-        println!("         ▒▒    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒    ▒▒       ");    
-        println!("       ▒▒    ▒▒    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒    ▒▒    ▒▒     ");    
-        println!("       ▒▒  ▒▒    ▒▒                  ▒▒    ▒▒  ▒▒     ");    
+        println!("           ▒▒  ▒▒▒▒▒▒▒▒▒▒██████▒▒▒▒▒▒▒▒▒▒  ▒▒         ");
+        println!("         ▒▒    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒    ▒▒       ");
+        println!("       ▒▒    ▒▒    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒    ▒▒    ▒▒     ");
+        println!("       ▒▒  ▒▒    ▒▒                  ▒▒    ▒▒  ▒▒     ");
         println!("           ▒▒  ▒▒                      ▒▒  ▒▒         ");
         println!();
         println!("We hope you enjoyed learning about the various aspects of Rust!");
@@ -223,7 +309,13 @@ fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<()> {
                         let filepath = b.as_path().canonicalize().unwrap();
                         let pending_exercises = exercises
                             .iter()
-                            .skip_while(|e| !filepath.ends_with(&e.path));
+                            .skip_while(|e| !filepath.ends_with(&e.path))
+                            // .filter(|e| filepath.ends_with(&e.path))
+                            .chain(
+                                exercises
+                                    .iter()
+                                    .filter(|e| !e.looks_done() && !filepath.ends_with(&e.path))
+                            );
                         clear_screen();
                         match verify(pending_exercises, verbose) {
                             Ok(_) => return Ok(()),

--- a/tests/fixture/state/info.toml
+++ b/tests/fixture/state/info.toml
@@ -9,3 +9,10 @@ name = "pending_test_exercise"
 path = "pending_test_exercise.rs"
 mode = "test"
 hint = """"""
+
+[[exercises]]
+name = "finished_exercise"
+path = "finished_exercise.rs"
+mode = "compile"
+hint = """"""
+

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -181,3 +181,81 @@ fn run_single_test_success_without_output() {
         .code(0)
         .stdout(predicates::str::contains("THIS TEST TOO SHALL PAS").not());
 }
+
+#[test]
+fn run_rustlings_list() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list"])
+        .current_dir("tests/fixture/success")
+        .assert()
+        .success();
+}
+
+#[test]
+fn run_rustlings_list_conflicting_display_options() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list", "--names", "--paths"])
+        .current_dir("tests/fixture/success")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn run_rustlings_list_conflicting_solve_options() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list", "--solved", "--unsolved"])
+        .current_dir("tests/fixture/success")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn run_rustlings_list_no_pending() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list"])
+        .current_dir("tests/fixture/success")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Pending").not());
+}
+
+#[test]
+fn run_rustlings_list_both_done_and_pending() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list"])
+        .current_dir("tests/fixture/state")
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("Done")
+                .and(predicates::str::contains("Pending"))
+        );
+}
+
+#[test]
+fn run_rustlings_list_without_pending() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list", "--solved"])
+        .current_dir("tests/fixture/state")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Pending").not());
+}
+
+#[test]
+fn run_rustlings_list_without_done() {
+    Command::cargo_bin("rustlings")
+        .unwrap()
+        .args(&["list", "--unsolved"])
+        .current_dir("tests/fixture/state")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done").not());
+}
+


### PR DESCRIPTION
The PR is two-fold:
1. `rustlings list` should now display more than just the exercise names. Information such as file paths and exercises statuses should be displayed. The `--paths` option limits the displayed fields to only the path names; while the `--names` option limits the displayed fields to only exercise names. You can also control which exercises are displayed, by using the `--filter` option, or the `--solved` or `--unsolved` flags.

**Sample invocations**:
```sh
# Display exercises that deal with traits, or enums, or structs.
rustlings list --filter "trait,enum,struct"

# Sample output:
# Name             	Path                                          	Status
# structs1         	exercises/structs/structs1.rs                 	Pending
# structs2         	exercises/structs/structs2.rs                 	Pending
# structs3         	exercises/structs/structs3.rs                 	Pending
# enums1           	exercises/enums/enums1.rs                     	Pending
# enums2           	exercises/enums/enums2.rs                     	Pending
# enums3           	exercises/enums/enums3.rs                     	Pending
# traits1          	exercises/traits/traits1.rs                   	Pending
# traits2          	exercises/traits/traits2.rs                   	Pending

# Display only exercises pending to be solved
rustlings list --unsolved

# Sample output:
# Name             	Path                                          	Status
# structs2         	exercises/structs/structs2.rs                 	Pending
# structs3         	exercises/structs/structs3.rs                 	Pending
# enums1           	exercises/enums/enums1.rs                     	Pending
# enums2           	exercises/enums/enums2.rs                     	Pending
# enums3           	exercises/enums/enums3.rs                     	Pending
# modules1         	exercises/modules/modules1.rs                 	Pending
# modules2         	exercises/modules/modules2.rs                 	Pending
# collections1     	exercises/collections/vec1.rs                 	Pending
# collections2     	exercises/collections/vec2.rs                 	Pending
# collections3     	exercises/collections/hashmap1.rs             	Pending
# collections4     	exercises/collections/hashmap2.rs             	Pending
```
This portion should also close #281.

**Some shell utility use cases**:
- Fetching pending _exercise file paths_ with the keyword "conversion" to pass to my editor:
```sh
vim $(rustlings list --filter "conversion" --paths --unsolved)
```

- Fetching _exercise names_ with keyword "conversion" to pass to `rustlings run`:
```sh
for exercise in $(rustlings list --filter "conversion" --names)
do
    rustlings run ${exercise}
done
```

2. The PR should also fix #465, and will likely fix #585, as well. The bug mentioned in those issues has to do with the way the `watch` command handler fetches the pending exercises.
Going forward, the least recently updated exercises along with all the other exercises in a pending state are fetched.

@fmoko @jrvidal if you've got some time, I'd love an eye on this. If there is anyone else with some experience on (or interest in) the CLI component, please feel free to let me know what you think.

Thanks,
Abdou