### PR TITLE
fix(if2): Rename if2 exercise function to foo_if_fizz.

### DIFF
--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -6,7 +6,7 @@
 
 // I AM NOT DONE
 
-pub fn fizz_if_foo(fizzish: &str) -> &str {
+pub fn foo_if_fizz(fizzish: &str) -> &str {
     if fizzish == "fizz" {
         "foo"
     } else {
@@ -21,16 +21,16 @@ mod tests {
 
     #[test]
     fn foo_for_fizz() {
-        assert_eq!(fizz_if_foo("fizz"), "foo")
+        assert_eq!(foo_if_fizz("fizz"), "foo")
     }
 
     #[test]
     fn bar_for_fuzz() {
-        assert_eq!(fizz_if_foo("fuzz"), "bar")
+        assert_eq!(foo_if_fizz("fuzz"), "bar")
     }
 
     #[test]
     fn default_to_baz() {
-        assert_eq!(fizz_if_foo("literally anything"), "baz")
+        assert_eq!(foo_if_fizz("literally anything"), "baz")
     }
 }


### PR DESCRIPTION
The reasoning here is pretty straightforward: you don't say "Hungry, if
eat." That doesn't make sense. We want to get "foo" back if given
"fizz", so it seems this makes far more sense as "Eat, if hungry," or in
this case, return `foo_if_fizz` is given.