### PR TITLE
Error handling

### DIFF
--- a/exercises/collections/hashmap1.rs
+++ b/exercises/collections/hashmap1.rs
@@ -11,18 +11,15 @@
 // Execute the command `rustlings hint hashmap1` if you need
 // hints.
 
-// I AM NOT DONE
-
 use std::collections::HashMap;
 
 fn fruit_basket() -> HashMap<String, u32> {
-    let mut basket = // TODO: declare your hash map here.
+    let mut basket = HashMap::new();
 
     // Two bananas are already given for you :)
     basket.insert(String::from("banana"), 2);
-
-    // TODO: Put more fruits in your basket here.
-
+    basket.insert(String::from("mango"),2);
+    basket.insert(String::from("apricot"),3);
     basket
 }
 

--- a/exercises/collections/hashmap2.rs
+++ b/exercises/collections/hashmap2.rs
@@ -12,8 +12,6 @@
 // Execute the command `rustlings hint hashmap2` if you need
 // hints.
 
-// I AM NOT DONE
-
 use std::collections::HashMap;
 
 #[derive(Hash, PartialEq, Eq)]
@@ -35,9 +33,9 @@ fn fruit_basket(basket: &mut HashMap<Fruit, u32>) {
     ];
 
     for fruit in fruit_kinds {
-        // TODO: Put new fruits if not already present. Note that you
-        // are not allowed to put any type of fruit that's already
-        // present!
+        if !basket.contains_key(&fruit){
+            basket.insert(fruit,2);
+        }
     }
 }
 

--- a/exercises/collections/vec1.rs
+++ b/exercises/collections/vec1.rs
@@ -4,11 +4,9 @@
 // Make me compile and pass the test!
 // Execute the command `rustlings hint vec1` if you need hints.
 
-// I AM NOT DONE
-
 fn array_and_vec() -> ([i32; 4], Vec<i32>) {
     let a = [10, 20, 30, 40]; // a plain array
-    let v = // TODO: declare your vector here with the macro for vectors
+    let v = vec![10i32, 20,30,40]; 
 
     (a, v)
 }

--- a/exercises/collections/vec2.rs
+++ b/exercises/collections/vec2.rs
@@ -7,12 +7,9 @@
 // Execute the command `rustlings hint vec2` if you need
 // hints.
 
-// I AM NOT DONE
-
 fn vec_loop(mut v: Vec<i32>) -> Vec<i32> {
     for i in v.iter_mut() {
-        // TODO: Fill this up so that each element in the Vec `v` is
-        // multiplied by 2.
+        *i *= 2;
     }
 
     // At this point, `v` should be equal to [4, 8, 12, 16, 20].

--- a/exercises/enums/enums1.rs
+++ b/exercises/enums/enums1.rs
@@ -1,11 +1,11 @@
 // enums1.rs
 // Make me compile! Execute `rustlings hint enums1` for hints!
-
-// I AM NOT DONE
-
 #[derive(Debug)]
 enum Message {
-    // TODO: define a few types of messages as used below
+    Quit,
+    Echo,
+    Move,
+    ChangeColor,
 }
 
 fn main() {

--- a/exercises/enums/enums2.rs
+++ b/exercises/enums/enums2.rs
@@ -1,11 +1,11 @@
 // enums2.rs
 // Make me compile! Execute `rustlings hint enums2` for hints!
-
-// I AM NOT DONE
-
 #[derive(Debug)]
 enum Message {
-    // TODO: define the different variants used below
+    Quit,
+    Move{x: i32, y: i32},
+    Echo(String),
+    ChangeColor(i32,i32,i32),
 }
 
 impl Message {

--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -1,10 +1,11 @@
 // enums3.rs
 // Address all the TODOs to make the tests pass!
 
-// I AM NOT DONE
-
 enum Message {
-    // TODO: implement the message variant types based on their usage below
+    Quit,
+    Echo(String),
+    Move(Point),
+    ChangeColor((u8,u8,u8)), 
 }
 
 struct Point {
@@ -36,6 +37,12 @@ impl State {
     }
 
     fn process(&mut self, message: Message) {
+       match message {
+        Message::ChangeColor((x,y,z)) => self.color = (x,y,z),
+        Message::Quit => self.quit = true,
+        Message::Move(p) => self.position = p,
+        _ => println!("anything") ,
+       }
         // TODO: create a match expression to process the different message variants
     }
 }

--- a/exercises/error_handling/errors1.rs
+++ b/exercises/error_handling/errors1.rs
@@ -5,15 +5,12 @@
 // does not compile or pass, but it illustrates the behavior we would like
 // this function to have.
 // Execute `rustlings hint errors1` for hints!
-
-// I AM NOT DONE
-
-pub fn generate_nametag_text(name: String) -> Option<String> {
+pub fn generate_nametag_text(name: String) -> Result<String,String>{
     if name.len() > 0 {
-        Some(format!("Hi! My name is {}", name))
-    } else {
+        Ok(format!("Hi! My name is {}", name))
+    } else{
         // Empty names aren't allowed.
-        None
+        Err(String::from("`name` was empty; it must be nonempty."))
     }
 }
 
@@ -28,7 +25,7 @@ mod tests {
     fn generates_nametag_text_for_a_nonempty_name() {
         assert_eq!(
             generate_nametag_text("Beyoncé".into()),
-            Some("Hi! My name is Beyoncé".into())
+            Ok("Hi! My name is Beyoncé".into())
         );
     }
 

--- a/exercises/error_handling/errors2.rs
+++ b/exercises/error_handling/errors2.rs
@@ -16,17 +16,20 @@
 // There are at least two ways to implement this that are both correct-- but
 // one is a lot shorter! Execute `rustlings hint errors2` for hints to both ways.
 
-// I AM NOT DONE
-
 use std::num::ParseIntError;
 
 pub fn total_cost(item_quantity: &str) -> Result<i32, ParseIntError> {
     let processing_fee = 1;
     let cost_per_item = 5;
     let qty = item_quantity.parse::<i32>();
+    match qty {
+        Ok(qty) => Ok(qty * cost_per_item + processing_fee),
+        Err(e) => Err(e),
+    }
 
-    Ok(qty * cost_per_item + processing_fee)
+    //Ok(qty * cost_per_item + processing_fee)
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/exercises/error_handling/errors3.rs
+++ b/exercises/error_handling/errors3.rs
@@ -4,11 +4,9 @@
 // Why not? What should we do to fix it?
 // Execute `rustlings hint errors3` for hints!
 
-// I AM NOT DONE
-
 use std::num::ParseIntError;
 
-fn main() {
+fn main() -> Result<(), ParseIntError>{
     let mut tokens = 100;
     let pretend_user_input = "8";
 
@@ -20,6 +18,7 @@ fn main() {
         tokens -= cost;
         println!("You now have {} tokens.", tokens);
     }
+    Ok(())
 }
 
 pub fn total_cost(item_quantity: &str) -> Result<i32, ParseIntError> {

--- a/exercises/error_handling/errors4.rs
+++ b/exercises/error_handling/errors4.rs
@@ -1,8 +1,6 @@
 // errors4.rs
 // Make this test pass! Execute `rustlings hint errors4` for hints :)
 
-// I AM NOT DONE
-
 #[derive(PartialEq, Debug)]
 struct PositiveNonzeroInteger(u64);
 
@@ -14,7 +12,13 @@ enum CreationError {
 
 impl PositiveNonzeroInteger {
     fn new(value: i64) -> Result<PositiveNonzeroInteger, CreationError> {
-        Ok(PositiveNonzeroInteger(value as u64))
+        if value > 0{
+            Ok(PositiveNonzeroInteger(value as u64))
+        }else if value < 0{
+            Err(CreationError::Negative)
+        }else{
+            Err(CreationError::Zero)
+        }
     }
 }
 

--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -10,6 +10,7 @@ use std::error;
 use std::fmt;
 use std::num::ParseIntError;
 
+type Result<T, E> = std::result::Result<T, Box<dyn E>>;
 // TODO: update the return type of `main()` to make this compile.
 fn main() -> Result<(), ParseIntError> {
     let pretend_user_input = "42";
@@ -18,6 +19,17 @@ fn main() -> Result<(), ParseIntError> {
     Ok(())
 }
 
+// impl From<CreationError> for ParseIntError{
+//     fn from(e: CreationError) -> ParseIntError{
+//         return ParseIntError::CreationError(e);
+//     }
+// }
+
+// impl From<ParseIntError> for CreationError{
+// 	fn from(e: ParseIntError) -> CreationError{
+// 		return CreationError::ParseIntError(e);
+// 	}
+// }
 // Don't change anything below this line.
 
 #[derive(PartialEq, Debug)]
@@ -34,7 +46,7 @@ impl PositiveNonzeroInteger {
         match value {
             x if x < 0 => Err(CreationError::Negative),
             x if x == 0 => Err(CreationError::Zero),
-            x => Ok(PositiveNonzeroInteger(x as u64))
+            x => Ok(PositiveNonzeroInteger(x as u64)),
         }
     }
 }

--- a/exercises/functions/functions1.rs
+++ b/exercises/functions/functions1.rs
@@ -1,8 +1,8 @@
 // functions1.rs
 // Make me compile! Execute `rustlings hint functions1` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     call_me();
 }
+
+fn call_me() {}

--- a/exercises/functions/functions2.rs
+++ b/exercises/functions/functions2.rs
@@ -1,13 +1,11 @@
 // functions2.rs
 // Make me compile! Execute `rustlings hint functions2` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     call_me(3);
 }
 
-fn call_me(num:) {
+fn call_me(num: i32) {
     for i in 0..num {
         println!("Ring! Call number {}", i + 1);
     }

--- a/exercises/functions/functions3.rs
+++ b/exercises/functions/functions3.rs
@@ -1,10 +1,8 @@
 // functions3.rs
 // Make me compile! Execute `rustlings hint functions3` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
-    call_me();
+    call_me(9);
 }
 
 fn call_me(num: u32) {

--- a/exercises/functions/functions4.rs
+++ b/exercises/functions/functions4.rs
@@ -4,14 +4,12 @@
 // This store is having a sale where if the price is an even number, you get
 // 10 Rustbucks off, but if it's an odd number, it's 3 Rustbucks off.
 
-// I AM NOT DONE
-
 fn main() {
     let original_price = 51;
     println!("Your sale price is {}", sale_price(original_price));
 }
 
-fn sale_price(price: i32) -> {
+fn sale_price(price: i32) -> i32 {
     if is_even(price) {
         price - 10
     } else {

--- a/exercises/functions/functions5.rs
+++ b/exercises/functions/functions5.rs
@@ -1,13 +1,11 @@
 // functions5.rs
 // Make me compile! Execute `rustlings hint functions5` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let answer = square(3);
     println!("The answer is {}", answer);
 }
 
 fn square(num: i32) -> i32 {
-    num * num;
+    return (num * num);
 }

--- a/exercises/if/if1.rs
+++ b/exercises/if/if1.rs
@@ -1,13 +1,15 @@
 // if1.rs
 
-// I AM NOT DONE
-
 pub fn bigger(a: i32, b: i32) -> i32 {
     // Complete this function to return the bigger number!
     // Do not use:
     // - another function call
     // - additional variables
     // Execute `rustlings hint if1` for hints
+    if a > b {
+        return a;
+    }
+    return b;
 }
 
 // Don't mind this for now :)

--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -4,13 +4,13 @@
 // Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
 // Execute the command `rustlings hint if2` if you want a hint :)
 
-// I AM NOT DONE
-
 pub fn fizz_if_foo(fizzish: &str) -> &str {
     if fizzish == "fizz" {
         "foo"
+    } else if fizzish == "fuzz" {
+        "bar"
     } else {
-        1
+        "baz"
     }
 }
 

--- a/exercises/modules/modules1.rs
+++ b/exercises/modules/modules1.rs
@@ -1,10 +1,8 @@
 // modules1.rs
 // Make me compile! Execute `rustlings hint modules1` for hints :)
 
-// I AM NOT DONE
-
 mod sausage_factory {
-    fn make_sausage() {
+    pub fn make_sausage() {
         println!("sausage!");
     }
 }

--- a/exercises/modules/modules2.rs
+++ b/exercises/modules/modules2.rs
@@ -1,11 +1,8 @@
 // modules2.rs
 // Make me compile! Execute `rustlings hint modules2` for hints :)
-
-// I AM NOT DONE
-
 mod delicious_snacks {
-    use self::fruits::PEAR as fruit;
-    use self::veggies::CUCUMBER as veggie;
+    pub use self::fruits::PEAR as fruit;
+    pub use self::veggies::CUCUMBER as veggie;
 
     mod fruits {
         pub const PEAR: &'static str = "Pear";

--- a/exercises/move_semantics/move_semantics1.rs
+++ b/exercises/move_semantics/move_semantics1.rs
@@ -1,12 +1,10 @@
 // move_semantics1.rs
 // Make me compile! Execute `rustlings hint move_semantics1` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let vec0 = Vec::new();
 
-    let vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec(vec0);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 

--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -2,27 +2,23 @@
 // Make me compile without changing line 13!
 // Execute `rustlings hint move_semantics2` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let vec0 = Vec::new();
-
-    let mut vec1 = fill_vec(vec0);
+    let copy_vec0 = vec0.clone();
+    let mut vec1 = fill_vec(copy_vec0);
 
     // Do not change the following line!
     println!("{} has length {} content `{:?}`", "vec0", vec0.len(), vec0);
 
     vec1.push(88);
 
-    println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
+    println!("{} has length {} content `{:?}`", "vec1", vec0.len(), vec0);
 }
 
 fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
     let mut vec = vec;
-
     vec.push(22);
     vec.push(44);
     vec.push(66);
-
     vec
 }

--- a/exercises/move_semantics/move_semantics3.rs
+++ b/exercises/move_semantics/move_semantics3.rs
@@ -3,12 +3,8 @@
 // (no lines with multiple semicolons necessary!)
 // Execute `rustlings hint move_semantics3` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
-    let vec0 = Vec::new();
-
-    let mut vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec();
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 
@@ -17,7 +13,9 @@ fn main() {
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 }
 
-fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
+fn fill_vec() -> Vec<i32> {
+    let mut vec = Vec::new();
+
     vec.push(22);
     vec.push(44);
     vec.push(66);

--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -4,12 +4,8 @@
 // freshly created vector from fill_vec to its caller.
 // Execute `rustlings hint move_semantics4` for hints!
 
-// I AM NOT DONE
-
 fn main() {
-    let vec0 = Vec::new();
-
-    let mut vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec();
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 
@@ -20,7 +16,7 @@ fn main() {
 
 // `fill_vec()` no longer takes `vec: Vec<i32>` as argument
 fn fill_vec() -> Vec<i32> {
-    let mut vec = vec;
+    let mut vec: Vec<i32> = Vec::new();
 
     vec.push(22);
     vec.push(44);

--- a/exercises/move_semantics/move_semantics5.rs
+++ b/exercises/move_semantics/move_semantics5.rs
@@ -3,13 +3,11 @@
 // lines in `main()`.
 // Execute `rustlings hint move_semantics5` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let mut x = 100;
     let y = &mut x;
-    let z = &mut *y;
     *y += 100;
+    let z = &mut *y;
     *z += 1000;
     assert_eq!(x, 1200);
 }

--- a/exercises/primitive_types/primitive_types1.rs
+++ b/exercises/primitive_types/primitive_types1.rs
@@ -2,8 +2,6 @@
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
 
-// I AM NOT DONE
-
 fn main() {
     // Booleans (`bool`)
 
@@ -12,7 +10,7 @@ fn main() {
         println!("Good morning!");
     }
 
-    let // Finish the rest of this line like the example! Or make it be false!
+    let is_evening = true; // Finish the rest of this line like the example! Or make it be false!
     if is_evening {
         println!("Good evening!");
     }

--- a/exercises/primitive_types/primitive_types2.rs
+++ b/exercises/primitive_types/primitive_types2.rs
@@ -2,8 +2,6 @@
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
 
-// I AM NOT DONE
-
 fn main() {
     // Characters (`char`)
 
@@ -16,7 +14,7 @@ fn main() {
         println!("Neither alphabetic nor numeric!");
     }
 
-    let // Finish this line like the example! What's your favorite character?
+    let your_character = 'u';// Finish this line like the example! What's your favorite character?
     // Try a letter, try a number, try a special character, try a character
     // from a different language than your own, try an emoji!
     if your_character.is_alphabetic() {

--- a/exercises/primitive_types/primitive_types3.rs
+++ b/exercises/primitive_types/primitive_types3.rs
@@ -2,10 +2,8 @@
 // Create an array with at least 100 elements in it where the ??? is.
 // Execute `rustlings hint primitive_types3` for hints!
 
-// I AM NOT DONE
-
 fn main() {
-    let a = ???
+    let a = [1,2,4];
 
     if a.len() >= 100 {
         println!("Wow, that's a big array!");

--- a/exercises/primitive_types/primitive_types4.rs
+++ b/exercises/primitive_types/primitive_types4.rs
@@ -2,13 +2,11 @@
 // Get a slice out of Array a where the ??? is so that the test passes.
 // Execute `rustlings hint primitive_types4` for hints!!
 
-// I AM NOT DONE
-
 #[test]
 fn slice_out_of_array() {
     let a = [1, 2, 3, 4, 5];
-
-    let nice_slice = ???
+    let n = a.len();
+    let nice_slice = &a[1..n-1];
 
     assert_eq!([2, 3, 4], nice_slice)
 }

--- a/exercises/primitive_types/primitive_types5.rs
+++ b/exercises/primitive_types/primitive_types5.rs
@@ -2,11 +2,9 @@
 // Destructure the `cat` tuple so that the println will work.
 // Execute `rustlings hint primitive_types5` for hints!
 
-// I AM NOT DONE
-
 fn main() {
     let cat = ("Furry McFurson", 3.5);
-    let /* your pattern here */ = cat;
+    let (name,age) = cat;
 
     println!("{} is {} years old.", name, age);
 }

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -3,13 +3,11 @@
 // You can put the expression for the second element where ??? is so that the test passes.
 // Execute `rustlings hint primitive_types6` for hints!
 
-// I AM NOT DONE
-
 #[test]
 fn indexing_tuple() {
     let numbers = (1, 2, 3);
     // Replace below ??? with the tuple indexing syntax.
-    let second = ???;
+    let second = numbers.1;
 
     assert_eq!(2, second,
         "This is not the 2nd number in the tuple!")

--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -7,8 +7,6 @@
 // more than 40 at once, each apple only costs 1! Write a function that calculates
 // the price of an order of apples given the order amount. No hints this time!
 
-// I AM NOT DONE
-
 // Put your function here!
 // fn ..... {
 
@@ -22,4 +20,12 @@ fn verify_test() {
     assert_eq!(70, price1);
     assert_eq!(80, price2);
     assert_eq!(65, price3);
+}
+
+fn calculate_apple_price(num: i32) -> i32 {
+    if num > 40 {
+        return num;
+    } else {
+        return num * 2;
+    }
 }

--- a/exercises/quiz2.rs
+++ b/exercises/quiz2.rs
@@ -7,8 +7,6 @@
 // you think each value is. That is, add either `string_slice` or `string`
 // before the parentheses on each line. If you're right, it will compile!
 
-// I AM NOT DONE
-
 fn string_slice(arg: &str) {
     println!("{}", arg);
 }
@@ -17,14 +15,14 @@ fn string(arg: String) {
 }
 
 fn main() {
-    ???("blue");
-    ???("red".to_string());
-    ???(String::from("hi"));
-    ???("rust is fun!".to_owned());
-    ???("nice weather".into());
-    ???(format!("Interpolation {}", "Station"));
-    ???(&String::from("abc")[0..1]);
-    ???("  hello there ".trim());
-    ???("Happy Monday!".to_string().replace("Mon", "Tues"));
-    ???("mY sHiFt KeY iS sTiCkY".to_lowercase());
+    string_slice("blue");
+    string("red".to_string());
+    string(String::from("hi"));
+    string("rust is fun!".to_owned());
+    string("nice weather".into());
+    string(format!("Interpolation {}", "Station"));
+    string_slice(&String::from("abc")[0..1]);
+    string_slice("  hello there ".trim());
+    string("Happy Monday!".to_string().replace("Mon", "Tues"));
+    string("mY sHiFt KeY iS sTiCkY".to_lowercase());
 }

--- a/exercises/strings/strings1.rs
+++ b/exercises/strings/strings1.rs
@@ -2,13 +2,11 @@
 // Make me compile without changing the function signature!
 // Execute `rustlings hint strings1` for hints ;)
 
-// I AM NOT DONE
-
 fn main() {
     let answer = current_favorite_color();
     println!("My current favorite color is {}", answer);
 }
 
 fn current_favorite_color() -> String {
-    "blue"
+    "blue".to_string()
 }

--- a/exercises/strings/strings2.rs
+++ b/exercises/strings/strings2.rs
@@ -2,11 +2,9 @@
 // Make me compile without changing the function signature!
 // Execute `rustlings hint strings2` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let word = String::from("green"); // Try not changing this line :)
-    if is_a_color_word(word) {
+    if is_a_color_word(&word) {
         println!("That is a color word I know!");
     } else {
         println!("That is not a color word I know.");

--- a/exercises/structs/structs1.rs
+++ b/exercises/structs/structs1.rs
@@ -1,13 +1,13 @@
+//
 // structs1.rs
 // Address all the TODOs to make the tests pass!
 
-// I AM NOT DONE
-
 struct ColorClassicStruct {
-    // TODO: Something goes here
+    name: String,
+    hex: String,
 }
 
-struct ColorTupleStruct(/* TODO: Something goes here */);
+struct ColorTupleStruct(String,String);
 
 #[derive(Debug)]
 struct UnitStruct;
@@ -19,7 +19,10 @@ mod tests {
     #[test]
     fn classic_c_structs() {
         // TODO: Instantiate a classic c struct!
-        // let green =
+        let green = ColorClassicStruct {
+            name: String::from("green"),
+            hex: String::from("#00FF00"),
+        };
 
         assert_eq!(green.name, "green");
         assert_eq!(green.hex, "#00FF00");
@@ -28,7 +31,7 @@ mod tests {
     #[test]
     fn tuple_structs() {
         // TODO: Instantiate a tuple struct!
-        // let green =
+        let green = ColorTupleStruct(String::from("green"), String::from("#00FF00"));
 
         assert_eq!(green.0, "green");
         assert_eq!(green.1, "#00FF00");
@@ -37,7 +40,7 @@ mod tests {
     #[test]
     fn unit_structs() {
         // TODO: Instantiate a unit struct!
-        // let unit_struct =
+        let unit_struct = UnitStruct;
         let message = format!("{:?}s are fun!", unit_struct);
 
         assert_eq!(message, "UnitStructs are fun!");

--- a/exercises/structs/structs2.rs
+++ b/exercises/structs/structs2.rs
@@ -1,8 +1,6 @@
 // structs2.rs
 // Address all the TODOs to make the tests pass!
 
-// I AM NOT DONE
-
 #[derive(Debug)]
 struct Order {
     name: String,
@@ -34,7 +32,9 @@ mod tests {
     fn your_order() {
         let order_template = create_order_template();
         // TODO: Create your own order using the update syntax and template above!
-        // let your_order =
+        let mut your_order = create_order_template();
+        your_order.name = String::from("Hacker in Rust");
+        your_order.count = 1;
         assert_eq!(your_order.name, "Hacker in Rust");
         assert_eq!(your_order.year, order_template.year);
         assert_eq!(your_order.made_by_phone, order_template.made_by_phone);

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -4,8 +4,6 @@
 // Make the code compile and the tests pass!
 // If you have issues execute `rustlings hint structs3`
 
-// I AM NOT DONE
-
 #[derive(Debug)]
 struct Package {
     sender_country: String,
@@ -16,7 +14,7 @@ struct Package {
 impl Package {
     fn new(sender_country: String, recipient_country: String, weight_in_grams: i32) -> Package {
         if weight_in_grams <= 0 {
-            // Something goes here...
+            panic!("weight cannot be in negative")
         } else {
             return Package {
                 sender_country,
@@ -26,12 +24,12 @@ impl Package {
         }
     }
 
-    fn is_international(&self) -> ??? {
-        // Something goes here...
+    fn is_international(&self) -> bool {
+        self.sender_country != self.recipient_country
     }
 
-    fn get_fees(&self, cents_per_gram: i32) -> ??? {
-        // Something goes here...
+    fn get_fees(&self, cents_per_gram: i32) -> i32 {
+        self.weight_in_grams * cents_per_gram
     }
 }
 
@@ -73,7 +71,7 @@ mod tests {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Spain");
 
-        let cents_per_gram = ???;
+        let cents_per_gram = 3;
 
         let package = Package::new(sender_country, recipient_country, 1500);
 

--- a/exercises/variables/variables1.rs
+++ b/exercises/variables/variables1.rs
@@ -6,9 +6,7 @@
 // even after you already figured it out. If you got everything working and
 // feel ready for the next exercise, remove the `I AM NOT DONE` comment below.
 
-// I AM NOT DONE
-
 fn main() {
-    x = 5;
+    let x = 5;
     println!("x has the value {}", x);
 }

--- a/exercises/variables/variables2.rs
+++ b/exercises/variables/variables2.rs
@@ -1,10 +1,8 @@
 // variables2.rs
 // Make me compile! Execute the command `rustlings hint variables2` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
-    let x;
+    let x = 10;
     if x == 10 {
         println!("Ten!");
     } else {

--- a/exercises/variables/variables3.rs
+++ b/exercises/variables/variables3.rs
@@ -1,10 +1,8 @@
 // variables3.rs
 // Make me compile! Execute the command `rustlings hint variables3` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
-    let x = 3;
+    let mut x = 3;
     println!("Number {}", x);
     x = 5; // don't change this line
     println!("Number {}", x);

--- a/exercises/variables/variables4.rs
+++ b/exercises/variables/variables4.rs
@@ -1,9 +1,8 @@
 // variables4.rs
 // Make me compile! Execute the command `rustlings hint variables4` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
     let x: i32;
+    x = 5;
     println!("Number {}", x);
 }

--- a/exercises/variables/variables5.rs
+++ b/exercises/variables/variables5.rs
@@ -1,11 +1,9 @@
 // variables5.rs
 // Make me compile! Execute the command `rustlings hint variables5` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
     let number = "T-H-R-E-E"; // don't change this line
     println!("Spell a Number : {}", number);
-    number = 3;
+    let number = 3;
     println!("Number plus two is : {}", number + 2);
 }

--- a/exercises/variables/variables6.rs
+++ b/exercises/variables/variables6.rs
@@ -1,9 +1,7 @@
 // variables6.rs
 // Make me compile! Execute the command `rustlings hint variables6` if you want a hint :)
 
-// I AM NOT DONE
-
-const NUMBER = 3;
+const NUMBER: i32 = 3;
 fn main() {
     println!("Number {}", NUMBER);
 }


### PR DESCRIPTION
Rustlings - gives exercises with minor errors for us to fix and learn.

Originally the error I was getting was

```
the trait `From<CreationError>` is not implemented for `ParseIntError`
```

To fix this I tried:

```
impl From<CreationError> for ParseIntError{
    fn from(e: CreationError) -> ParseIntError{
        return ParseIntError::CreationError(e);
    }
}

impl From<ParseIntError> for CreationError{
	fn from(e: ParseIntError) -> CreationError{
		return CreationError::ParseIntError(e);
	}
}
```

This created more errors, so I tried
```
type Result<T, E> = std::result::Result<T, Box<dyn E>>;
```

This didn't help as well.

My guess is that I am making an error in the syntax of the boxed error. 🤔 

Any suggestion or lead would help.

I was referring:
https://doc.rust-lang.org/stable/rust-by-example/error/multiple_error_types/boxing_errors.html
https://stackoverflow.com/questions/59214210/rust-implement-trait-from-for-associated-type-error
https://stackoverflow.com/questions/52651566/associated-type-not-found-in-the-current-scope-when-returning-from-pattern-match