### PR TITLE
updated README.md; specify need for admin rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will install Rustlings and give you access to the `rustlings` command. Run 
 
 ## Windows
 
-In PowerShell, set `ExecutionPolicy` to `RemoteSigned`:
+In PowerShell (Run as Administrator), set `ExecutionPolicy` to `RemoteSigned`:
 
 ```ps
 Set-ExecutionPolicy RemoteSigned


### PR DESCRIPTION
Running the command in `PowerShell` will fail if it's not opened with admin rights, I thought specifying this would make things more clear and save time