### PR TITLE
docs(move_semantics5): Replace "in vogue" with "in scope" in hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -231,7 +231,7 @@ path = "exercises/move_semantics/move_semantics5.rs"
 mode = "compile"
 hint = """
 Carefully reason about the range in which each mutable reference is in
-vogue. Does it help to update the value of referent (x) immediately after
+scope. Does it help to update the value of referent (x) immediately after
 the mutable reference is taken? Read more about 'Mutable References'
 in the book's section References and Borrowing':
 https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references.


### PR DESCRIPTION
The hint for `move_semantics5` refers to "the range in which each
mutable reference is in vogue". Unless this is a deliberate
introduction of "vogue" (an admittedly-useful term because "scope"
isn't purely lexical, as in many other languages), it may be in error:
I have been unable to find the term used with reference to *Rust*
references.

Thus, I'm suggesting the replacement, in case it's been overlooked.