### PR TITLE
fix(exercise): typo

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -133,7 +133,7 @@ path = "{}.rs""#,
                     "Failed to write 📎 Clippy 📎 Cargo.toml file."
                 };
                 fs::write(CLIPPY_CARGO_TOML_PATH, cargo_toml).expect(cargo_toml_error_msg);
-                // To support the ability to run the clipy exercises, build
+                // To support the ability to run the clippy exercises, build
                 // an executable, in addition to running clippy. With a
                 // compilation failure, this would silently fail. But we expect
                 // clippy to reflect the same failure while compiling later.


### PR DESCRIPTION
Hi, I found and fixed typos in `src/exercise.rs`. btw, thanks for the great job rustlings have done.