### PR TITLE
Updatedocs

### DIFF
--- a/exercises/error_handling/errors4.rs
+++ b/exercises/error_handling/errors4.rs
@@ -1,4 +1,6 @@
 // errors4.rs
+// The code is excessively positive about the numbers given it. It should fail if
+// they aren't, returning the appropriate Result.
 // Make this test pass! Execute `rustlings hint errors4` for hints :)
 
 // I AM NOT DONE

--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -1,7 +1,8 @@
 // errors5.rs
 
 // This program uses a completed version of the code from errors4.
-// It won't compile right now! Why?
+// It won't compile right now! Why? What are all the possible return
+// types from main?
 // Execute `rustlings hint errors5` for hints!
 
 // I AM NOT DONE

--- a/exercises/lifetimes/README.md
+++ b/exercises/lifetimes/README.md
@@ -1,0 +1,16 @@
+# Lifetimes
+
+Lifetimes tell the compiler how to check whether references live long
+enough to be valid in any given situation. For example lifetimes say
+"make sure parameter 'a' lives as long as parameter 'b' so that return
+value is valid". 
+
+They are only necessary on borrows, i.e. references, 
+since copied parameters or moves are owned in their scope and cannot
+be referenced outside. Lifetimes mean that calling code of e.g. functions
+can be checked to make sure their arguments are valid. Lifetimes are 
+restrictive of their callers.
+## Further information
+
+- [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
+- [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/stable/rust-by-example/scope/lifetime.html)

--- a/exercises/lifetimes/lifetimes1.rs
+++ b/exercises/lifetimes/lifetimes1.rs
@@ -1,0 +1,29 @@
+// lifetimes1.rs
+//
+// The rust compiler needs to know how to check whether supplied references are
+// valid, so that it can feedback to the programmer if a reference is at risk
+// of going out of scope before it is used. Remember references are borrows
+// and do not own their own data. What if their owner goes out of scope?
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes1` if you need
+// hints.
+
+// I AM NOT DONE
+
+fn longest(x: &str, y: &str) -> &str {
+    if x.len() > y.len() {
+        x
+    } else {
+        y
+    }
+}
+
+fn main() {
+    let string1 = String::from("abcd");
+    let string2 = "xyz";
+
+    let result = longest(string1.as_str(), string2);
+    println!("The longest string is {}", result);
+}

--- a/exercises/lifetimes/lifetimes2.rs
+++ b/exercises/lifetimes/lifetimes2.rs
@@ -1,0 +1,29 @@
+// lifetimes2.rs
+//
+// So if the compiler is just validating the references passed
+// to the annotated parameters and the return type, what do
+// we need to change?
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes2` if you need
+// hints.
+
+// I AM NOT DONE
+
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() {
+        x
+    } else {
+        y
+    }
+}
+fn main() {
+    let string1 = String::from("long string is long");
+    let result;
+    {
+        let string2 = String::from("xyz");
+        result = longest(string1.as_str(), string2.as_str());
+    }
+    println!("The longest string is {}", result);
+}

--- a/exercises/lifetimes/lifetimes3.rs
+++ b/exercises/lifetimes/lifetimes3.rs
@@ -1,0 +1,23 @@
+// lifetimes3.rs
+//
+// Lifetimes are also needed when structs hold references.
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes3` if you need
+// hints.
+
+// I AM NOT DONE
+
+struct Book {
+    author: &str,
+    title: &str,
+}
+
+fn main() {
+    let name = String::from("Jill Smith");
+    let title= String::from("Fish Flying");
+    let book = Book {author: &name, title: &title};
+
+    println!("{} by {}", book.title, book.author);
+}

--- a/exercises/lifetimes/lifetimes4.rs
+++ b/exercises/lifetimes/lifetimes4.rs
@@ -1,0 +1,27 @@
+// lifetimes4.rs
+//
+// So that the compiler can check lifetimes of supplied attributes
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes4` if you need
+// hints.
+
+// I AM NOT DONE
+
+#[derive(Debug)]
+struct Book<'a> {
+    author: &'a str,
+    title: &'a str,
+}
+
+fn main() {
+    let name = String::from("Jill Smith");
+    let book;
+    {
+        let title = String::from("Fish Flying");
+        book = Book { author: &name, title: &title };
+    }
+
+    println!("{:?}", book);
+}

--- a/exercises/lifetimes/mod.rs
+++ b/exercises/lifetimes/mod.rs
@@ -1,0 +1,4 @@
+mod lifetimes1;
+mod lifetimes2;
+mod lifetimes3;
+mod lifetimes4;

--- a/exercises/mod.rs
+++ b/exercises/mod.rs
@@ -24,3 +24,4 @@ mod tests;
 mod threads;
 mod traits;
 mod variables;
+mod lifetimes;

--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -1,4 +1,6 @@
 // option1.rs
+// How does the function signature of print_number differ from where
+// it is called in main?
 // Make me compile! Execute `rustlings hint option1` for hints
 
 // I AM NOT DONE

--- a/exercises/option/option2.rs
+++ b/exercises/option/option2.rs
@@ -1,4 +1,8 @@
 // option2.rs
+// You're gonna add if let and while let to the function below
+// where the todo: are
+// what's the difference between 'word' and 'optional_word'
+// and how do you get one from the other?
 // Make me compile! Execute `rustlings hint option2` for hints
 
 // I AM NOT DONE

--- a/exercises/option/option3.rs
+++ b/exercises/option/option3.rs
@@ -1,4 +1,5 @@
 // option3.rs
+// Let the compiler guide you. Also: https://doc.rust-lang.org/std/keyword.ref.html
 // Make me compile! Execute `rustlings hint option3` for hints
 
 // I AM NOT DONE

--- a/info.toml
+++ b/info.toml
@@ -376,6 +376,37 @@ path = "exercises/enums/enums3.rs"
 mode = "test"
 hint = "No hints this time ;)"
 
+# LIFETIMES
+
+[[exercises]]
+name = "lifetimes1"
+path = "exercises/lifetimes/lifetimes1.rs"
+mode = "compile"
+hint = """
+Let the compiler guide you. Also take a look at the book if you need help:
+https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html"""
+
+[[exercises]]
+name = "lifetimes2"
+path = "exercises/lifetimes/lifetimes2.rs"
+mode = "compile"
+hint = """
+What is the compiler checking? How could you change how long an owned variable lives?"""
+
+[[exercises]]
+name = "lifetimes3"
+path = "exercises/lifetimes/lifetimes3.rs"
+mode = "compile"
+hint = """
+If you use a lifetime annotation in a struct's fields where else does it need to be added?"""
+
+[[exercises]]
+name = "lifetimes4"
+path = "exercises/lifetimes/lifetimes4.rs"
+mode = "compile"
+hint = """
+This is basically the same as lifetimes2 except with structs"""
+
 # MODULES
 
 [[exercises]]


### PR DESCRIPTION
Attempted first Pull Request for this repository.  Unfortunately it contains 2 separate commits:
1) [docs: updated prefix comments](https://github.com/rust-lang/rustlings/commit/5a520921094ef2e9608567c1e42e7e77e4206060)
2) [feat: added lifetimes exercise directory](https://github.com/rust-lang/rustlings/commit/7c7520362c254af87633942abd60d64800cbf90a)

The first is just a first attempt at adding something useful as first PR - some v. small changes to comments in errors and options exercises, in attempt to follow "Completion" section of README.md. Not sure how up to date this is though. Please let me know if should be something else, unnecessary etc.

Second is section of exercises that basically reproduce the book's lifetimes section. Nothing smart going on, it just seemed missing.

I'd really like to know what the maintainers would like me to do to most usefully contribute to the repo.

(Also been a while since using git, sorry if bad)