### PR TITLE
Fix incorrect hashmap2 test

### DIFF
--- a/exercises/collections/hashmap2.rs
+++ b/exercises/collections/hashmap2.rs
@@ -68,7 +68,7 @@ mod tests {
         let mut basket = get_fruit_basket();
         fruit_basket(&mut basket);
         let count_fruit_kinds = basket.len();
-        assert!(count_fruit_kinds == 5);
+        assert!(count_fruit_kinds >= 5);
     }
 
     #[test]


### PR DESCRIPTION
The test `at_least_five_types_of_fruits` implies that there should be `at least` five types of fruit in the basket, but the test is actually checking for `exactly` five types of fruit, which was a bit misleading for newcomers like me :) 

A simple change from `==` to `>=` should do the trick and properly check for the `at least 5` condition.