### PR TITLE
Updated move_semantics2.rs

### DIFF
--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -7,7 +7,7 @@
 fn main() {
     let vec0 = Vec::new();
 
-    let mut vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec(&vec0);
 
     // Do not change the following line!
     println!("{} has length {} content `{:?}`", "vec0", vec0.len(), vec0);
@@ -17,9 +17,8 @@ fn main() {
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 }
 
-fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
-    let mut vec = vec;
-
+fn fill_vec(v:& Vec<i32>) -> Vec<i32> {
+    let mut vec = v.clone();
     vec.push(22);
     vec.push(44);
     vec.push(66);


### PR DESCRIPTION
In the previous code, the address which was stored in vec was passed, so it was showing immutable but instead of we can pass the address of vec and can clone that array into another one.