### PR TITLE
fix(move_semantics) : add move_semantics6.rs to its mod

### DIFF
--- a/exercises/move_semantics/mod.rs
+++ b/exercises/move_semantics/mod.rs
@@ -3,3 +3,4 @@ mod move_semantics2;
 mod move_semantics3;
 mod move_semantics4;
 mod move_semantics5;
+mod move_semantics6;


### PR DESCRIPTION
Recent exercise `move_semantics6` was not referenced in its `mod.rs`.