### PR TITLE
Moved iterators2.rs errors out of tests.

### DIFF
--- a/exercises/standard_library_types/iterators2.rs
+++ b/exercises/standard_library_types/iterators2.rs
@@ -1,28 +1,41 @@
 // iterators2.rs
-// In this module, you'll learn some of the unique advantages that iterators can offer.
-// Step 1. Complete the `capitalize_first` function to pass the first two cases.
-// Step 2. Apply the `capitalize_first` function to a vector of strings.
-//         Ensure that it returns a vector of strings as well.
-// Step 3. Apply the `capitalize_first` function again to a list.
-//         Try to ensure it returns a single string.
+// In this exercise, you'll learn some of the unique advantages that iterators
+// can offer. Follow the steps to complete the exercise.
 // As always, there are hints if you execute `rustlings hint iterators2`!
 
 // I AM NOT DONE
 
+// Step 1.
+// Complete the `capitalize_first` function.
+// "hello" -> "Hello"
 pub fn capitalize_first(input: &str) -> String {
     let mut c = input.chars();
     match c.next() {
         None => String::new(),
-        Some(first) => first.collect::<String>() + c.as_str(),
+        Some(first) => ???,
     }
+}
+
+// Step 2.
+// Apply the `capitalize_first` function to a slice of string slices.
+// Return a vector of strings.
+// ["hello", "world"] -> ["Hello", "World"]
+pub fn capitalize_words_vector(words: &[&str]) -> Vec<String> {
+    vec![]
+}
+
+// Step 3.
+// Apply the `capitalize_first` function again to a slice of string slices.
+// Return a single string.
+// ["hello", " ", "world"] -> "Hello World"
+pub fn capitalize_words_string(words: &[&str]) -> String {
+    String::new()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Step 1.
-    // Tests that verify your `capitalize_first` function implementation
     #[test]
     fn test_success() {
         assert_eq!(capitalize_first("hello"), "Hello");
@@ -33,18 +46,15 @@ mod tests {
         assert_eq!(capitalize_first(""), "");
     }
 
-    // Step 2.
     #[test]
     fn test_iterate_string_vec() {
         let words = vec!["hello", "world"];
-        let capitalized_words: Vec<String> = // TODO
-        assert_eq!(capitalized_words, ["Hello", "World"]);
+        assert_eq!(capitalize_words_vector(&words), ["Hello", "World"]);
     }
 
     #[test]
     fn test_iterate_into_string() {
         let words = vec!["hello", " ", "world"];
-        let capitalized_words = // TODO
-        assert_eq!(capitalized_words, "Hello World");
+        assert_eq!(capitalize_words_string(&words), "Hello World");
     }
 }

--- a/info.toml
+++ b/info.toml
@@ -704,21 +704,20 @@ path = "exercises/standard_library_types/iterators2.rs"
 mode = "test"
 hint = """
 Step 1
-You need to call something on `first` before it can be collected
-Currently its type is `char`. Have a look at the methods that are available on that type:
+The variable `first` is a `char`. It needs to be capitalized and added to the
+remaining characters in `c` in order to return the correct `String`.
+The remaining characters in `c` can be viewed as a string slice using the
+`as_str` method.
+The documentation for `char` contains many useful methods.
 https://doc.rust-lang.org/std/primitive.char.html
 
-
 Step 2
-First you'll need to turn the Vec into an iterator
-Then you'll need to apply your function unto each item in the vector
-P.s. Don't forget to collect() at the end!
-
+Create an iterator from the slice. Transform the iterated values by applying
+the `capitalize_first` function. Remember to collect the iterator.
 
 Step 3.
-This is very similar to the previous test. The only real change is that you will need to
-alter the type that collect is coerced into. For a bonus you could try doing this with a
-turbofish"""
+This is surprising similar to the previous solution. Collect is very powerful
+and very general. Rust just needs to know the desired type."""
 
 [[exercises]]
 name = "iterators3"


### PR DESCRIPTION
Moved all errors out of tests and into the base module.
The exercise compiles after step 1 allowing the user to test `capitalize_first`. The remaining steps fix the other two failing tests.

The exercise still showcases the power of `collect` without requiring the user to complete the entire exercise before checking their work.

The hint to solve the `capitalize_first` function was moved to the hint in `info.toml`.

Closes #359