### PR TITLE
fix(try_from_into): Hint at `&str` to `Box<dyn std::error:Error>` conversion.

### DIFF
--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -19,9 +19,14 @@ struct Color {
 // You need to create an implementation for a tuple of three integers,
 // an array of three integers and a slice of integers.
 //
-// Note that the implementation for tuple and array will be checked at compile time,
+// Note that correct RGB color values must be integers in the 0..=255 range.
+//
+// Also note that the implementation for tuple and array will be checked at compile time,
 // but the slice implementation needs to check the slice length!
-// Also note that correct RGB color values must be integers in the 0..=255 range.
+// A little hint:
+// `Box<dyn Error>` implements the `From` trait over `&str`.
+// This means you can call `"...".into()` to convert
+// and box your custom error to return as `Result::Err`.
 
 // Tuple implementation
 impl TryFrom<(i16, i16, i16)> for Color {


### PR DESCRIPTION
Proposal to improve UX at `try_from_into`.

Fixes https://github.com/rust-lang/rustlings/issues/816

Up for discussion:
- Is the hint too explicit?