### PR TITLE
[CLI] Feature: Add "next" to run the next unsolved exercise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In case you want to go by your own order, or want to only verify a single exerci
 rustlings run myExercise1
 ```
 
-Or simply use the following command to run the very next unsolved exerice in the tutorial:
+Or simply use the following command to run the next unsolved exercise in the course:
 
 ```bash
 rustlings run next

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ exercise:
 rustlings hint myExercise1
 ```
 
+You can also get the hint for the next unsolved exercise with the following command:
+
+``` bash
+rustlings hint next
+```
+
 To check your progress, you can run the following command:
 ```bash
 rustlings list

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ In case you want to go by your own order, or want to only verify a single exerci
 rustlings run myExercise1
 ```
 
+Or simply use the following command to run the very next unsolved exerice in the tutorial:
+
+```bash
+rustlings run next
+```
+
 In case you get stuck, you can run the following command to get a hint for your
 exercise:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,13 +286,24 @@ fn spawn_watch_shell(failed_exercise_hint: &Arc<Mutex<Option<String>>>) {
 }
 
 fn find_exercise<'a>(name: &str, exercises: &'a [Exercise]) -> &'a Exercise {
-    exercises
-        .iter()
-        .find(|e| e.name == name)
-        .unwrap_or_else(|| {
-            println!("No exercise found for '{}'!", name);
-            std::process::exit(1)
-        })
+    if name.eq("next") {
+        exercises
+            .iter()
+            .find(|e| !e.looks_done())
+            .unwrap_or_else(|| {
+                println!("🎉 Congratulations! You have done all the exercises!");
+                println!("🔚 There is no more exercises to do next!");
+                std::process::exit(1)
+            })
+    } else {
+        exercises
+            .iter()
+            .find(|e| e.name == name)
+            .unwrap_or_else(|| {
+                println!("No exercise found for '{}'!", name);
+                std::process::exit(1)
+            })
+    }
 }
 
 fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,7 @@ fn find_exercise<'a>(name: &str, exercises: &'a [Exercise]) -> &'a Exercise {
             .find(|e| !e.looks_done())
             .unwrap_or_else(|| {
                 println!("🎉 Congratulations! You have done all the exercises!");
-                println!("🔚 There is no more exercises to do next!");
+                println!("🔚 There are no more exercises to do next!");
                 std::process::exit(1)
             })
     } else {


### PR DESCRIPTION
Based on #783 

This PR should allow users to use the following command to run the next unsolved exercise in the `exercises` vector.
```bash
rustlings run next
```

When there are no more unsolved exercises, it will print the following messages and `exit` with `1`.
```
🎉 Congratulations! You have done all the exercises!
🔚 There are no more exercises to do next!
```