### PR TITLE
docs(generics): add bounds help

### DIFF
--- a/exercises/generics/README.md
+++ b/exercises/generics/README.md
@@ -5,3 +5,4 @@ In this section you'll learn about saving yourself many lines of code with gener
 ### Book Sections
 
 - [Generic Data Types](https://doc.rust-lang.org/stable/book/ch10-01-syntax.html)
+- [Bounds](https://doc.rust-lang.org/rust-by-example/generics/bounds.html)


### PR DESCRIPTION
add help for bounds provided by the rust by example book since the previous help doesn't explain bounds / generic constraints which is needed to solve *generics3.rs*.