### PR TITLE
fix(clippy1): Trigger approx_constant lint rule instead of downgraded float_cmp.

### DIFF
--- a/exercises/clippy/clippy1.rs
+++ b/exercises/clippy/clippy1.rs
@@ -8,10 +8,16 @@
 
 // I AM NOT DONE
 
+use std::f32;
+
 fn main() {
-    let x = 1.2331f64;
-    let y = 1.2332f64;
-    if y != x {
-        println!("Success!");
-    }
+    let pi = 3.14f32;
+    let radius = 5.00f32;
+
+    let area = pi * f32::powi(radius, 2);
+
+    println!(
+        "The area of a circle with radius {:.2} is {:.5}!",
+        radius, area
+    )
 }

--- a/info.toml
+++ b/info.toml
@@ -906,15 +906,15 @@ name = "clippy1"
 path = "exercises/clippy/clippy1.rs"
 mode = "clippy"
 hint = """
-Not every floating point value can be represented exactly in binary values in
-memory. Take a look at the description of 
-https://doc.rust-lang.org/stable/std/primitive.f32.html
-When using the binary compare operators with floating points you won't compare
-the floating point values but the binary representation in memory. This is 
-usually not what you would like to do. 
+Rust stores the highest precision version of any long or inifinite precision
+mathematical constants in the rust standard library.
+https://doc.rust-lang.org/stable/std/f32/consts/index.html
+
+We may be tempted to use our own approximations for certain mathematical constants,
+but clippy recognizes those imprecise mathematical constants as a source of 
+potential error.
 See the suggestions of the clippy warning in compile output and use the
-machine epsilon value...
-https://doc.rust-lang.org/stable/std/primitive.f32.html#associatedconstant.EPSILON"""
+appropriate replacement constant from std::f32::consts..."""
 
 [[exercises]]
 name = "clippy2"


### PR DESCRIPTION
This PR fixes clippy1 for newer versions of Rust. When ran on rustc v1.57.0, clippy1 would pass without any changes. This was because the lint rule that clippy1 relies on (`float_cmp`) was [recently downgraded](https://github.com/rust-lang/rust-clippy/commit/3ad3c51cee1d36d01fd145d6a45e33cff2bc12a1#diff-5d66e1251bbfd7bc6f38d570e3bbe87424568fc8535678b654b9eda155da44a6).

This PR changes clippy1 and its hint to use a different lint rule: `approx_constant`. See [`approx_constant` lint rule](https://rust-lang.github.io/rust-clippy/master/#approx_constant).

To satisfy clippy for this exercise, users must change line 14: 
```rust
let pi = 3.14f32;
```
to 
```rust
let pi = f32::consts::PI;
```
closes #888