### PR TITLE
fix(structs3): Add panic! statement into structs3

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -15,7 +15,7 @@ struct Package {
 impl Package {
     fn new(sender_country: String, recipient_country: String, weight_in_grams: i32) -> Package {
         if weight_in_grams <= 0 {
-            // Something goes here...
+            panic!("Can not ship a weightless package.")
         } else {
             return Package {sender_country, recipient_country, weight_in_grams};
         }


### PR DESCRIPTION
Adds panic! statement into Structs3 instead of requiring users to implement themselves. New users following along with Rust Book likely will not be exposed to panic! statements as discussed in issue #685.

closes #685