### PR TITLE
fix(structs3): Add check to prevent naive implementation of is_international

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -66,6 +66,7 @@ mod tests {
 
         assert!(!package.is_international());
     }
+
     #[test]
     fn calculate_transport_fees() {
         let sender_country = String::from("Spain");

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -58,6 +58,15 @@ mod tests {
     }
 
     #[test]
+    fn create_local_package() {
+        let sender_country = String::from("Canada");
+        let recipient_country = sender_country.clone();
+
+        let package = Package::new(sender_country, recipient_country, 1200);
+
+        assert!(!package.is_international());
+    }
+    #[test]
     fn calculate_transport_fees() {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Spain");


### PR DESCRIPTION
Current version of structs3 exercise allows naive implementation of `is_international`. Tests pass if we merely return `true`. I added a test that creates a domestic package (i.e. sender and receiver country are the same)

More importantly, as someone new to Rust I wasn't sure if Strings get compared "by reference" or "by value", so I wondered if 

```Rust
    fn is_international(&self) -> bool {
        self.sender_country != self.recipient_country
    }
```

would just _always_ return `true` (because they're objects on two different parts of the heap). Adding my test for a local package means my above implementation would be wrong if Strings weren't compared by value.