### PR TITLE
Add comment about avoiding "cheesing" a solution

### DIFF
--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -1,5 +1,5 @@
 // move_semantics2.rs
-// Make me compile without changing line 13!
+// Make me compile without changing line 13 or moving line 10!
 // Execute `rustlings hint move_semantics2` for hints :)
 
 // I AM NOT DONE


### PR DESCRIPTION
In `move_semantics2` you can get it to compile and pass by simply moving `vec1` below the first `println!` function, so this is to tell people to avoid doing that. 