### PR TITLE
docs: mention flatten in the options2 hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -583,8 +583,7 @@ https://doc.rust-lang.org/rust-by-example/flow_control/while_let.html
 
 Remember that Options can be stacked in if let and while let.
 For example: Some(Some(variable)) = variable2
-
-
+Also see Option::flatten
 """
 
 [[exercises]]


### PR DESCRIPTION
[`Option::flatten`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten) is so useful, I thought I would mention it as an alternative to "stacking Options".

Thanks for considering this, I've been having fun with `rustlings` and hope to make more substantial contributions in the future. :smile: