### PR TITLE
iterators5: Change Progress to derive Clone and Copy

### DIFF
--- a/exercises/standard_library_types/iterators5.rs
+++ b/exercises/standard_library_types/iterators5.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum Progress {
     None,
     Some,


### PR DESCRIPTION
Sorry in advance if this is just me being ignorant.  I'm pretty new to rust, and I'm still sorting out the ownership model.

I personally found it really unintuitive to not call `count_iterator` as a part of my `count_collection_iterator` implementation.

Rather than writing the problem solution here, I'll give an example with `count_for` and `count_collection_for`:
```
fn count_for(map: &HashMap<String, Progress>, value: Progress) -> usize {
    let mut count = 0;
    for val in map.values() {
        if val == &value {
            count += 1;
        }
    }
    count
}

fn count_collection_for(collection: &[HashMap<String, Progress>], value: Progress) -> usize {
    let mut count = 0;
    for map in collection {
        count = count + count_for(map, value);
    }
    count
}
```
It feels very natural to implement the iterators more similar to this, but this results in the following error:
```
! Compiling of exercises/standard_library_types/iterators5.rs failed! Please try again. Here's the output:
error[E0382]: use of moved value: `value`
  --> exercises/standard_library_types/iterators5.rs:45:40
   |
42 | fn count_collection_for(collection: &[HashMap<String, Progress>], value: Progress) -> usize {
   |                                                                   ----- move occurs because `value` has type `Progress`, which does not implement the `Copy` trait
...
45 |         count = count + count_for(map, value);
   |                                        ^^^^^ value moved here, in previous iteration of loop

error: aborting due to previous error

For more information about this error, try `rustc --explain E0382`.
```

I spent some time trying to find a way to not move `value` also without duplicating code, and it led me to either implementing the Copy / Clone traits, or using Arc to pass a shared atomic value.

Both of these require changes outside of the functions, which is counter to the suggestions in the top level comment:
> Only the two iterator methods (count_iterator and count_collection_iterator) need to be modified.

If there is some other solution that I did not find that calls `count_iterator` from `count_collection_iterator` I would love to know it.  Otherwise I would like to suggest adding these traits to Progress to allow this solution.

Thanks.