### PR TITLE
chore: Update hint of iterators3

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -774,7 +774,7 @@ case is a vector of integers and the failure case is a DivisionError.
 
 The list_of_results function needs to return a vector of results.
 
-See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect how 
+See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect for how 
 the `FromIterator` trait is used in `collect()`."""
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -772,7 +772,10 @@ The division_results variable needs to be collected into a collection type.
 The result_with_list function needs to return a single Result where the success
 case is a vector of integers and the failure case is a DivisionError.
 
-The list_of_results function needs to return a vector of results."""
+The list_of_results function needs to return a vector of results.
+
+See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect how 
+the `FromIterator` trait is used in `collect()`."""
 
 [[exercises]]
 name = "iterators4"


### PR DESCRIPTION
`collect()` needs some hint for standard_library_types/iterators3 exercise with doc link for understanding different return types via `FromIterator`.