### PR TITLE
Fix/collections exercises naming

### DIFF
--- a/exercises/collections/hashmap1.rs
+++ b/exercises/collections/hashmap1.rs
@@ -8,7 +8,7 @@
 //
 // Make me compile and pass the tests!
 //
-// Execute the command `rustlings hint collections3` if you need
+// Execute the command `rustlings hint hashmap1` if you need
 // hints.
 
 // I AM NOT DONE
@@ -39,8 +39,6 @@ mod tests {
     #[test]
     fn at_least_five_fruits() {
         let basket = fruit_basket();
-        assert!(basket
-            .values()
-            .sum::<u32>() >= 5);
+        assert!(basket.values().sum::<u32>() >= 5);
     }
 }

--- a/exercises/collections/hashmap2.rs
+++ b/exercises/collections/hashmap2.rs
@@ -9,7 +9,7 @@
 //
 // Make me pass the tests!
 //
-// Execute the command `rustlings hint collections4` if you need
+// Execute the command `rustlings hint hashmap2` if you need
 // hints.
 
 // I AM NOT DONE
@@ -75,9 +75,7 @@ mod tests {
     fn greater_than_eleven_fruits() {
         let mut basket = get_fruit_basket();
         fruit_basket(&mut basket);
-        let count = basket
-            .values()
-            .sum::<u32>();
+        let count = basket.values().sum::<u32>();
         assert!(count > 11);
     }
 }

--- a/exercises/collections/vec1.rs
+++ b/exercises/collections/vec1.rs
@@ -2,7 +2,7 @@
 // Your task is to create a `Vec` which holds the exact same elements
 // as in the array `a`.
 // Make me compile and pass the test!
-// Execute the command `rustlings hint collections1` if you need hints.
+// Execute the command `rustlings hint vec1` if you need hints.
 
 // I AM NOT DONE
 

--- a/exercises/collections/vec2.rs
+++ b/exercises/collections/vec2.rs
@@ -28,11 +28,6 @@ mod tests {
         let v: Vec<i32> = (1..).filter(|x| x % 2 == 0).take(5).collect();
         let ans = vec_loop(v.clone());
 
-        assert_eq!(
-            ans,
-            v.iter()
-                .map(|x| x * 2)
-                .collect::<Vec<i32>>()
-        );
+        assert_eq!(ans, v.iter().map(|x| x * 2).collect::<Vec<i32>>());
     }
 }

--- a/exercises/collections/vec2.rs
+++ b/exercises/collections/vec2.rs
@@ -4,7 +4,7 @@
 //
 // Make me pass the test!
 //
-// Execute the command `rustlings hint collections2` if you need
+// Execute the command `rustlings hint vec2` if you need
 // hints.
 
 // I AM NOT DONE

--- a/info.toml
+++ b/info.toml
@@ -359,7 +359,7 @@ each constant."""
 # COLLECTIONS
 
 [[exercises]]
-name = "collections1"
+name = "vec1"
 path = "exercises/collections/vec1.rs"
 mode = "test"
 hint = """
@@ -373,7 +373,7 @@ of the Rust book to learn more.
 """
 
 [[exercises]]
-name = "collections2"
+name = "vec2"
 path = "exercises/collections/vec2.rs"
 mode = "test"
 hint = """
@@ -383,7 +383,7 @@ Hint 2: Check the suggestion from the compiler error ;)
 """
 
 [[exercises]]
-name = "collections3"
+name = "hashmap1"
 path = "exercises/collections/hashmap1.rs"
 mode = "test"
 hint = """
@@ -394,7 +394,7 @@ Hint 2: Number of fruits should be at least 5. And you have to put
 """
 
 [[exercises]]
-name = "collections4"
+name = "hashmap2"
 path = "exercises/collections/hashmap2.rs"
 mode = "test"
 hint = """


### PR DESCRIPTION
Hello,

## Issue

Apparently, the collections exercises are not following the standard naming.

Inside `collections/` directory we have files named `vecX.rs` and `hashmapX.rs` but the rustlings CLI expect them to be named `collectionsX.rs`

## Proposal

As mention in https://github.com/rust-lang/rustlings/issues/651, we could rename files inside `collections/` but in my opinions the possibility to have different names inside a directory is good for clarity. 

Furthermore, the same pattern (ie. Exercises name different from directory name) is also present in `error_handling/`, `standard_directory_types/` and `conversions/` directories.

Obviously, if you think that the solution in #651 is better, i'll change it :)