### PR TITLE
fix(installation): first PowerShell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will install Rustlings and give you access to the `rustlings` command. Run 
 In PowerShell, set `ExecutionPolicy` to `RemoteSigned`:
 
 ```ps
-Set-ExecutionPolicy RemoteSigned
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
 Then, you can run:


### PR DESCRIPTION
ExecutionPolicy to RemoteSigned command must be fixed because the old command was getting denied access to change the Execution Policy property