### PR TITLE
Fix inconsistent wording

### DIFF
--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -4,7 +4,7 @@
 // - Functions
 
 // Mary is buying apples. One apple usually costs 2 Rustbucks, but if you buy
-// more than 40 at once, each apple only costs 1! Write a function that calculates
+// 40 or more at once, each apple only costs 1! Write a function that calculates
 // the price of an order of apples given the quantity bought. No hints this time!
 
 // I AM NOT DONE


### PR DESCRIPTION
The second test expects the function to return 80 when there is an order of 40 apples, but the current wording implies returning 40 will pass as well