### PR TITLE
chore: Fix book link for variables6 and tweak some punctuation

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -78,7 +78,7 @@ path = "exercises/variables/variables6.rs"
 mode = "compile"
 hint = """
 We know about variables and mutability, but there is another important type of
-variable available; constants.
+variable available: constants.
 Constants are always immutable and they are declared with keyword 'const' rather
 than keyword 'let'.
 Constants types must also always be annotated.

--- a/info.toml
+++ b/info.toml
@@ -83,8 +83,8 @@ Constants are always immutable and they are declared with keyword 'const' rather
 than keyword 'let'.
 Constants types must also always be annotated.
 
-Read more about constants under 'Differences Between Variables and Constants' in the book's section 'Variables and Mutability':
-https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
+Read more about constants and the differences between variables and constants under 'Constants' in the book's section 'Variables and Mutability':
+https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#constants
 """
 
 # FUNCTIONS


### PR DESCRIPTION
## What

* chore: Update `variables6.rs` hint book link, wording
* chore: Tweak punctuation in `variables6.rs` hint

## Why

* While the included link for `variables6.rs` does navigate to the correct page, the header in the link itself does not actually exist so it only loads the top of the page. There is, however, some text about the difference between variables and constants in the "Constants" section, so reword the hint some and update the link.
* While the meaning is still obvious as is, it makes a little more sense to use a colon here =)

## A note on why there are two commits

These two could and should be squashed together, but if we wanted to leave the semicolon in, we could easily revert that commit.