### PR TITLE
remove deprecated user uploaded extension from .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,4 +4,4 @@ tasks:
 
 vscode:
   extensions:
-    - rust-lang.rust@0.7.8:CvNqMTgDdt3UXt+6BCDTVg==
+    - rust-lang.rust@0.7.8

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ When you get a permission denied message then you have to exclude the directory 
 
 [Run on Repl.it](https://repl.it/github/rust-lang/rustlings)
 
-[Open in Gitpod](https://gitpod.io/#https://github.com/rust-lang/rustlings)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rust-lang/rustlings)
 
 ## Manually
 


### PR DESCRIPTION
Currently, when we open the `ruslings` codebase on `gitpod` vscode, the following error is warning is being thrown and the `rust-lang` vscode extension is not installed:

![Gitpod warning](https://user-images.githubusercontent.com/2624550/167485903-6287cc97-f775-437b-b537-712848fcbe84.jpeg)

This PR enables the installation of the official `rust-lang` vscode extension. Furthermore, this PR also updates the `Open in Gitpod` link to have the official button.