### PR TITLE
capitalize `c` letter

### DIFF
--- a/exercises/structs/README.md
+++ b/exercises/structs/README.md
@@ -1,6 +1,6 @@
 ### Structs
 
-Rust has three struct types: a classic c struct, a tuple struct, and a unit struct.
+Rust has three struct types: a classic C struct, a tuple struct, and a unit struct.
 
 #### Book Sections
 


### PR DESCRIPTION
By capitalizing the `c` letter it makes clear that we're talking about the C programming language.