### PR TITLE
fix: use trait objects for try_from_into

### DIFF
--- a/exercises/conversions/from_str.rs
+++ b/exercises/conversions/from_str.rs
@@ -2,6 +2,7 @@
 // Additionally, upon implementing FromStr, you can use the `parse` method
 // on strings to generate an object of the implementor type.
 // You can read more about it at https://doc.rust-lang.org/std/str/trait.FromStr.html
+use std::error;
 use std::str::FromStr;
 
 #[derive(Debug)]
@@ -23,7 +24,7 @@ struct Person {
 // If everything goes well, then return a Result of a Person object
 
 impl FromStr for Person {
-    type Err = String;
+    type Err = Box<dyn error::Error>;
     fn from_str(s: &str) -> Result<Person, Self::Err> {
     }
 }

--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -3,6 +3,7 @@
 // instead of the target type itself.
 // You can read more about it at https://doc.rust-lang.org/std/convert/trait.TryFrom.html
 use std::convert::{TryFrom, TryInto};
+use std::error;
 
 #[derive(Debug, PartialEq)]
 struct Color {
@@ -24,19 +25,19 @@ struct Color {
 
 // Tuple implementation
 impl TryFrom<(i16, i16, i16)> for Color {
-    type Error = String;
+    type Error = Box<dyn error::Error>;
     fn try_from(tuple: (i16, i16, i16)) -> Result<Self, Self::Error> {}
 }
 
 // Array implementation
 impl TryFrom<[i16; 3]> for Color {
-    type Error = String;
+    type Error = Box<dyn error::Error>;
     fn try_from(arr: [i16; 3]) -> Result<Self, Self::Error> {}
 }
 
 // Slice implementation
 impl TryFrom<&[i16]> for Color {
-    type Error = String;
+    type Error = Box<dyn error::Error>;
     fn try_from(slice: &[i16]) -> Result<Self, Self::Error> {}
 }
 
@@ -76,41 +77,43 @@ mod tests {
     }
     #[test]
     fn test_tuple_correct() {
-        let c: Result<Color, String> = (183, 65, 14).try_into();
+        let c: Result<Color, _> = (183, 65, 14).try_into();
+        assert!(c.is_ok());
         assert_eq!(
-            c,
-            Ok(Color {
+            c.unwrap(),
+            Color {
                 red: 183,
                 green: 65,
                 blue: 14
-            })
+            }
         );
     }
     #[test]
     fn test_array_out_of_range_positive() {
-        let c: Result<Color, String> = [1000, 10000, 256].try_into();
+        let c: Result<Color, _> = [1000, 10000, 256].try_into();
         assert!(c.is_err());
     }
     #[test]
     fn test_array_out_of_range_negative() {
-        let c: Result<Color, String> = [-10, -256, -1].try_into();
+        let c: Result<Color, _> = [-10, -256, -1].try_into();
         assert!(c.is_err());
     }
     #[test]
     fn test_array_sum() {
-        let c: Result<Color, String> = [-1, 255, 255].try_into();
+        let c: Result<Color, _> = [-1, 255, 255].try_into();
         assert!(c.is_err());
     }
     #[test]
     fn test_array_correct() {
-        let c: Result<Color, String> = [183, 65, 14].try_into();
+        let c: Result<Color, _> = [183, 65, 14].try_into();
+        assert!(c.is_ok());
         assert_eq!(
-            c,
-            Ok(Color {
+            c.unwrap(),
+            Color {
                 red: 183,
                 green: 65,
                 blue: 14
-            })
+            }
         );
     }
     #[test]
@@ -131,14 +134,15 @@ mod tests {
     #[test]
     fn test_slice_correct() {
         let v = vec![183, 65, 14];
-        let c: Result<Color, String> = Color::try_from(&v[..]);
+        let c: Result<Color, _> = Color::try_from(&v[..]);
+        assert!(c.is_ok());
         assert_eq!(
-            c,
-            Ok(Color {
+            c.unwrap(),
+            Color {
                 red: 183,
                 green: 65,
                 blue: 14
-            })
+            }
         );
     }
     #[test]

--- a/info.toml
+++ b/info.toml
@@ -884,5 +884,5 @@ path = "exercises/conversions/from_str.rs"
 mode = "test"
 hint = """
 The implementation of FromStr should return an Ok with a Person object,
-or an Err with a string if the string is not valid.
+or an Err with an error if the string is not valid.
 This is almost like the `try_from_into` exercise."""


### PR DESCRIPTION
Use `Box<dyn error::Error>` to allow solutions to use `?` to propagate
errors.  In the tests, explicitly check `is_ok()` instead of trying to
force the error type to `String` (or other `PartialEq` type) using
`assert_eq!()`.