### PR TITLE
fix: Add 5.3 to structs/README

### DIFF
--- a/exercises/structs/README.md
+++ b/exercises/structs/README.md
@@ -5,3 +5,4 @@ Rust has three struct types: a classic c struct, a tuple struct, and a unit stru
 #### Book Sections
 
 - [Structures](https://doc.rust-lang.org/book/ch05-01-defining-structs.html)
+- [Method Syntax](https://doc.rust-lang.org/book/ch05-03-method-syntax.html)


### PR DESCRIPTION
I was unable to do structs3 exercise until I read chapter 5.3 of the book. Hence, 5.3 should be in the structs README :)