### PR TITLE
Enabled iterators3.rs to run without commented out tests.

### DIFF
--- a/exercises/standard_library_types/iterators3.rs
+++ b/exercises/standard_library_types/iterators3.rs
@@ -1,11 +1,10 @@
 // iterators3.rs
 // This is a bigger exercise than most of the others! You can do it!
 // Here is your mission, should you choose to accept it:
-// 1. Complete the divide function to get the first four tests to pass
-// 2. Uncomment the last two tests and get them to pass by filling in
-//    values for `x` using `division_results`.
+// 1. Complete the divide function to get the first four tests to pass.
+// 2. Get the remaining tests to pass by completing the result_with_list and
+//    list_of_results functions.
 // Execute `rustlings hint iterators3` to get some hints!
-// Have fun :-)
 
 // I AM NOT DONE
 
@@ -21,16 +20,28 @@ pub struct NotDivisibleError {
     divisor: i32,
 }
 
-// This function should calculate `a` divided by `b` if `a` is
-// evenly divisible by b.
-// Otherwise, it should return a suitable error.
+// Calculate `a` divided by `b` if `a` is evenly divisible by `b`.
+// Otherwise, return a suitable error.
 pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {}
+
+// Complete the function and return a value of the correct type so the test passes.
+// Desired output: Ok([1, 11, 1426, 3])
+fn result_with_list() -> () {
+    let numbers = vec![27, 297, 38502, 81];
+    let division_results = numbers.into_iter().map(|n| divide(n, 27));
+}
+
+// Complete the function and return a value of the correct type so the test passes.
+// Desired output: [Ok(1), Ok(11), Ok(1426), Ok(3)]
+fn list_of_results() -> () {
+    let numbers = vec![27, 297, 38502, 81];
+    let division_results = numbers.into_iter().map(|n| divide(n, 27));
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Tests that verify your `divide` function implementation
     #[test]
     fn test_success() {
         assert_eq!(divide(81, 9), Ok(9));
@@ -57,22 +68,16 @@ mod tests {
         assert_eq!(divide(0, 81), Ok(0));
     }
 
-    // Iterator exercises using your `divide` function
-    /*
     #[test]
-    fn result_with_list() {
-        let numbers = vec![27, 297, 38502, 81];
-        let division_results = numbers.into_iter().map(|n| divide(n, 27));
-        let x //... Fill in here!
-        assert_eq!(format!("{:?}", x), "Ok([1, 11, 1426, 3])");
+    fn test_result_with_list() {
+        assert_eq!(format!("{:?}", result_with_list()), "Ok([1, 11, 1426, 3])");
     }
 
     #[test]
-    fn list_of_results() {
-        let numbers = vec![27, 297, 38502, 81];
-        let division_results = numbers.into_iter().map(|n| divide(n, 27));
-        let x //... Fill in here!
-        assert_eq!(format!("{:?}", x), "[Ok(1), Ok(11), Ok(1426), Ok(3)]");
+    fn test_list_of_results() {
+        assert_eq!(
+            format!("{:?}", list_of_results()),
+            "[Ok(1), Ok(11), Ok(1426), Ok(3)]"
+        );
     }
-    */
 }

--- a/info.toml
+++ b/info.toml
@@ -725,11 +725,15 @@ name = "iterators3"
 path = "exercises/standard_library_types/iterators3.rs"
 mode = "test"
 hint = """
-Minor hint: In each of the two cases in the match in main, you can create x with either
-a 'turbofish' or by hinting the type of x to the compiler. You may try both.
+The divide function needs to return the correct error when even division is not
+possible.
 
-Major hint: Have a look at the Iter trait and at the explanation of its collect function.
-Especially the part about Result is interesting."""
+The division_results variable needs to be collected into a collection type.
+
+The result_with_list function needs to return a single Result where the success
+case is a vector of integers and the failure case is a DivisionError.
+
+The list_of_results function needs to return a vector of results."""
 
 [[exercises]]
 name = "iterators4"


### PR DESCRIPTION
Adapted all but one compiler error into logic errors. The exercise can be tested after completing step one, without the need for the tests to be commented out.

The assertions against debug output are kept to allow the code to compile before `result_with_list` and `list_of_results` are completed. They also prevent the compiler from revealing the answer too eagerly.
﻿
