### PR TITLE
Change &mut *y to &mut x

### DIFF
--- a/exercises/move_semantics/move_semantics5.rs
+++ b/exercises/move_semantics/move_semantics5.rs
@@ -8,7 +8,7 @@
 fn main() {
     let mut x = 100;
     let y = &mut x;
-    let z = &mut *y;
+    let z = &mut x;
     *y += 100;
     *z += 1000;
     assert_eq!(x, 1200);


### PR DESCRIPTION
Instead of having to explain why 
```rs
let mut x = 100; 
let y = &mut x;
let mut z_owned = *y;
let z = &mut z_owned;
*y += 100;
*z += 1000;
```
and 
```rs
let mut x = 100; 
let y = &mut x;
let z = &mut *y;
*y += 100;
*z += 1000;
```
are different, you still get the point across about having only one mutable reference.
As it stands, this exercise does too much (dereferencing and having only one mutable reference), and by doing so confuses people.

Example of someone being confused by this:
<https://discord.com/channels/273534239310479360/273541522815713281/872689531428692040>
(this is in the rust community discord <https://discord.com/invite/rust-lang-community>) 