### PR TITLE
docs(exercises): consistent exercise description

### DIFF
--- a/exercises/clippy/clippy1.rs
+++ b/exercises/clippy/clippy1.rs
@@ -1,10 +1,12 @@
 // clippy1.rs
+//
 // The Clippy tool is a collection of lints to analyze your code
 // so you can catch common mistakes and improve your Rust code.
 //
 // For these exercises the code will fail to compile when there are clippy warnings
 // check clippy's suggestions from the output to solve the exercise.
-// Execute `rustlings hint clippy1` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint clippy1
 
 // I AM NOT DONE
 

--- a/exercises/clippy/clippy2.rs
+++ b/exercises/clippy/clippy2.rs
@@ -1,5 +1,8 @@
 // clippy2.rs
-// Make me compile! Execute `rustlings hint clippy2` for hints :)
+//
+// Make me compile! 
+//
+// If you need help, open the corresponding README.md or run: rustlings hint clippy2
 
 // I AM NOT DONE
 

--- a/exercises/collections/hashmap1.rs
+++ b/exercises/collections/hashmap1.rs
@@ -1,4 +1,5 @@
 // hashmap1.rs
+//
 // A basket of fruits in the form of a hash map needs to be defined.
 // The key represents the name of the fruit and the value represents
 // how many of that particular fruit is in the basket. You have to put
@@ -8,8 +9,7 @@
 //
 // Make me compile and pass the tests!
 //
-// Execute the command `rustlings hint hashmap1` if you need
-// hints.
+// If you need help, open the corresponding README.md or run: rustlings hint hashmap1
 
 // I AM NOT DONE
 

--- a/exercises/collections/hashmap2.rs
+++ b/exercises/collections/hashmap2.rs
@@ -1,5 +1,5 @@
 // hashmap2.rs
-
+//
 // A basket of fruits in the form of a hash map is given. The key
 // represents the name of the fruit and the value represents how many
 // of that particular fruit is in the basket. You have to put *MORE
@@ -9,8 +9,7 @@
 //
 // Make me pass the tests!
 //
-// Execute the command `rustlings hint hashmap2` if you need
-// hints.
+// If you need help, open the corresponding README.md or run: rustlings hint hashmap2
 
 // I AM NOT DONE
 

--- a/exercises/collections/vec1.rs
+++ b/exercises/collections/vec1.rs
@@ -1,8 +1,10 @@
 // vec1.rs
+//
 // Your task is to create a `Vec` which holds the exact same elements
 // as in the array `a`.
 // Make me compile and pass the test!
-// Execute the command `rustlings hint vec1` if you need hints.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint vec1
 
 // I AM NOT DONE
 

--- a/exercises/collections/vec2.rs
+++ b/exercises/collections/vec2.rs
@@ -1,11 +1,11 @@
 // vec2.rs
+//
 // A Vec of even numbers is given. Your task is to complete the loop
 // so that each number in the Vec is multiplied by 2.
 //
 // Make me pass the test!
 //
-// Execute the command `rustlings hint vec2` if you need
-// hints.
+// If you need help, open the corresponding README.md or run: rustlings hint vec2
 
 // I AM NOT DONE
 

--- a/exercises/conversions/as_ref_mut.rs
+++ b/exercises/conversions/as_ref_mut.rs
@@ -1,6 +1,10 @@
+// as_ref_mut.rs
+//
 // AsRef and AsMut allow for cheap reference-to-reference conversions.
 // Read more about them at https://doc.rust-lang.org/std/convert/trait.AsRef.html
 // and https://doc.rust-lang.org/std/convert/trait.AsMut.html, respectively.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint as_ref_mut
 
 // I AM NOT DONE
 

--- a/exercises/conversions/from_into.rs
+++ b/exercises/conversions/from_into.rs
@@ -1,6 +1,27 @@
+// from_into.rs
+//
 // The From trait is used for value-to-value conversions.
 // If From is implemented correctly for a type, the Into trait should work conversely.
 // You can read more about it at https://doc.rust-lang.org/std/convert/trait.From.html
+// Your task is to complete this implementation
+// in order for the line `let p = Person::from("Mark,20")` to compile
+// Please note that you'll need to parse the age component into a `usize`
+// with something like `"4".parse::<usize>()`. The outcome of this needs to
+// be handled appropriately.
+//
+// Steps:
+// 1. If the length of the provided string is 0, then return the default of Person
+// 2. Split the given string on the commas present in it
+// 3. Extract the first element from the split operation and use it as the name
+// 4. If the name is empty, then return the default of Person
+// 5. Extract the other element from the split operation and parse it into a `usize` as the age
+// If while parsing the age, something goes wrong, then return the default of Person
+// Otherwise, then return an instantiated Person object with the results
+//
+// If you need help, open the corresponding README.md or run: rustlings hint from_into
+
+// I AM NOT DONE
+
 #[derive(Debug)]
 struct Person {
     name: String,
@@ -18,26 +39,8 @@ impl Default for Person {
     }
 }
 
-// Your task is to complete this implementation
-// in order for the line `let p = Person::from("Mark,20")` to compile
-// Please note that you'll need to parse the age component into a `usize`
-// with something like `"4".parse::<usize>()`. The outcome of this needs to
-// be handled appropriately.
-//
-// Steps:
-// 1. If the length of the provided string is 0, then return the default of Person
-// 2. Split the given string on the commas present in it
-// 3. Extract the first element from the split operation and use it as the name
-// 4. If the name is empty, then return the default of Person
-// 5. Extract the other element from the split operation and parse it into a `usize` as the age
-// If while parsing the age, something goes wrong, then return the default of Person
-// Otherwise, then return an instantiated Person object with the results
-
-// I AM NOT DONE
-
 impl From<&str> for Person {
-    fn from(s: &str) -> Person {
-    }
+    fn from(s: &str) -> Person {}
 }
 
 fn main() {

--- a/exercises/conversions/from_str.rs
+++ b/exercises/conversions/from_str.rs
@@ -1,7 +1,25 @@
+// from_str.rs
+//
 // This does practically the same thing that TryFrom<&str> does.
 // Additionally, upon implementing FromStr, you can use the `parse` method
 // on strings to generate an object of the implementor type.
 // You can read more about it at https://doc.rust-lang.org/std/str/trait.FromStr.html
+//
+// Steps:
+// 1. If the length of the provided string is 0, an error should be returned
+// 2. Split the given string on the commas present in it
+// 3. Only 2 elements should be returned from the split, otherwise return an error
+// 4. Extract the first element from the split operation and use it as the name
+// 5. Extract the other element from the split operation and parse it into a `usize` as the age
+//    with something like `"4".parse::<usize>()`
+//
+// If while extracting the name and the age something goes wrong, an error should be returned
+// If everything goes well, then return a Result of a Person object
+//
+// If you need help, open the corresponding README.md or run: rustlings hint from_str
+
+// I AM NOT DONE
+
 use std::error;
 use std::str::FromStr;
 
@@ -10,18 +28,6 @@ struct Person {
     name: String,
     age: usize,
 }
-
-// I AM NOT DONE
-
-// Steps:
-// 1. If the length of the provided string is 0, an error should be returned
-// 2. Split the given string on the commas present in it
-// 3. Only 2 elements should be returned from the split, otherwise return an error
-// 4. Extract the first element from the split operation and use it as the name
-// 5. Extract the other element from the split operation and parse it into a `usize` as the age
-//    with something like `"4".parse::<usize>()`
-// 5. If while extracting the name and the age something goes wrong, an error should be returned
-// If everything goes well, then return a Result of a Person object
 
 impl FromStr for Person {
     type Err = Box<dyn error::Error>;

--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -1,7 +1,23 @@
+// try_from_into.rs
+//
 // TryFrom is a simple and safe type conversion that may fail in a controlled way under some circumstances.
 // Basically, this is the same as From. The main difference is that this should return a Result type
 // instead of the target type itself.
 // You can read more about it at https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+//
+// Your task is to complete this implementation
+// and return an Ok result of inner type Color.
+// You need to create an implementation for a tuple of three integers,
+// an array of three integers and a slice of integers.
+//
+// Note that the implementation for tuple and array will be checked at compile time,
+// but the slice implementation needs to check the slice length!
+// Also note that correct RGB color values must be integers in the 0..=255 range.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint try_from_into
+
+// I AM NOT DONE
+
 use std::convert::{TryFrom, TryInto};
 use std::error;
 
@@ -11,17 +27,6 @@ struct Color {
     green: u8,
     blue: u8,
 }
-
-// I AM NOT DONE
-
-// Your task is to complete this implementation
-// and return an Ok result of inner type Color.
-// You need to create an implementation for a tuple of three integers,
-// an array of three integers and a slice of integers.
-//
-// Note that the implementation for tuple and array will be checked at compile time,
-// but the slice implementation needs to check the slice length!
-// Also note that correct RGB color values must be integers in the 0..=255 range.
 
 // Tuple implementation
 impl TryFrom<(i16, i16, i16)> for Color {

--- a/exercises/conversions/using_as.rs
+++ b/exercises/conversions/using_as.rs
@@ -1,9 +1,13 @@
+// using_as.rs
+//
 // Type casting in Rust is done via the usage of the `as` operator.
 // Please note that the `as` operator is not only used when type casting.
 // It also helps with renaming imports.
 //
 // The goal is to make sure that the division does not fail to compile
 // and returns the proper type.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint using_as
 
 // I AM NOT DONE
 

--- a/exercises/enums/enums1.rs
+++ b/exercises/enums/enums1.rs
@@ -1,5 +1,8 @@
 // enums1.rs
-// Make me compile! Execute `rustlings hint enums1` for hints!
+//
+// Make me compile! 
+//
+// If you need help, open the corresponding README.md or run: rustlings hint enums1
 
 // I AM NOT DONE
 

--- a/exercises/enums/enums2.rs
+++ b/exercises/enums/enums2.rs
@@ -1,5 +1,8 @@
 // enums2.rs
-// Make me compile! Execute `rustlings hint enums2` for hints!
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint enums2
 
 // I AM NOT DONE
 

--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -1,5 +1,8 @@
 // enums3.rs
+//
 // Address all the TODOs to make the tests pass!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint enums3
 
 // I AM NOT DONE
 

--- a/exercises/error_handling/errors1.rs
+++ b/exercises/error_handling/errors1.rs
@@ -1,10 +1,12 @@
 // errors1.rs
+//
 // This function refuses to generate text to be printed on a nametag if
 // you pass it an empty string. It'd be nicer if it explained what the problem
 // was, instead of just sometimes returning `None`. The 2nd test currently
 // does not compile or pass, but it illustrates the behavior we would like
 // this function to have.
-// Execute `rustlings hint errors1` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint errors1
 
 // I AM NOT DONE
 

--- a/exercises/error_handling/errors2.rs
+++ b/exercises/error_handling/errors2.rs
@@ -1,20 +1,23 @@
 // errors2.rs
+//
 // Say we're writing a game where you can buy items with tokens. All items cost
 // 5 tokens, and whenever you purchase items there is a processing fee of 1
 // token. A player of the game will type in how many items they want to buy,
 // and the `total_cost` function will calculate the total number of tokens.
 // Since the player typed in the quantity, though, we get it as a string-- and
 // they might have typed anything, not just numbers!
-
+//
 // Right now, this function isn't handling the error case at all (and isn't
 // handling the success case properly either). What we want to do is:
 // if we call the `parse` function on a string that is not a number, that
 // function will return a `ParseIntError`, and in that case, we want to
 // immediately return that error from our function and not try to multiply
 // and add.
-
+//
 // There are at least two ways to implement this that are both correct-- but
 // one is a lot shorter! Execute `rustlings hint errors2` for hints to both ways.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint errors2
 
 // I AM NOT DONE
 

--- a/exercises/error_handling/errors3.rs
+++ b/exercises/error_handling/errors3.rs
@@ -1,8 +1,10 @@
 // errors3.rs
+//
 // This is a program that is trying to use a completed version of the
 // `total_cost` function from the previous exercise. It's not working though!
 // Why not? What should we do to fix it?
-// Execute `rustlings hint errors3` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint errors3
 
 // I AM NOT DONE
 

--- a/exercises/error_handling/errorsn.rs
+++ b/exercises/error_handling/errorsn.rs
@@ -1,4 +1,5 @@
 // errorsn.rs
+//
 // This is a bigger error exercise than the previous ones!
 // You can do it! :)
 //
@@ -15,7 +16,7 @@
 // type goes where the question marks are, and how do we return
 // that type from the body of read_and_validate?
 //
-// Execute `rustlings hint errorsn` for hints :)
+// If you need help, open the corresponding README.md or run: rustlings hint errorsn
 
 // I AM NOT DONE
 

--- a/exercises/error_handling/result1.rs
+++ b/exercises/error_handling/result1.rs
@@ -1,5 +1,8 @@
 // result1.rs
-// Make this test pass! Execute `rustlings hint result1` for hints :)
+//
+// Make this test pass!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint result1
 
 // I AM NOT DONE
 

--- a/exercises/functions/functions1.rs
+++ b/exercises/functions/functions1.rs
@@ -1,5 +1,8 @@
 // functions1.rs
-// Make me compile! Execute `rustlings hint functions1` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint functions1
 
 // I AM NOT DONE
 

--- a/exercises/functions/functions2.rs
+++ b/exercises/functions/functions2.rs
@@ -1,5 +1,8 @@
 // functions2.rs
-// Make me compile! Execute `rustlings hint functions2` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint functions2
 
 // I AM NOT DONE
 

--- a/exercises/functions/functions3.rs
+++ b/exercises/functions/functions3.rs
@@ -1,5 +1,8 @@
 // functions3.rs
-// Make me compile! Execute `rustlings hint functions3` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint functions3
 
 // I AM NOT DONE
 

--- a/exercises/functions/functions4.rs
+++ b/exercises/functions/functions4.rs
@@ -1,8 +1,10 @@
 // functions4.rs
-// Make me compile! Execute `rustlings hint functions4` for hints :)
-
+//
 // This store is having a sale where if the price is an even number, you get
 // 10 Rustbucks off, but if it's an odd number, it's 3 Rustbucks off.
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint functions4
 
 // I AM NOT DONE
 

--- a/exercises/functions/functions5.rs
+++ b/exercises/functions/functions5.rs
@@ -1,5 +1,8 @@
 // functions5.rs
-// Make me compile! Execute `rustlings hint functions5` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint functions5
 
 // I AM NOT DONE
 

--- a/exercises/generics/generics1.rs
+++ b/exercises/generics/generics1.rs
@@ -1,5 +1,9 @@
+// generics1.rs
+//
 // This shopping list program isn't compiling!
 // Use your knowledge of generics to fix it.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint generics1
 
 // I AM NOT DONE
 

--- a/exercises/generics/generics2.rs
+++ b/exercises/generics/generics2.rs
@@ -1,5 +1,9 @@
+// generics2.rs
+//
 // This powerful wrapper provides the ability to store a positive integer value.
 // Rewrite it using generics so that it supports wrapping ANY type.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint generics2
 
 // I AM NOT DONE
 

--- a/exercises/generics/generics3.rs
+++ b/exercises/generics/generics3.rs
@@ -1,14 +1,16 @@
+// generics3.rs
+//
 // An imaginary magical school has a new report card generation system written in Rust!
 // Currently the system only supports creating report cards where the student's grade
 // is represented numerically (e.g. 1.0 -> 5.5).
 // However, the school also issues alphabetical grades (A+ -> F-) and needs
 // to be able to print both types of report card!
-
+//
 // Make the necessary code changes in the struct ReportCard and the impl block
 // to support alphabetical report cards. Change the Grade in the second test to "A+"
 // to show that your changes allow alphabetical grades.
-
-// Execute 'rustlings hint generics3' for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint generics3
 
 // I AM NOT DONE
 
@@ -20,8 +22,10 @@ pub struct ReportCard {
 
 impl ReportCard {
     pub fn print(&self) -> String {
-        format!("{} ({}) - achieved a grade of {}",
-            &self.student_name, &self.student_age, &self.grade)
+        format!(
+            "{} ({}) - achieved a grade of {}",
+            &self.student_name, &self.student_age, &self.grade
+        )
     }
 }
 

--- a/exercises/if/if1.rs
+++ b/exercises/if/if1.rs
@@ -1,9 +1,13 @@
 // if1.rs
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint if1
 
 // I AM NOT DONE
 
 pub fn bigger(a: i32, b: i32) -> i32 {
-    // Complete this function to return the bigger number!
+    // TODO: Complete this function to return the bigger number!
     // Do not use:
     // - another function call
     // - additional variables

--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -1,8 +1,9 @@
 // if2.rs
-
+//
 // Step 1: Make me compile!
 // Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
-// Execute the command `rustlings hint if2` if you want a hint :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint if2
 
 // I AM NOT DONE
 

--- a/exercises/macros/macros1.rs
+++ b/exercises/macros/macros1.rs
@@ -1,5 +1,8 @@
 // macros1.rs
-// Make me compile! Execute `rustlings hint macros1` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint macros1
 
 // I AM NOT DONE
 

--- a/exercises/macros/macros2.rs
+++ b/exercises/macros/macros2.rs
@@ -1,5 +1,8 @@
 // macros2.rs
-// Make me compile! Execute `rustlings hint macros2` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint macros2
 
 // I AM NOT DONE
 

--- a/exercises/macros/macros3.rs
+++ b/exercises/macros/macros3.rs
@@ -1,6 +1,8 @@
 // macros3.rs
+//
 // Make me compile, without taking the macro out of the module!
-// Execute `rustlings hint macros3` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint macros3
 
 // I AM NOT DONE
 

--- a/exercises/macros/macros4.rs
+++ b/exercises/macros/macros4.rs
@@ -1,5 +1,8 @@
 // macros4.rs
-// Make me compile! Execute `rustlings hint macros4` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint macros4
 
 // I AM NOT DONE
 

--- a/exercises/modules/modules1.rs
+++ b/exercises/modules/modules1.rs
@@ -1,5 +1,8 @@
 // modules1.rs
-// Make me compile! Execute `rustlings hint modules1` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint modules1
 
 // I AM NOT DONE
 

--- a/exercises/modules/modules2.rs
+++ b/exercises/modules/modules2.rs
@@ -1,5 +1,8 @@
 // modules2.rs
-// Make me compile! Execute `rustlings hint modules2` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint modules2
 
 // I AM NOT DONE
 

--- a/exercises/move_semantics/move_semantics1.rs
+++ b/exercises/move_semantics/move_semantics1.rs
@@ -1,5 +1,8 @@
 // move_semantics1.rs
-// Make me compile! Execute `rustlings hint move_semantics1` for hints :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint move_semantics1
 
 // I AM NOT DONE
 

--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -1,6 +1,8 @@
 // move_semantics2.rs
+//
 // Make me compile without changing line 13!
-// Execute `rustlings hint move_semantics2` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint move_semantics2
 
 // I AM NOT DONE
 

--- a/exercises/move_semantics/move_semantics3.rs
+++ b/exercises/move_semantics/move_semantics3.rs
@@ -1,7 +1,9 @@
 // move_semantics3.rs
+//
 // Make me compile without adding new lines-- just changing existing lines!
 // (no lines with multiple semicolons necessary!)
-// Execute `rustlings hint move_semantics3` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint move_semantics3
 
 // I AM NOT DONE
 

--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -1,8 +1,10 @@
 // move_semantics4.rs
+//
 // Refactor this code so that instead of having `vec0` and creating the vector
 // in `fn main`, we create it within `fn fill_vec` and transfer the
 // freshly created vector from fill_vec to its caller.
-// Execute `rustlings hint move_semantics4` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint move_semantics4
 
 // I AM NOT DONE
 

--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -1,9 +1,12 @@
 // option1.rs
-// Make me compile! Execute `rustlings hint option1` for hints
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint option1
 
 // I AM NOT DONE
 
-// you can modify anything EXCEPT for this function's sig
+// You can modify anything EXCEPT for this function's sig
 fn print_number(maybe_number: Option<u16>) {
     println!("printing: {}", maybe_number.unwrap());
 }

--- a/exercises/option/option2.rs
+++ b/exercises/option/option2.rs
@@ -1,5 +1,8 @@
 // option2.rs
-// Make me compile! Execute `rustlings hint option2` for hints
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint option2
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types1.rs
+++ b/exercises/primitive_types/primitive_types1.rs
@@ -1,6 +1,9 @@
 // primitive_types1.rs
+//
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
+//
+// If you need help, open the corresponding README.md
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types2.rs
+++ b/exercises/primitive_types/primitive_types2.rs
@@ -1,6 +1,9 @@
 // primitive_types2.rs
+//
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
+//
+// If you need help, open the corresponding README.md
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types3.rs
+++ b/exercises/primitive_types/primitive_types3.rs
@@ -1,6 +1,8 @@
 // primitive_types3.rs
+//
 // Create an array with at least 100 elements in it where the ??? is.
-// Execute `rustlings hint primitive_types3` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint primitive_types3
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types4.rs
+++ b/exercises/primitive_types/primitive_types4.rs
@@ -1,6 +1,8 @@
 // primitive_types4.rs
+//
 // Get a slice out of Array a where the ??? is so that the test passes.
-// Execute `rustlings hint primitive_types4` for hints!!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint primitive_types4
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types5.rs
+++ b/exercises/primitive_types/primitive_types5.rs
@@ -1,6 +1,8 @@
 // primitive_types5.rs
+//
 // Destructure the `cat` tuple so that the println will work.
-// Execute `rustlings hint primitive_types5` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint primitive_types5
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -1,7 +1,9 @@
 // primitive_types6.rs
+//
 // Use a tuple index to access the second element of `numbers`.
 // You can put the expression for the second element where ??? is so that the test passes.
-// Execute `rustlings hint primitive_types6` for hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint primitive_types6
 
 // I AM NOT DONE
 

--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -1,18 +1,21 @@
 // quiz1.rs
-// This is a quiz for the following sections:
+//
+// This quiz covers the sections:
 // - Variables
 // - Functions
-
+//
 // Mary is buying apples. One apple usually costs 2 Rustbucks, but if you buy
 // more than 40 at once, each apple only costs 1! Write a function that calculates
-// the price of an order of apples given the order amount. No hints this time!
+// the price of an order of apples given the order amount.
+//
+// No hints this time :)
 
 // I AM NOT DONE
 
 // Put your function here!
 // fn ..... {
 
-// Don't modify this function!
+// Don't modify this test function!
 #[test]
 fn verify_test() {
     let price1 = calculate_apple_price(35);

--- a/exercises/quiz2.rs
+++ b/exercises/quiz2.rs
@@ -1,11 +1,14 @@
 // quiz2.rs
-// This is a quiz for the following sections:
+//
+// This quiz covers the sections:
 // - Strings
-
+//
 // Ok, here are a bunch of values-- some are `String`s, some are `&str`s. Your
 // task is to call one of these two functions on each value depending on what
 // you think each value is. That is, add either `string_slice` or `string`
 // before the parentheses on each line. If you're right, it will compile!
+//
+// No hints this time :)
 
 // I AM NOT DONE
 

--- a/exercises/quiz3.rs
+++ b/exercises/quiz3.rs
@@ -1,11 +1,13 @@
 // quiz3.rs
-// This is a quiz for the following sections:
+//
+// This quiz covers the sections:
 // - Tests
-
+//
 // This quiz isn't testing our function -- make it do that in such a way that
 // the test passes. Then write a second test that tests that we get the result
 // we expect to get when we call `times_two` with a negative number.
-// No hints, you can do this :)
+//
+// No hints this time :)
 
 // I AM NOT DONE
 
@@ -24,7 +26,7 @@ mod tests {
 
     #[test]
     fn returns_twice_of_negative_numbers() {
-        // TODO replace unimplemented!() with an assert for `times_two(-4)`
+        // TODO: replace unimplemented!() with an assert for `times_two(-4)`
         unimplemented!()
     }
 }

--- a/exercises/quiz4.rs
+++ b/exercises/quiz4.rs
@@ -1,9 +1,12 @@
 // quiz4.rs
+//
 // This quiz covers the sections:
 // - Modules
 // - Macros
-
+//
 // Write a macro that passes the quiz! No hints this time, you can do it!
+//
+// No hints this time :)
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/arc1.rs
+++ b/exercises/standard_library_types/arc1.rs
@@ -1,4 +1,5 @@
 // arc1.rs
+//
 // In this exercise, we are given a Vec of u32 called "numbers" with values ranging
 // from 0 to 99 -- [ 0, 1, 2, ..., 98, 99 ]
 // We would like to use this set of numbers within 8 different threads simultaneously.
@@ -8,15 +9,15 @@
 // The third thread (offset 2), will sum 2, 10, 18, ...
 // ...
 // The eighth thread (offset 7), will sum 7, 15, 23, ...
-
+//
 // Because we are using threads, our values need to be thread-safe.  Therefore,
 // we are using Arc.  We need to make a change in each of the two TODOs.
-
-
+//
 // Make this code compile by filling in a value for `shared_numbers` where the
 // first TODO comment is, and create an initial binding for `child_numbers`
 // where the second TODO comment is. Try not to create any copies of the `numbers` Vec!
-// Execute `rustlings hint arc1` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint arc1
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/box1.rs
+++ b/exercises/standard_library_types/box1.rs
@@ -14,7 +14,7 @@
 //
 // Note: the tests should not be changed
 //
-// Execute `rustlings hint box1` for hints :)
+// If you need help, open the corresponding README.md or run: rustlings hint box1
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/iterators1.rs
+++ b/exercises/standard_library_types/iterators1.rs
@@ -6,7 +6,7 @@
 // This module helps you get familiar with the structure of using an iterator and 
 // how to go through elements within an iterable collection.
 // 
-// Execute `rustlings hint iterators1` for hints :D
+// If you need help, open the corresponding README.md or run: rustlings hint iterators1
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/iterators2.rs
+++ b/exercises/standard_library_types/iterators2.rs
@@ -1,7 +1,9 @@
 // iterators2.rs
+//
 // In this exercise, you'll learn some of the unique advantages that iterators
 // can offer. Follow the steps to complete the exercise.
-// As always, there are hints if you execute `rustlings hint iterators2`!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint iterators2
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/iterators3.rs
+++ b/exercises/standard_library_types/iterators3.rs
@@ -1,10 +1,12 @@
 // iterators3.rs
+//
 // This is a bigger exercise than most of the others! You can do it!
 // Here is your mission, should you choose to accept it:
 // 1. Complete the divide function to get the first four tests to pass.
 // 2. Get the remaining tests to pass by completing the result_with_list and
 //    list_of_results functions.
-// Execute `rustlings hint iterators3` to get some hints!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint iterators3
 
 // I AM NOT DONE
 

--- a/exercises/standard_library_types/iterators4.rs
+++ b/exercises/standard_library_types/iterators4.rs
@@ -1,9 +1,13 @@
 // iterators4.rs
+//
+// Make the tests pass!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint iterators4
 
 // I AM NOT DONE
 
 pub fn factorial(num: u64) -> u64 {
-    // Complete this function to return the factorial of num
+    // TODO: Complete this function to return the factorial of num
     // Do not use:
     // - return
     // Try not to use:

--- a/exercises/standard_library_types/iterators5.rs
+++ b/exercises/standard_library_types/iterators5.rs
@@ -1,5 +1,5 @@
 // iterators5.rs
-
+//
 // Let's define a simple model to track Rustlings exercise progress. Progress
 // will be modelled using a hash map. The name of the exercise is the key and
 // the progress is the value. Two counting functions were created to count the
@@ -7,10 +7,10 @@
 // imperative style for loops. Recreate this counting functionality using
 // iterators. Only the two iterator methods (count_iterator and
 // count_collection_iterator) need to be modified.
-// Execute `rustlings hint
-// iterators5` for hints.
 //
 // Make the code compile and the tests pass.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint iterators5
 
 // I AM NOT DONE
 

--- a/exercises/strings/strings1.rs
+++ b/exercises/strings/strings1.rs
@@ -1,6 +1,8 @@
 // strings1.rs
+//
 // Make me compile without changing the function signature!
-// Execute `rustlings hint strings1` for hints ;)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint strings1
 
 // I AM NOT DONE
 

--- a/exercises/strings/strings2.rs
+++ b/exercises/strings/strings2.rs
@@ -1,6 +1,8 @@
 // strings2.rs
+//
 // Make me compile without changing the function signature!
-// Execute `rustlings hint strings2` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint strings2
 
 // I AM NOT DONE
 

--- a/exercises/structs/structs1.rs
+++ b/exercises/structs/structs1.rs
@@ -1,5 +1,8 @@
 // structs1.rs
+//
 // Address all the TODOs to make the tests pass!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint structs1
 
 // I AM NOT DONE
 

--- a/exercises/structs/structs2.rs
+++ b/exercises/structs/structs2.rs
@@ -1,5 +1,8 @@
 // structs2.rs
+//
 // Address all the TODOs to make the tests pass!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint structs2
 
 // I AM NOT DONE
 

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -1,8 +1,10 @@
 // structs3.rs
+//
 // Structs contain data, but can also have logic. In this exercise we have
 // defined the Package struct and we want to test some logic attached to it.
 // Make the code compile and the tests pass!
-// If you have issues execute `rustlings hint structs3`
+//
+// If you need help, open the corresponding README.md or run: rustlings hint structs3
 
 // I AM NOT DONE
 

--- a/exercises/tests/tests1.rs
+++ b/exercises/tests/tests1.rs
@@ -1,10 +1,13 @@
 // tests1.rs
+//
 // Tests are important to ensure that your code does what you think it should do.
 // Tests can be run on this file with the following command:
 // rustlings run tests1
-
+//
 // This test has a problem with it -- make the test compile! Make the test
-// pass! Make the test fail! Execute `rustlings hint tests1` for hints :)
+// pass! Make the test fail!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint tests1
 
 // I AM NOT DONE
 

--- a/exercises/tests/tests2.rs
+++ b/exercises/tests/tests2.rs
@@ -1,6 +1,9 @@
 // tests2.rs
+//
 // This test has a problem with it -- make the test compile! Make the test
-// pass! Make the test fail! Execute `rustlings hint tests2` for hints :)
+// pass! Make the test fail!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint tests2
 
 // I AM NOT DONE
 

--- a/exercises/tests/tests3.rs
+++ b/exercises/tests/tests3.rs
@@ -1,8 +1,10 @@
 // tests3.rs
+//
 // This test isn't testing our function -- make it do that in such a way that
 // the test passes. Then write a second test that tests whether we get the result
 // we expect to get when we call `is_even(5)`.
-// Execute `rustlings hint tests3` for hints :)
+//
+// If you need help, open the corresponding README.md or run: rustlings hint tests3
 
 // I AM NOT DONE
 

--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -1,10 +1,13 @@
 // threads1.rs
-// Make this compile! Execute `rustlings hint threads1` for hints :)
+//
 // The idea is the thread spawned on line 22 is completing jobs while the main thread is
 // monitoring progress until 10 jobs are completed. Because of the difference between the
 // spawned threads' sleep time, and the waiting threads sleep time, when you see 6 lines
 // of "waiting..." and the program ends without timing out when running,
 // you've got it :)
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint threads1
 
 // I AM NOT DONE
 

--- a/exercises/traits/traits1.rs
+++ b/exercises/traits/traits1.rs
@@ -1,4 +1,5 @@
 // traits1.rs
+//
 // Time to implement some traits!
 //
 // Your task is to implement the trait
@@ -7,6 +8,8 @@
 // The trait AppendBar has only one function,
 // which appends "Bar" to any object
 // implementing this trait.
+//
+// If you need help, open the corresponding README.md or run: rustlings hint traits1
 
 // I AM NOT DONE
 
@@ -15,7 +18,7 @@ trait AppendBar {
 }
 
 impl AppendBar for String {
-    //Add your code here
+    // Add your code here
 }
 
 fn main() {

--- a/exercises/traits/traits2.rs
+++ b/exercises/traits/traits2.rs
@@ -9,6 +9,8 @@
 //
 // No boiler plate code this time,
 // you can do this!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint traits2
 
 // I AM NOT DONE
 
@@ -16,7 +18,7 @@ trait AppendBar {
     fn append_bar(self) -> Self;
 }
 
-//TODO: Add your code here
+// TODO: Add your code here
 
 #[cfg(test)]
 mod tests {

--- a/exercises/variables/variables1.rs
+++ b/exercises/variables/variables1.rs
@@ -1,10 +1,12 @@
 // variables1.rs
-// Make me compile! Execute the command `rustlings hint variables1` if you want a hint :)
-
+//
 // About this `I AM NOT DONE` thing:
 // We sometimes encourage you to keep trying things on a given exercise,
 // even after you already figured it out. If you got everything working and
 // feel ready for the next exercise, remove the `I AM NOT DONE` comment below.
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables1
 
 // I AM NOT DONE
 

--- a/exercises/variables/variables2.rs
+++ b/exercises/variables/variables2.rs
@@ -1,5 +1,8 @@
 // variables2.rs
-// Make me compile! Execute the command `rustlings hint variables2` if you want a hint :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables2
 
 // I AM NOT DONE
 

--- a/exercises/variables/variables3.rs
+++ b/exercises/variables/variables3.rs
@@ -1,5 +1,8 @@
 // variables3.rs
-// Make me compile! Execute the command `rustlings hint variables3` if you want a hint :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables3
 
 // I AM NOT DONE
 

--- a/exercises/variables/variables4.rs
+++ b/exercises/variables/variables4.rs
@@ -1,5 +1,8 @@
 // variables4.rs
-// Make me compile! Execute the command `rustlings hint variables4` if you want a hint :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables4
 
 // I AM NOT DONE
 

--- a/exercises/variables/variables5.rs
+++ b/exercises/variables/variables5.rs
@@ -1,5 +1,8 @@
 // variables5.rs
-// Make me compile! Execute the command `rustlings hint variables5` if you want a hint :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables5
 
 // I AM NOT DONE
 

--- a/exercises/variables/variables6.rs
+++ b/exercises/variables/variables6.rs
@@ -1,5 +1,8 @@
 // variables6.rs
-// Make me compile! Execute the command `rustlings hint variables6` if you want a hint :)
+//
+// Make me compile!
+//
+// If you need help, open the corresponding README.md or run: rustlings hint variables6
 
 // I AM NOT DONE
 


### PR DESCRIPTION
To have a consistent exercise description block, every exercise will have the following structure:
```
// <filename.rs>
//
// description / instructions
//
// help line
```

This way every exercise has the same structure. Learners will know that the first line is the filename, the last is the help line and in between is a description or instructions.
At the moment, some exercises don't have a filename at the beginning and / or don't show help information (e. g. the hint for this exercise). Sometimes help information or links are in between the instructions. In some exercises instructions come after some lines of code, which is inconsistent and could confuse some people.
Additionally to the current hint, I also added an reference to the corresponding README.md, in case learners will overlook it.