### PR TITLE
Advanced review on several topics

### DIFF
--- a/exercises/enums/enums1.rs
+++ b/exercises/enums/enums1.rs
@@ -1,12 +1,8 @@
 // enums1.rs
 // Make me compile! Execute `rustlings hint enums1` for hints!
 
-// I AM NOT DONE
-
 #[derive(Debug)]
-enum Message {
-    // TODO: define a few types of messages as used below
-}
+enum Message { Quit,Echo,Move,ChangeColor }
 
 fn main() {
     println!("{:?}", Message::Quit);

--- a/exercises/enums/enums2.rs
+++ b/exercises/enums/enums2.rs
@@ -5,7 +5,10 @@
 
 #[derive(Debug)]
 enum Message {
-    // TODO: define the different variants used below
+    Move { x:i32, y:i32 },
+    Echo(String),
+    ChangeColor(u8,u8,u8),
+    Quit
 }
 
 impl Message {
@@ -16,7 +19,7 @@ impl Message {
 
 fn main() {
     let messages = [
-        Message::Move { x: 10, y: 30 },
+        Message::Move { x: 10, y: 30 }, // ### Assimilate :: as namespace operator for variants
         Message::Echo(String::from("hello world")),
         Message::ChangeColor(200, 255, 255),
         Message::Quit,

--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -4,7 +4,10 @@
 // I AM NOT DONE
 
 enum Message {
-    // TODO: implement the message variant types based on their usage below
+    ChangeColor((u8,u8,u8)),
+    Echo(String),
+    Move(Point),
+    Quit
 }
 
 struct Point {
@@ -36,7 +39,12 @@ impl State {
     }
 
     fn process(&mut self, message: Message) {
-        // TODO: create a match expression to process the different message variants
+        match message {  // ### Using self is a thing. And again, don't forget namespacing with variants
+            Message::ChangeColor(inp) => self.change_color(inp),
+            Message::Echo(s) => self.echo(s),
+            Message::Move(pt) => self.move_position(pt), 
+            Message::Quit => self.quit(),
+        }
     }
 }
 

--- a/exercises/if/if1.rs
+++ b/exercises/if/if1.rs
@@ -3,6 +3,7 @@
 // I AM NOT DONE
 
 pub fn bigger(a: i32, b: i32) -> i32 {
+    if ( a > b ) { a } else { b }  // ### Recall the expr|stmt syntax and how if are expr in RUST.
     // Complete this function to return the bigger number!
     // Do not use:
     // - another function call

--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -4,14 +4,15 @@
 // Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
 // Execute the command `rustlings hint if2` if you want a hint :)
 
-// I AM NOT DONE
-
 pub fn fizz_if_foo(fizzish: &str) -> &str {
-    if fizzish == "fizz" {
+    return if fizzish == "fizz" {
         "foo"
-    } else {
-        1
+    } else if fizzish == "fuzz" { 
+        "bar"
     }
+    else { 
+        "baz"
+    };
 }
 
 // No test changes needed!

--- a/exercises/move_semantics/move_semantics1.rs
+++ b/exercises/move_semantics/move_semantics1.rs
@@ -6,10 +6,12 @@
 fn main() {
     let vec0 = Vec::new();
 
-    let vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec(vec0);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 
+    // ### Note that mutability is an attribute of names, thus when a value is moved mutability may
+    // change
     vec1.push(88);
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);

--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -2,12 +2,10 @@
 // Make me compile without changing line 13!
 // Execute `rustlings hint move_semantics2` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let vec0 = Vec::new();
 
-    let mut vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec(vec0.clone());
 
     // Do not change the following line!
     println!("{} has length {} content `{:?}`", "vec0", vec0.len(), vec0);

--- a/exercises/move_semantics/move_semantics3.rs
+++ b/exercises/move_semantics/move_semantics3.rs
@@ -3,8 +3,6 @@
 // (no lines with multiple semicolons necessary!)
 // Execute `rustlings hint move_semantics3` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let vec0 = Vec::new();
 
@@ -17,7 +15,7 @@ fn main() {
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 }
 
-fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
+fn fill_vec(mut vec: Vec<i32>) -> Vec<i32> {
     vec.push(22);
     vec.push(44);
     vec.push(66);

--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -4,12 +4,8 @@
 // freshly created vector from fill_vec to its caller.
 // Execute `rustlings hint move_semantics4` for hints!
 
-// I AM NOT DONE
-
 fn main() {
-    let vec0 = Vec::new();
-
-    let mut vec1 = fill_vec(vec0);
+    let mut vec1 = fill_vec();
 
     println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
 
@@ -20,7 +16,7 @@ fn main() {
 
 // `fill_vec()` no longer takes `vec: Vec<i32>` as argument
 fn fill_vec() -> Vec<i32> {
-    let mut vec = vec;
+    let mut vec = Vec::new();
 
     vec.push(22);
     vec.push(44);

--- a/exercises/move_semantics/move_semantics5.rs
+++ b/exercises/move_semantics/move_semantics5.rs
@@ -8,8 +8,8 @@
 fn main() {
     let mut x = 100;
     let y = &mut x;
-    let z = &mut x;
     *y += 100;
+    let z = &mut x;
     *z += 1000;
     assert_eq!(x, 1200);
 }

--- a/exercises/primitive_types/primitive_types1.rs
+++ b/exercises/primitive_types/primitive_types1.rs
@@ -2,8 +2,6 @@
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
 
-// I AM NOT DONE
-
 fn main() {
     // Booleans (`bool`)
 
@@ -12,7 +10,7 @@ fn main() {
         println!("Good morning!");
     }
 
-    let // Finish the rest of this line like the example! Or make it be false!
+    let is_evening : bool = false; // Finish the rest of this line like the example! Or make it be false!
     if is_evening {
         println!("Good evening!");
     }

--- a/exercises/primitive_types/primitive_types2.rs
+++ b/exercises/primitive_types/primitive_types2.rs
@@ -2,8 +2,6 @@
 // Fill in the rest of the line that has code missing!
 // No hints, there's no tricks, just get used to typing these :)
 
-// I AM NOT DONE
-
 fn main() {
     // Characters (`char`)
 
@@ -16,7 +14,7 @@ fn main() {
         println!("Neither alphabetic nor numeric!");
     }
 
-    let // Finish this line like the example! What's your favorite character?
+    let your_character : char = 'x';// Finish this line like the example! What's your favorite character?
     // Try a letter, try a number, try a special character, try a character
     // from a different language than your own, try an emoji!
     if your_character.is_alphabetic() {

--- a/exercises/primitive_types/primitive_types3.rs
+++ b/exercises/primitive_types/primitive_types3.rs
@@ -2,10 +2,8 @@
 // Create an array with at least 100 elements in it where the ??? is.
 // Execute `rustlings hint primitive_types3` for hints!
 
-// I AM NOT DONE
-
 fn main() {
-    let a = ???
+    let a = [42;100];
 
     if a.len() >= 100 {
         println!("Wow, that's a big array!");

--- a/exercises/primitive_types/primitive_types4.rs
+++ b/exercises/primitive_types/primitive_types4.rs
@@ -8,7 +8,7 @@
 fn slice_out_of_array() {
     let a = [1, 2, 3, 4, 5];
 
-    let nice_slice = ???
+    let nice_slice = &a[1..4]; // ### Bear in mind that slice ranges are : a <= e < b
 
     assert_eq!([2, 3, 4], nice_slice)
 }

--- a/exercises/primitive_types/primitive_types5.rs
+++ b/exercises/primitive_types/primitive_types5.rs
@@ -2,11 +2,9 @@
 // Destructure the `cat` tuple so that the println will work.
 // Execute `rustlings hint primitive_types5` for hints!
 
-// I AM NOT DONE
-
 fn main() {
     let cat = ("Furry McFurson", 3.5);
-    let /* your pattern here */ = cat;
+    let (name,age) = cat;
 
     println!("{} is {} years old.", name, age);
 }

--- a/exercises/primitive_types/primitive_types6.rs
+++ b/exercises/primitive_types/primitive_types6.rs
@@ -9,7 +9,7 @@
 fn indexing_tuple() {
     let numbers = (1, 2, 3);
     // Replace below ??? with the tuple indexing syntax.
-    let second = ???;
+    let second = numbers.1; // ### Recall that tuples are indexed this way
 
     assert_eq!(2, second,
         "This is not the 2nd number in the tuple!")

--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -11,7 +11,9 @@
 // I AM NOT DONE
 
 // Put your function here!
-// fn calculate_apple_price {
+fn calculate_apple_price (napples : i32) -> i32 {
+    if ( napples > 40 ) { napples } else { 2*napples } 
+}
 
 // Don't modify this function!
 #[test]

--- a/exercises/structs/structs1.rs
+++ b/exercises/structs/structs1.rs
@@ -3,11 +3,14 @@
 
 // I AM NOT DONE
 
+
+#[derive(Debug, PartialEq)]
 struct ColorClassicStruct {
-    // TODO: Something goes here
+    name : String,
+    hex : String
 }
 
-struct ColorTupleStruct(/* TODO: Something goes here */);
+struct ColorTupleStruct(String,String);
 
 #[derive(Debug)]
 struct UnitStruct;
@@ -18,17 +21,18 @@ mod tests {
 
     #[test]
     fn classic_c_structs() {
-        // TODO: Instantiate a classic c struct!
-        // let green =
+        let green = ColorClassicStruct{ name : "green".to_string(), hex :"#00FF00".to_string()};
+        // ### since String != strliteral but rather String < strliteral (??) we need to use
+        // to_string()
 
+        assert_eq!(green,green,"probando");
         assert_eq!(green.name, "green");
         assert_eq!(green.hex, "#00FF00");
     }
 
     #[test]
     fn tuple_structs() {
-        // TODO: Instantiate a tuple struct!
-        // let green =
+        let green = ColorTupleStruct("green".to_string(),"#00FF00".to_string());
 
         assert_eq!(green.0, "green");
         assert_eq!(green.1, "#00FF00");
@@ -37,7 +41,7 @@ mod tests {
     #[test]
     fn unit_structs() {
         // TODO: Instantiate a unit struct!
-        // let unit_struct =
+        let unit_struct = UnitStruct;
         let message = format!("{:?}s are fun!", unit_struct);
 
         assert_eq!(message, "UnitStructs are fun!");

--- a/exercises/structs/structs2.rs
+++ b/exercises/structs/structs2.rs
@@ -1,8 +1,6 @@
 // structs2.rs
 // Address all the TODOs to make the tests pass!
 
-// I AM NOT DONE
-
 #[derive(Debug)]
 struct Order {
     name: String,
@@ -33,8 +31,8 @@ mod tests {
     #[test]
     fn your_order() {
         let order_template = create_order_template();
-        // TODO: Create your own order using the update syntax and template above!
-        // let your_order =
+        let your_order = Order { name:"Hacker in Rust".to_string(), count:1, ..order_template };
+
         assert_eq!(your_order.name, "Hacker in Rust");
         assert_eq!(your_order.year, order_template.year);
         assert_eq!(your_order.made_by_phone, order_template.made_by_phone);

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -4,8 +4,6 @@
 // Make the code compile and the tests pass!
 // If you have issues execute `rustlings hint structs3`
 
-// I AM NOT DONE
-
 #[derive(Debug)]
 struct Package {
     sender_country: String,
@@ -15,9 +13,8 @@ struct Package {
 
 impl Package {
     fn new(sender_country: String, recipient_country: String, weight_in_grams: i32) -> Package {
-        if weight_in_grams <= 0 {
-            // Something goes here...
-        } else {
+        if weight_in_grams <= 0 { panic!("Weight must be positive"); } 
+        else {
             Package {
                 sender_country,
                 recipient_country,
@@ -26,12 +23,12 @@ impl Package {
         }
     }
 
-    fn is_international(&self) -> ??? {
-        // Something goes here...
+    fn is_international(&self) -> bool {
+        self.sender_country != self.recipient_country
     }
 
-    fn get_fees(&self, cents_per_gram: i32) -> ??? {
-        // Something goes here...
+    fn get_fees(&self, cents_per_gram: i32) -> i32 {
+        cents_per_gram*self.weight_in_grams
     }
 }
 

--- a/exercises/variables/variables1.rs
+++ b/exercises/variables/variables1.rs
@@ -6,9 +6,7 @@
 // even after you already figured it out. If you got everything working and
 // feel ready for the next exercise, remove the `I AM NOT DONE` comment below.
 
-// I AM NOT DONE
-
 fn main() {
-    x = 5;
+    let x = 5;
     println!("x has the value {}", x);
 }

--- a/exercises/variables/variables2.rs
+++ b/exercises/variables/variables2.rs
@@ -1,10 +1,8 @@
 // variables2.rs
 // Make me compile! Execute the command `rustlings hint variables2` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
-    let x;
+    let x = 42;
     if x == 10 {
         println!("Ten!");
     } else {

--- a/exercises/variables/variables3.rs
+++ b/exercises/variables/variables3.rs
@@ -1,10 +1,8 @@
 // variables3.rs
 // Make me compile! Execute the command `rustlings hint variables3` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
-    let x = 3;
+    let mut x = 3;
     println!("Number {}", x);
     x = 5; // don't change this line
     println!("Number {}", x);

--- a/exercises/variables/variables4.rs
+++ b/exercises/variables/variables4.rs
@@ -1,9 +1,7 @@
 // variables4.rs
 // Make me compile! Execute the command `rustlings hint variables4` if you want a hint :)
 
-// I AM NOT DONE
-
 fn main() {
-    let x: i32;
+    let x: i32 = 42;
     println!("Number {}", x);
 }

--- a/exercises/variables/variables5.rs
+++ b/exercises/variables/variables5.rs
@@ -6,6 +6,7 @@
 fn main() {
     let number = "T-H-R-E-E"; // don't change this line
     println!("Spell a Number : {}", number);
-    number = 3;
+    let number = 3; 
+    // ### redefinition of variables is supported through new let statements.
     println!("Number plus two is : {}", number + 2);
 }

--- a/exercises/variables/variables6.rs
+++ b/exercises/variables/variables6.rs
@@ -3,7 +3,7 @@
 
 // I AM NOT DONE
 
-const NUMBER = 3;
+const NUMBER : i32 = 3; // ### Constants may always have a type annotation
 fn main() {
     println!("Number {}", NUMBER);
 }


### PR DESCRIPTION
Reached **enums**, reviewed a lot of stuff:
- Constants require explicit type annotation.
-  String literals are actually slices (a.k.a &str) and String references (&String) can be interpreted as slices so I should assume str > String (??)
- There's no escape with string literals as values for strings .. either use String::from (...) or .to_string().
- Struct field's are assigned with the same operator (`:`) they are type annotated (odd..)
- Enumerations need to use a scope operator `::` to select variants!!!!!
- `match` expressions also have a default: `other` and an ignore `_`.
- some derivable traits: `PartialEq, PartialOrd, Debug, Clone,Copy`.