### PR TITLE
feat: Add move_semantics5 exercise.

### DIFF
--- a/exercises/move_semantics/move_semantics5.rs
+++ b/exercises/move_semantics/move_semantics5.rs
@@ -1,0 +1,14 @@
+// move_semantics5.rs
+// Make me compile without adding any newlines or removing any of the lines.
+// Execute `rustlings hint move_semantics5` for hints :)
+
+// I AM NOT DONE
+
+fn main() {
+    let mut x = 100;
+    let y = &mut x;
+    let z = &mut *y;
+    *y += 100;
+    *z += 1000;
+    assert_eq!(x, 1200);
+}

--- a/exercises/option/option3.rs
+++ b/exercises/option/option3.rs
@@ -1,0 +1,20 @@
+// option2.rs
+// Make me compile! Execute `rustlings hint option3` for hints
+
+// I AM NOT DONE
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let y: Option<Point> = Some(Point { x: 100, y: 200 });
+
+    match y {
+        Some(p) => println!("Co-ordinates are{},{} ", p.x, p.y),
+        _ => println!("no match"),
+    }
+    // Fix without deleting this line.
+    y;
+}

--- a/exercises/option/option3.rs
+++ b/exercises/option/option3.rs
@@ -12,9 +12,8 @@ fn main() {
     let y: Option<Point> = Some(Point { x: 100, y: 200 });
 
     match y {
-        Some(p) => println!("Co-ordinates are{},{} ", p.x, p.y),
+        Some(p) => println!("Co-ordinates are {},{} ", p.x, p.y),
         _ => println!("no match"),
     }
-    // Fix without deleting this line.
-    y;
+    y; // Fix without deleting this line.
 }

--- a/exercises/option/option3.rs
+++ b/exercises/option/option3.rs
@@ -1,4 +1,4 @@
-// option2.rs
+// option3.rs
 // Make me compile! Execute `rustlings hint option3` for hints
 
 // I AM NOT DONE

--- a/info.toml
+++ b/info.toml
@@ -210,6 +210,13 @@ So the end goal is to:
    - since we're not creating a new vec in `main` anymore, we need to create
      a new vec in `fill_vec`, similarly to the way we did in `main`"""
 
+[[exercises]]
+name = "move_semantics5"
+path = "exercises/move_semantics/move_semantics5.rs"
+mode = "compile"
+hint = """Carefully reason about the range in which each mutable reference is in vogue. Does updating the value of referrent (x) immediately after the mutable reference is taken helps ? Read more about 'Mutable Referenes' in the book's section References and Borrowing': https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references."""
+
+
 # PRIMITIVE TYPES
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -586,6 +586,16 @@ Also see Option::flatten
 """
 
 [[exercises]]
+name = "option3"
+path = "exercises/option/option3.rs"
+mode = "compile"
+hint = """
+The compiler says a partial move happened in the `match`
+statement. How can this be avoided ? The compiler shows the correction
+needed. After making the correction as suggested by the compiler, do
+read: https://doc.rust-lang.org/std/keyword.ref.html"""
+
+[[exercises]]
 name = "result1"
 path = "exercises/error_handling/result1.rs"
 mode = "test"

--- a/info.toml
+++ b/info.toml
@@ -221,7 +221,6 @@ mutable reference is taken helps? Read more about 'Mutable Referenes'
 in the book's section References and Borrowing':
 https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references."""
 
-
 # PRIMITIVE TYPES
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -214,7 +214,12 @@ So the end goal is to:
 name = "move_semantics5"
 path = "exercises/move_semantics/move_semantics5.rs"
 mode = "compile"
-hint = """Carefully reason about the range in which each mutable reference is in vogue. Does updating the value of referrent (x) immediately after the mutable reference is taken helps ? Read more about 'Mutable Referenes' in the book's section References and Borrowing': https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references."""
+hint = """
+Carefully reason about the range in which each mutable reference is in
+vogue. Does updating the value of referrent (x) immediately after the
+mutable reference is taken helps? Read more about 'Mutable Referenes'
+in the book's section References and Borrowing':
+https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references."""
 
 
 # PRIMITIVE TYPES
@@ -591,7 +596,7 @@ path = "exercises/option/option3.rs"
 mode = "compile"
 hint = """
 The compiler says a partial move happened in the `match`
-statement. How can this be avoided ? The compiler shows the correction
+statement. How can this be avoided? The compiler shows the correction
 needed. After making the correction as suggested by the compiler, do
 read: https://doc.rust-lang.org/std/keyword.ref.html"""
 


### PR DESCRIPTION
- Added an exercise for `move_semantics` which helps in improving the understanding of mutable references.
- Added an exercise for `option` which helps in understanding of usage of keyword _ref_