### PR TITLE
fix(iterators3): insert todo!() into divide() to compile without error

### DIFF
--- a/exercises/standard_library_types/iterators3.rs
+++ b/exercises/standard_library_types/iterators3.rs
@@ -22,7 +22,9 @@ pub struct NotDivisibleError {
 
 // Calculate `a` divided by `b` if `a` is evenly divisible by `b`.
 // Otherwise, return a suitable error.
-pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {}
+pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {
+    todo!();
+}
 
 // Complete the function and return a value of the correct type so the test passes.
 // Desired output: Ok([1, 11, 1426, 3])


### PR DESCRIPTION
Add `todo!()` macro into `divide()` function to be able to compile without error.
We can get the following compile error without `todo!()` macro, and it is not important for this exercise to fix this.
Adding this macro, We can focus on passing the tests.

```
$ rustlings run iterators3
! Compiling of exercises/standard_library_types/iterators3.rs failed! Please try again. Here's the output:
error[E0308]: mismatched types
  --> exercises/standard_library_types/iterators3.rs:25:34
   |
25 | pub fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {}
   |        ------                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found `()`
   |        |
   |        implicitly returns `()` as its body has no tail or `return` expression
   |
   = note:   expected enum `std::result::Result<i32, DivisionError>`
           found unit type `()`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
```