### PR TITLE
Fix rust analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "kernel32-sys"
@@ -547,11 +556,13 @@ dependencies = [
  "assert_cmd",
  "console 0.7.7",
  "glob",
+ "home",
  "indicatif",
  "notify",
  "predicates",
  "regex",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -578,18 +589,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.129"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.129"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -598,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "rustlings"
 version = "4.6.0"
-authors = [
-	"anastasie <ana@ana.st>",
-	"Carol (Nichols || Goulding) <carol.nichols@gmail.com>",
-]
+authors = ["anastasie <ana@ana.st>", "Carol (Nichols || Goulding) <carol.nichols@gmail.com>"]
 edition = "2021"
 default-run = "rustlings"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "rustlings"
 version = "4.6.0"
-authors = ["anastasie <ana@ana.st>", "Carol (Nichols || Goulding) <carol.nichols@gmail.com>"]
+authors = [
+	"anastasie <ana@ana.st>",
+	"Carol (Nichols || Goulding) <carol.nichols@gmail.com>",
+]
 edition = "2021"
+default-run = "rustlings"
 
 [dependencies]
 argh = "0.1.4"
@@ -11,11 +15,18 @@ console = "0.7.7"
 notify = "4.0.15"
 toml = "0.4.10"
 regex = "1.1.6"
-serde = {version = "1.0.10", features = ["derive"]}
+serde = { version = "1.0.133", features = ["derive"] }
+glob = "0.3.0"
+serde_json = "1.0.74"
+home = "0.5.3"
 
 [[bin]]
 name = "rustlings"
 path = "src/main.rs"
+
+[[bin]]
+name = "fix-rust-analyzer"
+path = "src/fix-rust-analyzer.rs"
 
 [dev-dependencies]
 assert_cmd = "0.11.0"

--- a/src/fix-rust-analyzer.rs
+++ b/src/fix-rust-analyzer.rs
@@ -1,0 +1,72 @@
+use glob::glob;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct RustProject {
+    sysroot_src: String,
+    crates: Vec<Crate>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Crate {
+    root_module: String,
+    edition: String,
+    deps: Vec<String>,
+}
+
+impl RustProject {
+    fn new() -> RustProject {
+        RustProject {
+            sysroot_src: RustProject::get_sysroot_src(),
+            crates: Vec::new(),
+        }
+    }
+
+    fn get_sysroot_src() -> String {
+        let mut sysroot_src = home::rustup_home()
+            .expect("Can't find Rustup... aborting")
+            .to_string_lossy()
+            .to_string();
+
+        use std::process::Command;
+        let output = Command::new("rustup")
+            .arg("default")
+            .output()
+            .expect("Failed to get rustup default toolchain");
+
+        let toolchain = String::from_utf8_lossy(&output.stdout).to_string();
+
+        sysroot_src += "/toolchains/";
+        sysroot_src += toolchain
+            .split_once(' ')
+            .expect("Malformed default toolchain path")
+            .0;
+        sysroot_src += "/lib/rustlib/src/rust/library";
+        println!("{}", sysroot_src);
+        sysroot_src
+    }
+}
+
+fn main() {
+    let mut project = RustProject::new();
+    for e in glob("./exercises/**/*").expect("Glob failed to read pattern") {
+        let path = e
+            .expect("Unable to extract path")
+            .to_string_lossy()
+            .to_string();
+        if let Some((_, ext)) = path.split_once(".") {
+            if ext == "rs" {
+                project.crates.push(Crate {
+                    deps: Vec::new(),
+                    edition: "2021".to_string(),
+                    root_module: path,
+                })
+            }
+        }
+    }
+    std::fs::write(
+        "./rust-project.json",
+        serde_json::to_vec(&project).expect("Failed to serialize to JSON"),
+    )
+    .expect("Failed to write file");
+}


### PR DESCRIPTION
Small binary to fix `rustlings` to work with rust-analyzer.

It generates a `rust-project.json` and links to the default `rustup` toolchain. If rustup doesn't exist it will fail.

Simply run `cargo run --bin fix-rust-analyzer`

Feel free to do what you like with it, or if you want me to include it in the `rustlings` binary when a `rust-analyzer` exists just let me know.

And thanks so much for `The Rust Book` and `rustlings`, really great learning resources.