### PR TITLE
threads1: use more threads, model more reference counting

### DIFF
--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -1,6 +1,6 @@
 // threads1.rs
 // Make this compile! Execute `rustlings hint threads1` for hints :)
-// The idea is the threads spawned on line 22 are completing jobs while the main thread is
+// The idea is the threads spawned on line 20 are completing jobs while the main thread is
 // monitoring progress until 10 jobs are completed.
 
 // I AM NOT DONE

--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -1,10 +1,7 @@
 // threads1.rs
 // Make this compile! Execute `rustlings hint threads1` for hints :)
-// The idea is the thread spawned on line 22 is completing jobs while the main thread is
-// monitoring progress until 10 jobs are completed. Because of the difference between the
-// spawned threads' sleep time, and the waiting threads sleep time, when you see 6 lines
-// of "waiting..." and the program ends without timing out when running,
-// you've got it :)
+// The idea is the threads spawned on line 22 are completing jobs while the main thread is
+// monitoring progress until 10 jobs are completed.
 
 // I AM NOT DONE
 
@@ -18,15 +15,18 @@ struct JobStatus {
 
 fn main() {
     let status = Arc::new(JobStatus { jobs_completed: 0 });
-    let status_shared = status.clone();
-    thread::spawn(move || {
-        for _ in 0..10 {
-            thread::sleep(Duration::from_millis(250));
-            status_shared.jobs_completed += 1;
-        }
-    });
+    for i in 0..10 {
+        let status_ref = Arc::clone(&status);
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(250 * i));
+            status_ref.jobs_completed += 1;
+        });
+    }
     while status.jobs_completed < 10 {
-        println!("waiting... ");
+        println!("waiting for {} jobs ({} jobs running)... ", 
+            (10 - status.jobs_completed), 
+            (Arc::strong_count(&status) - 1) // subtract one for refrence in _this_ thread
+        );
         thread::sleep(Duration::from_millis(500));
     }
 }

--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -15,7 +15,7 @@ struct JobStatus {
 
 fn main() {
     let status = Arc::new(JobStatus { jobs_completed: 0 });
-    for i in 0..10 {
+    for i in 1..=10 {
         let status_ref = Arc::clone(&status);
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(250 * i));


### PR DESCRIPTION
# Changes
- Switch from a single additional thread (receiving/holding a single `Arc::clone` reference) running a loop modeling 10 sequential jobs, to a loop generating 10 threads each modeling 1 job (each getting their own `Arc::clone` reference)
- use the previously ignored `for` loop var to keep the execution timing approx the same
- Print a more descriptive waiting message (taking an opportunity to use comment to disambiguate the count)

# Rationale

It takes a (reasonable) misunderstanding I had that caused me much confusion & frustration, as explained in detail below ("Motivation"), and makes the program work closer to how I thought it did.

Ultimately the difference between the two versions is possibly just a matter of taste— but my intention is to save people from going through my frustration and confusion (if perhaps also my exploration of edge cases), and I think this achieves that.

## Pros

1. `Arc::clone(&status)` seems generally recommended style over `status.clone()` 

2. With the `Arc::clone` between the `for` header and `thread::spawn` it is much harder to mentally transpose the two lines as I initially (repeatedly) did (though of course, this PR does actually swap them).

3. Whereas in computing we talk about cardinality in the trichotomy of "zero, one or many", I assert that It serves a purpose of diminishing potential for confusion while learning to disambiguate that there is "one" main thread and "many" other threads. 

    While the 2 threads of threads1 (as in `main`) account technically as "many", there is a (potentially) confusing "one" explicit clone of the `Arc` after "one" initialization. 

4. Having the counter count more better illustrates the concept of the counter in action. 
5. The added call to `Arc::strong_count(&status)` obviates that there _is_ an underlying count*. The use of `strong_count` may also inspire a question of "why strong?" and create a path to exploring weak references and their uses (and `Arc::downgrade`).
6. IMO, it is just a more realistic model of contemporary async task execution to fan out to full parallelization (of sleeps) vs giving all to one worker thread

*[ If people are working from code examples by rote pattern, as I expect will only increase as Rust becomes more widely learned with various degrees of rigorous approach, they may not have a clear understanding (that `Rc` exists, that `Arc` is an acronym, or) of what `A.R.C.` stands for. I can imagine various ways someone could take the name as simply metaphorical for how values move between threads:
- someone with an EE background might read "arc" and think of an electrical arc over a spark gap
- someone with a background in astronomy, rocketry, or basketball (to name a few) might think of it as invoking something moving in an elliptical path from one place to another (perhaps because it was "thrown" ... [yeet](https://areweyeetyet.rs/)ed even 😄 )
- confusing it with `Ark` in the archaic sense of "a chest or box." (c.f. "Ark of the Covenant") - one might think of if as "like `Box`, but special".
- confusing it with `Ark` in the sense "Something affording protection; safety, shelter, refuge" (c.f. Noah's ark, but also (invoking) uses in Sci-Fi especially)

I am not shocked if some of these ~puns were known when the name was decided, but I digress]

## Cons

More compute resources are used, both CPU and memory I expect. Overall execution time of the program (verifying the exercise) is likely slower (though probably not appreciably?)

## Invariants

1. The initial state of the exercise is near identical in terms of compiler output, varying only in line numbers:
    ```
    error[E0594]: cannot assign to data in an `Arc`
      --> exercises/threads/threads1.rs:[25/22]:13
       |
    [25/22] |             status_shared.jobs_completed += 1;
       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot assign
       |
       = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Arc<JobStatus>`
    

    ```

2. The overall approach to the solution

# Motivation

## My initial (mis)understanding 

I (blasphemously) was/am using rustlings as a learning tool before having done a proper read through of The Book (through Chapter 16 anyway). 

Nonetheless, through knowledge-osmosis (from e.g. conference talks) I understood, going into this exercise, that `Arc` is an atomic reference counted binding: doing ~ersatz refcount GC by effectively incrementing a count on `clone(&self)` and decrementing on `drop(&mut self)` (then performing the dealloc if the count hit 0 (or perhaps < 0)).

Armed with this knowledge, I (incorrectly) mentally mapped what was happening in this file to something like "(once "all" the threads are spawned) the `Arc` holds the count of the running jobs/threads and `status`holds the count of completed jobs/threads".  

This is to say (perhaps owing also to recent time spent over in Elixir/Erlang land), I immediately **assumed we were looking at 1 thread for (modeling) _each_ of 10 monitored jobs,** vs correctly reading the code to see that **in reality, we were looking at only 1 (additional) thread for (modeling) all 10 jobs**.

I think this misunderstanding was further enabled by a comment apostrophe typo and line break placement  (both in the sentences removed herein)  wherein I had seen `// spawned threads' sleep time` instead of `the… spawned thread's sleep time`

## How attempting the exercise played out for me

Based on the initial state of compilation failure, I didn't have a ton of trouble getting the point of the exercise vis-a-vis a need for synchronization for the mutation (the idea that the `Arc`, as written, was insufficient).

The problem was that I was intermediately confused by what was happening with the current usage! And got more confused as I tried to engage with it.

### "Does `Arc` implement `Copy`?"

Based on my misunderstanding of the number of threads involved, my eyes/brain easily (and repeatedly) transposed lines 22 and 23 (pre-my-changes) and I (consistently until I finally didn't) saw a loop calling `thread::spawn(move || …)` 10 times.

Above that was line 21: `let status_shared = status.clone();` ... 1 time. 

I promptly noticed the (apparent) mismatch:
- that the reference count wouldn't match the (apparent) number of uses, 
- and that the compiler (/ borrow checker) was (apparently) allowing a repeated move, which it seems like it shouldn't. 

But it also seemed that (perhaps) this was intended.

The name of the variable — `status_shared`— read to me (in light of this) as "status that is (actively) shared (between all threads)" [vs (I now presume) the intention: "status that is (about to be) shared with (i.e. given/moved to) the other thread"].

<details>
<summary>I briefly reasoned that "huh. I guess `Arc` implements `Copy`?"</summary>

 I was/am skeptical that even if that were the case that one could use the `move` keyword to repeatedly capture a variable into a closure in a loop; but ... it looked that way. 

Still, I'd heard passing discussion about `Arc::clone(&foo)` vs `foo.clone()` style – and it seemed weird that that would be so prevalent if one can just pass the whole `Arc`by reference
</details>


I checked the documentation: nope.

### Trying to do it with just `Arc` while confused

So it seemed like a weird misdirect, a lot of changes to require vs most of the exercises, but I figured ... maybe line 21 is just a hint that one want to use `clone` generally 

I tried what seemed mostly right to me (still missing the fact of the loop vs spawn order):

```diff
 fn main() {
-    let status = Arc::new(JobStatus { jobs_completed: 0 });
-    let status_shared = status.clone();
+    let mut status = JobStatus { jobs_completed: 0 };
+    let status_shared = Arc::new(&mut status);
     thread::spawn(move || {
         for _ in 0..10 {
             thread::sleep(Duration::from_millis(250));
-            status_shared.jobs_completed += 1;
+            Arc::clone(&status_shared).jobs_completed += 1;
         }
```

Alas this both only moved me from:
> error[E0594]: cannot assign to data in an `Arc`
> …
> help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Arc<JobStatus>`
to:
> error[E0594]: cannot assign to data in an `Arc`
> …
> help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Arc<&mut JobStatus>`

besides which it raised the dual specters of (non-Arc-wrapped) status's lifetime vs the Arc's borrow, and the inability to take a read borrow from `status` cause its already borrowed, and status_shared cause its moved! (cause `move` is still casting to a `FnOnce`, even though usage is just as a read borrow for clone.)

I swallowed my feelings needing to specify mut at Arc construction time to get a mut binding out and tried just doing:

```diff 
 fn main() {
     let status = Arc::new(JobStatus { jobs_completed: 0 });
-    let status_shared = status.clone();
-    thread::spawn(move || {
+    thread::spawn(|| {
         for _ in 0..10 {
             thread::sleep(Duration::from_millis(250));
-            status_shared.jobs_completed += 1;
+            Arc::clone(&status).jobs_completed += 1;
```

(as well as some stuff with `Arc::downgrade` and trying to stick `mut` in places it can't go)

But thus E0594 persisted and E0373 appeared:
>error[E0373]: closure may outlive the current function, but it borrows `status`, which is owned by the current function
>…
>note: function requires argument type to outlive `'static`
>…
>help: to force the closure to take ownership of `status` (and any other referenced variables), use the `move` keyword

### Going further afield

I was frustrated and went off into the weeds to two solutions that worked, but seemed obviously not what had been the intended answer here.

Because I happened to know that x86 and aarch64 have atomic register increment ops and thought it might exist / found it, I successfully tried deleting the struct and making `status` a `core::sync::atomic::AtomicU8`. I had to make it static but got that solution working.

I also made `status` an `Arc<()>` had "each thread" (actually each iteration of the loop, I hadn't realized my confusion yet though) take a clone of that before sleeping and changed the `while` condition to `Arc::strong_count(&status) > 1`.

### Coming back

Satisfied that I had found _a_ solution by myself, I finally looked at hints, and saw that the answer was actually just "add a `Mutex`" (or, I opted, `RwLock`).

I took a while to understand why I needed/wanted an `Arc` when I had another synchronization (lifetimes again), and I got it working much as intended...

but STILL thinking there were 10 threads, I couldn't for the life of me figure out why there was only one clone and how it was solving the problem.

I considered that … like… an initialized `Arc` had a count of 0 ? and that doing a clone in main was needed to increase it to 1 before spawning the threads (nope. `Arc::strong_count()` indicated that the first binding on initialization was definitely counted the same as any other). 

I thought that maybe double binding in main was needed to trick the checker into ~imagining a deadlock that made the var effectively `'static`? (which ... no. and like both would still Drop before the known lifetime of the closure)

... and like ... `Arc` still didn't implement `Copy` so ... wtf?

After ... too long... I realized my mistake about the order of `thread::spawn` and `for`.

