### PR TITLE
docs(option): improve further information if let and while let

### DIFF
--- a/exercises/option/README.md
+++ b/exercises/option/README.md
@@ -16,3 +16,5 @@ Option types are very common in Rust code, as they have a number of uses:
 - [Option Enum Format](https://doc.rust-lang.org/stable/book/ch10-01-syntax.html#in-enum-definitions)
 - [Option Module Documentation](https://doc.rust-lang.org/std/option/)
 - [Option Enum Documentation](https://doc.rust-lang.org/std/option/enum.Option.html)
+- [if let](https://doc.rust-lang.org/rust-by-example/flow_control/if_let.html)
+- [while let](https://doc.rust-lang.org/rust-by-example/flow_control/while_let.html)

--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -3,7 +3,7 @@
 
 // I AM NOT DONE
 
-// you can modify anything EXCEPT for this function's sig
+// you can modify anything EXCEPT for this function's signature
 fn print_number(maybe_number: Option<u16>) {
     println!("printing: {}", maybe_number.unwrap());
 }


### PR DESCRIPTION
Added further information for *option/option2.rs* since `if let` and `while let` were not covered by the links.