### PR TITLE
fix(advanced_errors): Fix unit test unreachable_patterns warning

### DIFF
--- a/exercises/advanced_errors/advanced_errs2.rs
+++ b/exercises/advanced_errors/advanced_errs2.rs
@@ -64,7 +64,6 @@ impl Display for ParseClimateError {
         match self {
             NoCity => write!(f, "no city name"),
             ParseFloat(e) => write!(f, "error parsing temperature: {}", e),
-            _ => write!(f, "unhandled error!"),
         }
     }
 }


### PR DESCRIPTION
After the code is perfected, the following warnings will appear when the unit test is executed:

```
  --> src/main.rs:72:13
   |
72 |             _ => write!(f, "unhandled error!"),
   |             ^
   |
   = note: `#[warn(unreachable_patterns)]` on by default
```

It is recommended to delete this line of code.