### PR TITLE
fix(iterators5): balance test fixture

### DIFF
--- a/exercises/standard_library_types/iterators5.rs
+++ b/exercises/standard_library_types/iterators5.rs
@@ -102,6 +102,7 @@ mod tests {
         map.insert(String::from("arc1"), Some);
         map.insert(String::from("as_ref_mut"), None);
         map.insert(String::from("from_str"), None);
+        map.insert(String::from("using_as"), None);
 
         map
     }


### PR DESCRIPTION
It was easy to write the filter in `count_iterator` incorrectly, as there are as many `Complete`d entries as there are other entries. This means both `.filter(|v| v == &value)` and `.filter(|v| != &value)` give the same result. This balances out so the number is different and the mistake will be caught appropriately.