### PR TITLE
fix(iterators1.rs): corrected a 'mismatched types' error

### DIFF
--- a/exercises/standard_library_types/iterators1.rs
+++ b/exercises/standard_library_types/iterators1.rs
@@ -15,10 +15,10 @@ fn main () {
 
     let mut my_iterable_fav_fruits = ???;   // TODO: Step 1
 
-    assert_eq!(my_iterable_fav_fruits.next(), Some(&"banana"));
+    assert_eq!(my_iterable_fav_fruits.next(), Some("banana"));
     assert_eq!(my_iterable_fav_fruits.next(), ???);     // TODO: Step 2
-    assert_eq!(my_iterable_fav_fruits.next(), Some(&"avocado"));
+    assert_eq!(my_iterable_fav_fruits.next(), Some("avocado"));
     assert_eq!(my_iterable_fav_fruits.next(), ???);     // TODO: Step 2.1
-    assert_eq!(my_iterable_fav_fruits.next(), Some(&"raspberry"));
+    assert_eq!(my_iterable_fav_fruits.next(), Some("raspberry"));
     assert_eq!(my_iterable_fav_fruits.next(), ???);     // TODO: Step 3
 }


### PR DESCRIPTION
The values in the vector are of type &str. But within the tests, the additional & is changing the test strings to type &&str resulting in error E0308 (mismatched types).

error[E0308]: mismatched types
  --> exercises/standard_library_types/iterators1.rs:18:5
   |
18 |     assert_eq!(my_iterable_fav_fruits.next(), Some(&"banana"));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `str`, found `&str`
   |
   = note: expected enum `Option<&str>`
              found enum `Option<&&str>`
   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)