### PR TITLE
Correct small typo in exercises/conversions/from_str.rs

### DIFF
--- a/exercises/conversions/from_str.rs
+++ b/exercises/conversions/from_str.rs
@@ -20,7 +20,7 @@ struct Person {
 // 4. Extract the first element from the split operation and use it as the name
 // 5. Extract the other element from the split operation and parse it into a `usize` as the age
 //    with something like `"4".parse::<usize>()`
-// 5. If while extracting the name and the age something goes wrong, an error should be returned
+// 6. If while extracting the name and the age something goes wrong, an error should be returned
 // If everything goes well, then return a Result of a Person object
 
 impl FromStr for Person {


### PR DESCRIPTION
The 2nd step 5 of the instruction should be step 6.