### PR TITLE
fix(iterators5): derive Clone, Copy

### DIFF
--- a/exercises/standard_library_types/iterators5.rs
+++ b/exercises/standard_library_types/iterators5.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum Progress {
     None,
     Some,

--- a/info.toml
+++ b/info.toml
@@ -788,7 +788,10 @@ test count_iterator.
 The collection variable in count_collection_iterator is a slice of HashMaps. It
 needs to be converted into an iterator in order to use the iterator methods.
 
-The fold method can be useful in the count_collection_iterator function."""
+The fold method can be useful in the count_collection_iterator function.
+
+For a further challenge, consult the documentation for Iterator to find
+a different method that could make your code more compact than using fold."""
 
 # THREADS
 


### PR DESCRIPTION
To allow more flexibility in solutions, derive `Clone` and `Copy`
for `Progress`.

Fixes #763.

Also add a hint about conciseness by using some method other than `fold`.