### PR TITLE
docs(errors): add additional help for Result/Boxing

### DIFF
--- a/exercises/error_handling/README.md
+++ b/exercises/error_handling/README.md
@@ -3,3 +3,9 @@ For this exercise check out the sections:
 - [Generics](https://doc.rust-lang.org/book/ch10-01-syntax.html)
 
 of the Rust Book.
+
+or alternatively, check out the sections:
+- [Result](https://doc.rust-lang.org/rust-by-example/error/result.html)
+- [Boxing errors](https://doc.rust-lang.org/rust-by-example/error/multiple_error_types/boxing_errors.html)
+  
+of the Rust By Example Book.


### PR DESCRIPTION
add additional help information provided by the rust by example book, since the previous help pages didn't cover the whole section, especially error_handling/errorsn.rs was a bit difficult for me.
Those 2 added help pages will explain Result and Boxing errors very easily without much text to read.