### PR TITLE
refactor(using_as): improve readability by using sum() instead of fold()

### DIFF
--- a/exercises/conversions/using_as.rs
+++ b/exercises/conversions/using_as.rs
@@ -8,7 +8,7 @@
 // I AM NOT DONE
 
 fn average(values: &[f64]) -> f64 {
-    let total = values.iter().fold(0.0, |a, b| a + b);
+    let total = values.iter().sum::<f64>();
     total / values.len()
 }
 


### PR DESCRIPTION
`fold()` works fine here but `sum()` is much easier to understand for a beginner.