### PR TITLE
fix: improve function argument type in functions3.rs

### DIFF
--- a/exercises/functions/functions3.rs
+++ b/exercises/functions/functions3.rs
@@ -7,7 +7,7 @@ fn main() {
     call_me();
 }
 
-fn call_me(num: i32) {
+fn call_me(num: u32) {
     for i in 0..num {
         println!("Ring! Call number {}", i + 1);
     }


### PR DESCRIPTION
Hi!
Going through the exercise functions3.rs, it feels like using u32 instead of i32  could be an improvement. Even though passing a negative number won't make the compiler complaint and the loop will exit immediately, it feels that it lacks of intention (to the eyes of someone who's learning like me). I hope this small change makes sense.