### PR TITLE
fix(install.sh):fix `rust version` check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,21 @@ function vercomp() {
     then
         max_len=$len2
     fi
+
+    #pad right in short arr
+    if [[ len1 -gt len2 ]];
+    then
+        for ((i = len2; i < len1; i++));
+        do
+            v2[$i]=0
+        done
+    else
+        for ((i = len1; i < len2; i++));
+        do
+            v1[$i]=0
+        done
+    fi
+
     for i in `seq 0 $max_len`
     do
         # Fill empty fields with zeros in v1


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #985 

Problem Summary: Our `install.sh` has `MinRustVersion` such as 1.56.And bash will have a version check,it will split to array and to check one by one.But there is a cornor case,when user use the same version but has `z` version (x.y.z).The short will out of bound(version=x.y).So i add a `pad right` to ensure the length of them is the same.
https://github.com/rust-lang/rustlings/blob/102a4b92a0c2e98ff4ba9f060850d81b4ebbe42f/install.sh#L73-L99
### What is changed and how it works?
Add a `pad right` to ensure the length of them is the same to avoid out of bound of array.
```shell
#pad right in short arr
    if [[ len1 -gt len2 ]];
    then
        for ((i = len2; i < len1; i++));
        do
            v2[$i]=0
        done
    else
        for ((i = len1; i < len2; i++));
        do
            v1[$i]=0
        done
    fi
```
