### PR TITLE
Replace emojis when NO_EMOJI env variable present

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -127,9 +127,10 @@ name = "{}"
 path = "{}.rs""#,
                     self.name, self.name, self.name
                 );
-                let cargo_toml_error_msg = match env::var("NO_EMOJI").is_ok() {
-                    true => "Failed to write Clippy Cargo.toml file.",
-                    false => "Failed to write 📎 Clippy 📎 Cargo.toml file."
+                let cargo_toml_error_msg = if env::var("NO_EMOJI").is_ok() {
+                    "Failed to write Clippy Cargo.toml file."
+                } else {
+                    "Failed to write 📎 Clippy 📎 Cargo.toml file."
                 };
                 fs::write(CLIPPY_CARGO_TOML_PATH, cargo_toml)
                     .expect(cargo_toml_error_msg);

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -1,3 +1,4 @@
+use std::env;
 use regex::Regex;
 use serde::Deserialize;
 use std::fmt::{self, Display, Formatter};
@@ -126,8 +127,12 @@ name = "{}"
 path = "{}.rs""#,
                     self.name, self.name, self.name
                 );
+                let cargo_toml_error_msg = match env::var("NO_EMOJI").is_ok() {
+                    true => "Failed to write Clippy Cargo.toml file.",
+                    false => "Failed to write 📎 Clippy 📎 Cargo.toml file."
+                };
                 fs::write(CLIPPY_CARGO_TOML_PATH, cargo_toml)
-                    .expect("Failed to write 📎 Clippy 📎 Cargo.toml file.");
+                    .expect(cargo_toml_error_msg);
                 // To support the ability to run the clipy exercises, build
                 // an executable, in addition to running clippy. With a
                 // compilation failure, this would silently fail. But we expect

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,23 +1,47 @@
 macro_rules! warn {
     ($fmt:literal, $ex:expr) => {{
+        use std::env;
         use console::{style, Emoji};
         let formatstr = format!($fmt, $ex);
-        println!(
-            "{} {}",
-            style(Emoji("⚠️ ", "!")).red(),
-            style(formatstr).red()
-        );
+        match env::var("NO_EMOJI").is_ok() {
+            true => {
+                println!(
+                    "{} {}",
+                    style("!").red(),
+                    style(formatstr).red()
+                );
+            },
+            false => {
+                println!(
+                    "{} {}",
+                    style(Emoji("⚠️ ", "!")).red(),
+                    style(formatstr).red()
+                );
+            }
+        }
     }};
 }
 
 macro_rules! success {
     ($fmt:literal, $ex:expr) => {{
+        use std::env;
         use console::{style, Emoji};
         let formatstr = format!($fmt, $ex);
-        println!(
-            "{} {}",
-            style(Emoji("✅", "✓")).green(),
-            style(formatstr).green()
-        );
+        match env::var("NO_EMOJI").is_ok() {
+            true => {
+                println!(
+                    "{} {}",
+                    style("✓").green(),
+                    style(formatstr).green()
+                );
+            },
+            false => {
+                println!(
+                    "{} {}",
+                    style(Emoji("✅", "✓")).green(),
+                    style(formatstr).green()
+                );
+            }
+        }
     }};
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,21 +3,18 @@ macro_rules! warn {
         use std::env;
         use console::{style, Emoji};
         let formatstr = format!($fmt, $ex);
-        match env::var("NO_EMOJI").is_ok() {
-            true => {
-                println!(
-                    "{} {}",
-                    style("!").red(),
-                    style(formatstr).red()
-                );
-            },
-            false => {
-                println!(
-                    "{} {}",
-                    style(Emoji("⚠️ ", "!")).red(),
-                    style(formatstr).red()
-                );
-            }
+        if env::var("NO_EMOJI").is_ok() {
+            println!(
+                "{} {}",
+                style("!").red(),
+                style(formatstr).red()
+            );
+        } else {
+            println!(
+                "{} {}",
+                style(Emoji("⚠️ ", "!")).red(),
+                style(formatstr).red()
+            );
         }
     }};
 }
@@ -27,21 +24,18 @@ macro_rules! success {
         use std::env;
         use console::{style, Emoji};
         let formatstr = format!($fmt, $ex);
-        match env::var("NO_EMOJI").is_ok() {
-            true => {
-                println!(
-                    "{} {}",
-                    style("✓").green(),
-                    style(formatstr).green()
-                );
-            },
-            false => {
-                println!(
-                    "{} {}",
-                    style(Emoji("✅", "✓")).green(),
-                    style(formatstr).green()
-                );
-            }
+        if env::var("NO_EMOJI").is_ok() {
+            println!(
+                "{} {}",
+                style("✓").green(),
+                style(formatstr).green()
+            );
+        } else {
+            println!(
+                "{} {}",
+                style(Emoji("✅", "✓")).green(),
+                style(formatstr).green()
+            );
         }
     }};
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,3 +1,4 @@
+use std::env;
 use crate::exercise::{CompiledExercise, Exercise, Mode, State};
 use console::style;
 use indicatif::ProgressBar;
@@ -137,14 +138,24 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
         State::Pending(context) => context,
     };
 
+    let no_emoji = env::var("NO_EMOJI").is_ok();
+
+    let clippy_success_msg = match no_emoji {
+        true => "The code is compiling, and Clippy is happy!",
+        false => "The code is compiling, and 📎 Clippy 📎 is happy!"
+    };
+
     let success_msg = match exercise.mode {
         Mode::Compile => "The code is compiling!",
         Mode::Test => "The code is compiling, and the tests pass!",
-        Mode::Clippy => "The code is compiling, and 📎 Clippy 📎 is happy!",
+        Mode::Clippy => clippy_success_msg,
     };
 
     println!();
-    println!("🎉 🎉  {} 🎉 🎉", success_msg);
+    match no_emoji {
+        true => println!("~*~ {} ~*~", success_msg),
+        false => println!("🎉 🎉  {} 🎉 🎉", success_msg)
+    };
     println!();
 
     if let Some(output) = prompt_output {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -140,9 +140,10 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
 
     let no_emoji = env::var("NO_EMOJI").is_ok();
 
-    let clippy_success_msg = match no_emoji {
-        true => "The code is compiling, and Clippy is happy!",
-        false => "The code is compiling, and 📎 Clippy 📎 is happy!"
+    let clippy_success_msg = if no_emoji {
+        "The code is compiling, and Clippy is happy!"
+    } else {
+        "The code is compiling, and 📎 Clippy 📎 is happy!"
     };
 
     let success_msg = match exercise.mode {
@@ -152,10 +153,11 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
     };
 
     println!();
-    match no_emoji {
-        true => println!("~*~ {} ~*~", success_msg),
-        false => println!("🎉 🎉  {} 🎉 🎉", success_msg)
-    };
+    if no_emoji {
+        println!("~*~ {} ~*~", success_msg)
+    } else {
+        println!("🎉 🎉  {} 🎉 🎉", success_msg)
+    }
     println!();
 
     if let Some(output) = prompt_output {


### PR DESCRIPTION
When the `NO_EMOJI` environment variable is set, replace/eliminate emojis in output.

For instance, without `NO_EMOJI` set (normal behaviour):
<img width="500" alt="Screen Shot 2021-03-19 at 2 25 48 AM" src="https://user-images.githubusercontent.com/2555355/111759202-97ca8c00-885a-11eb-9031-b05fb9e34709.png">

With `NO_EMOJI` set:
<img width="500" alt="Screen Shot 2021-03-19 at 2 26 30 AM" src="https://user-images.githubusercontent.com/2555355/111759325-b29d0080-885a-11eb-90be-230f96696c30.png">

Addresses #364.