### PR TITLE
fix(errors6.rs): remove one answer code

### DIFF
--- a/exercises/error_handling/errors6.rs
+++ b/exercises/error_handling/errors6.rs
@@ -20,9 +20,6 @@ enum ParsePosNonzeroError {
 }
 
 impl ParsePosNonzeroError {
-    fn from_creation(err: CreationError) -> ParsePosNonzeroError {
-        ParsePosNonzeroError::Creation(err)
-    }
     // TODO: add another error conversion function here.
 }
 


### PR DESCRIPTION
Although marked as 'TODO', three tests pass without any implementation because the correct answer code already exists.