### PR TITLE
Fix Rust's HashMap equivalent in C++

### DIFF
--- a/exercises/collections/README.md
+++ b/exercises/collections/README.md
@@ -14,7 +14,7 @@ structures that are used very often in Rust programs:
 * A *vector* allows you to store a variable number of values next to
   each other.
 * A *hash map* allows you to associate a value with a particular key.
-  You may also know this by the names *map* in C++, *dictionary* in
-  Python or an *associative array* in other languages.
+  You may also know this by the names [*unordered map* in C++](https://en.cppreference.com/w/cpp/container/unordered_map), 
+  [*dictionary* in Python](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) or an *associative array* in other languages.
 
 [Rust book chapter](https://doc.rust-lang.org/stable/book/ch08-01-vectors.html)


### PR DESCRIPTION
C++ `map` is more like BTreeMap in Rust.

`unordered_map` in C++(11) is the equivalent of `HashMap` in Rust.
(+ additional like for references).