### PR TITLE
fix(structs3.rs): assigned value to cents_per_gram in test

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -73,7 +73,7 @@ mod tests {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Spain");
 
-        let cents_per_gram = ???;
+        let cents_per_gram = 3;
 
         let package = Package::new(sender_country, recipient_country, 1500);
 


### PR DESCRIPTION
Intended to simplify the lesson by removing the need to figure out what the value is meant to be based on the test.

Previous commits (https://github.com/rust-lang/rustlings/commit/9ca08b8f2b09366e97896a4a8cf9ff3bb4d54380 and https://github.com/rust-lang/rustlings/commit/114b54cbdb977234b39e5f180d937c14c78bb8b2#diff-ce1c232ff0ddaff909351bb84cb5bff423b5b9e04f21fd4db7ffe443e598e174) removed the mathematical complexity, and I feel this addition is a needed change to further streamline the exercise.