### PR TITLE
Add hints on how to get gcc installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Alternatively, for a first-time Rust learner, there are several other resources:
 ## Getting Started
 
 _Note: If you're on MacOS, make sure you've installed Xcode and its developer tools by typing `xcode-select --install`._
+_Note: If you're on Linux, make sure you've installed gcc. Deb: `sudo apt install gcc`. Yum: `sudo yum -y install gcc`._
 
 You will need to have Rust installed. You can get it by visiting https://rustup.rs. This'll also install Cargo, Rust's package/project manager.
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,18 @@ else
     exit 1
 fi
 
+if [ -x "$(command -v cc)" ]
+then
+    echo "SUCCESS: cc is installed"
+else
+    echo "ERROR: cc does not seem to be installed."
+    echo "Please download (g)cc using your package manager."
+    echo "OSX: xcode-select --install"
+    echo "Deb: sudo apt install gcc"
+    echo "Yum: sudo yum -y install gcc"
+    exit 1
+fi
+
 if [ -x "$(command -v rustc)" ]
 then
     echo "SUCCESS: Rust is installed"


### PR DESCRIPTION
Just tried installing Rustlings using the `install.sh` script on a fresh Ubuntu install and I forgot to install `build-essential` so it failed once cargo started trying to compile. This commit adds a check to the script for `cc` as well as a note to `README.md`.

I'm not on an OSX system right now, but iirc `cc` is what the Xcode CLI tools uses, as well so it should work across both platforms. Not sure about Windows.

If you would prefer that I make a PR with only the `README.md` change, I'm happy to do that.