### PR TITLE
Docs, Closures and Lifetimes

### DIFF
--- a/exercises/closures/README.md
+++ b/exercises/closures/README.md
@@ -9,8 +9,8 @@ Closures are often used as arguments to higher order functions (functions which
 take other functions as parameters), e.g. map(), filter(), reduce() et al on iterators,
 but aren't restricted to these cases.
 
-Rust's ownership model means that we might have to do something extra when declaring
-closures which other languages don't require.
+Rust's ownership model means that we may need to think about how captured values
+are treated: copied, moved, or borrowed immutably or mutably. 
 
 ## Further information
 

--- a/exercises/closures/README.md
+++ b/exercises/closures/README.md
@@ -1,0 +1,17 @@
+# Closures
+
+Closures are a common programming concept found in many languages, but are primarily
+associated with 'functional' programming styles. Closure are anonymous functions
+(i.e. unlike regular functions, they don't have a name) that may access some variables
+from their enclosing scope (they 'close' over their scope, capturing variables).
+
+Closures are often used as arguments to higher order functions (functions which 
+take other functions as parameters), e.g. map(), filter(), reduce() et al on iterators,
+but aren't restricted to these cases.
+
+Rust's ownership model means that we might have to do something extra when declaring
+closures which other languages don't require.
+
+## Further information
+
+- [Closures: Anonymous Functions that Can Capture Their Environment](https://doc.rust-lang.org/book/ch13-01-closures.html)

--- a/exercises/closures/closures1.rs
+++ b/exercises/closures/closures1.rs
@@ -1,6 +1,6 @@
 // closures1.rs
 // Closures are anonymous functions, but they can be assigned to a variable
-// so that they can be used later on
+// so that they can be used later on.
 // make me compile and pass
 
 // Execute `rustlings hint closures1` for hints!

--- a/exercises/closures/closures1.rs
+++ b/exercises/closures/closures1.rs
@@ -1,0 +1,21 @@
+// closures1.rs
+// Closures are anonymous functions, but they can be assigned to a variable
+// so that they can be used later on
+// make me compile and pass
+
+// Execute `rustlings hint closures1` for hints!
+
+// I AM NOT DONE
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    # [test]
+    fn test_closure() {
+        let closure = ;
+        assert_eq!("I'm a closure",closure());
+    }
+}

--- a/exercises/closures/closures2.rs
+++ b/exercises/closures/closures2.rs
@@ -1,0 +1,24 @@
+// closure2.rs
+// What is the difference between a closure and a function? Can you get this code
+// to compile?
+
+// Execute `rustlings hint closures2` for hints!
+
+// I AM NOT DONE
+
+fn output(closure) {
+    println!("What am I?");
+    closure();
+}
+
+fn main() {
+
+    fn actual() {
+        println!("I'm actually a function")
+    }
+
+    let actual_fn = actual;
+    let closure = || println!("I'm a closure");
+    output(closure);
+    output(actual_fn);
+}

--- a/exercises/closures/closures3.rs
+++ b/exercises/closures/closures3.rs
@@ -1,0 +1,24 @@
+// closure3.rs
+// What is the difference between a closure and a function, part II? Can you get this code
+// to compile?
+
+// Execute `rustlings hint closures3` for hints!
+
+// I AM NOT DONE
+
+fn main() {
+    let my_name = String::from("Lim Lady");
+
+    fn actual() {
+        println!("my name is: {}", my_name);
+    }
+
+    let actual_fn = actual;
+    let closure = || {
+        println!("my name is: {}", my_name);
+    };
+
+    println!("Who am I?");
+    actual_fn();
+    closure();
+}

--- a/exercises/closures/closures4.rs
+++ b/exercises/closures/closures4.rs
@@ -1,0 +1,34 @@
+// closure4.rs
+// Where are you going to use closures? Where the context defines the code
+// you want some other code to invoke. So, unlike functions or methods, closures
+// are for when the code is not generally useful, or attached to a
+// type, but is specific to the context you are defining it in. Closures can
+// define parameters, just like functions, but these are defined by the context
+// it is intended to run in, where the actual arguments will be supplied.
+// https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_by
+
+// Execute `rustlings hint closures4` for hints!
+
+// I AM NOT DONE
+
+fn alphabetize(list: &mut Vec<&str>) {
+    list.sort_by();
+}
+
+fn main() {
+    let mut list = vec!("Oliver","Tarquinn","Bertrude");
+    println!("before {:?}",list);
+    alphabetize(& mut list);
+    println!("after {:?}",list);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    # [test]
+    fn test_alphabetize() {
+        let mut list = vec!("Oliver","Tarquinn","Bertrude");
+        assert_eq!(vec!("Bertrude","Oliver","Tarquinn"),alphabetize(&mut list));
+    }
+}

--- a/exercises/closures/closures4.rs
+++ b/exercises/closures/closures4.rs
@@ -1,10 +1,10 @@
 // closure4.rs
-// Where are you going to use closures? Where the context defines the code
+// Where are you going to use closures? Where the context defines the logic
 // you want some other code to invoke. So, unlike functions or methods, closures
 // are for when the code is not generally useful, or attached to a
 // type, but is specific to the context you are defining it in. Closures can
-// define parameters, just like functions, but these are defined by the context
-// it is intended to run in, where the actual arguments will be supplied.
+// define parameters, just like functions, but these are specified by the context
+// the closure is intended to be invoked in, where the actual arguments will be supplied.
 // https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_by
 
 // Execute `rustlings hint closures4` for hints!

--- a/exercises/closures/closures5.rs
+++ b/exercises/closures/closures5.rs
@@ -21,6 +21,9 @@ fn sum_letters(animals: &Vec<&str>) -> usize {
     // pay close attention to the where clause in the function signatures
     // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.reduce
     // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
+    // and the return types of the different ways of getting an iterator
+    // https://doc.rust-lang.org/stable/std/iter/
+    // https://doc.rust-lang.org/std/iter/trait.IntoIterator.html#tymethod.into_iter
     // TODO: change the next 2 lines to compile and pass the test.
     let sum_closure = |x: &usize, y: &usize| &(x + y);
     animals.iter().reduce(sum_closure).unwrap().to_owned()

--- a/exercises/closures/closures5.rs
+++ b/exercises/closures/closures5.rs
@@ -1,9 +1,8 @@
 // closure5.rs
 // These are some fairly common uses of closures on iterator methods
 // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.map
+// https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.reduce
 // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
-// my original version used 'reduce()' instead of 'fold()' but why would that
-// be unsuitable for a sum function in Rust (specifically)?
 
 // Execute `rustlings hint closures5` for hints!
 
@@ -12,16 +11,19 @@
 fn count_letters(animals: &Vec<&str>) -> Vec<usize>{
     // the compiler should help you figure out what signature to use
     // after you annotate it with one that fails.
+    // TODO: fill in this line with closure that compiles and passes the test.
     let count_closure = ;
     animals.iter().map(count_closure).collect()
 }
 
 fn sum_letters(animals: &Vec<&str>) -> usize {
-    let sum_closure =
     let animals = count_letters(animals);
-    // pay close attention to the where clause in the function signature
+    // pay close attention to the where clause in the function signatures
+    // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.reduce
     // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
-    animals.iter().fold(0, sum_closure)
+    // TODO: change the next 2 lines to compile and pass the test.
+    let sum_closure = |x: &usize, y: &usize| &(x + y);
+    animals.iter().reduce(sum_closure).unwrap().to_owned()
 }
 
 fn main() {
@@ -36,7 +38,7 @@ mod tests {
     use super::*;
 
     # [test]
-    fn test_() {
+    fn test_closures() {
         let animals= vec!["cat","fish","horse"];
         assert_eq!(vec![3,4,5], count_letters(&animals));
         assert_eq!(12, sum_letters(&animals));

--- a/exercises/closures/closures5.rs
+++ b/exercises/closures/closures5.rs
@@ -23,6 +23,7 @@ fn sum_letters(animals: &Vec<&str>) -> usize {
     // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
     // and the return types of the different ways of getting an iterator
     // https://doc.rust-lang.org/stable/std/iter/
+    // https://doc.rust-lang.org/std/iter/index.html#the-three-forms-of-iteration
     // https://doc.rust-lang.org/std/iter/trait.IntoIterator.html#tymethod.into_iter
     // TODO: change the next 2 lines to compile and pass the test.
     let sum_closure = |x: &usize, y: &usize| &(x + y);

--- a/exercises/closures/closures5.rs
+++ b/exercises/closures/closures5.rs
@@ -1,0 +1,44 @@
+// closure5.rs
+// These are some fairly common uses of closures on iterator methods
+// https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.map
+// https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
+// my original version used 'reduce()' instead of 'fold()' but why would that
+// be unsuitable for a sum function in Rust (specifically)?
+
+// Execute `rustlings hint closures5` for hints!
+
+// I AM NOT DONE
+
+fn count_letters(animals: &Vec<&str>) -> Vec<usize>{
+    // the compiler should help you figure out what signature to use
+    // after you annotate it with one that fails.
+    let count_closure = ;
+    animals.iter().map(count_closure).collect()
+}
+
+fn sum_letters(animals: &Vec<&str>) -> usize {
+    let sum_closure =
+    let animals = count_letters(animals);
+    // pay close attention to the where clause in the function signature
+    // https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.fold
+    animals.iter().fold(0, sum_closure)
+}
+
+fn main() {
+    let animals= vec!["cat","fish","horse"];
+    println!("animals: {:?}",animals);
+    println!("length: {:?}", count_letters(&animals));
+    println!("total: {:?}", sum_letters(&animals));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    # [test]
+    fn test_() {
+        let animals= vec!["cat","fish","horse"];
+        assert_eq!(vec![3,4,5], count_letters(&animals));
+        assert_eq!(12, sum_letters(&animals));
+    }
+}

--- a/exercises/closures/closures6.rs
+++ b/exercises/closures/closures6.rs
@@ -1,0 +1,25 @@
+// closure6.rs
+// The compiler will take care of inferring the correct types for
+// closures you write:
+// https://doc.rust-lang.org/book/ch13-01-closures.html#capturing-the-environment-with-closures
+// But if you want to make sure that values are inaccessible after
+// the closure, they can be moved rather than borrowed using the 'move' keyword.
+// Make me compile!
+
+// Execute `rustlings hint closures6` for hints!
+
+// I AM NOT DONE
+
+fn move_it() {
+    let who_wants_to = vec!["I want to ", "He wants to ", "They want to "];
+    let do_what = String::from("move it");
+
+    let chorus: Vec<String> = who_wants_to.iter().map( move |&who| who.to_owned() + do_what.as_str() + ", " + do_what.as_str() + ".").collect();
+    println!("{:?}",chorus);
+
+    println!("{:?}!",do_what.to_uppercase());
+}
+
+fn main() {
+    move_it();
+}

--- a/exercises/closures/closures7.rs
+++ b/exercises/closures/closures7.rs
@@ -1,0 +1,26 @@
+// closure7.rs
+// You can use patterns in closure (and function) parameters.
+// However there is one big difference between the patterns
+// you can use in these sorts of places (like let statements)
+// and conditional places (like match). It's called Irrefutability.
+// Make me compile!
+
+// Execute `rustlings hint closures7` for hints!
+
+// I AM NOT DONE
+
+fn main() {
+
+    let clo = |(definitely, _)| {
+        println!("maybe {:?}", definitely);
+    };
+
+    clo(("oh yes", "oh no"));
+
+    let maybe = Some("yes");
+    let list = vec![maybe];
+
+    list.iter().inspect(|&Some(value)| {
+        println!("maybe {:?}", value);
+    });
+}

--- a/exercises/closures/closures7.rs
+++ b/exercises/closures/closures7.rs
@@ -20,7 +20,7 @@ fn main() {
     let maybe = Some("yes");
     let list = vec![maybe];
 
-    list.iter().inspect(|&Some(value)| {
+    list.into_iter().inspect(|Some(value)| {
         println!("maybe {:?}", value);
     });
 }

--- a/exercises/closures/mod.rs
+++ b/exercises/closures/mod.rs
@@ -3,3 +3,4 @@ mod closures2;
 mod closures3;
 mod closures4;
 mod closures5;
+mod closures6;

--- a/exercises/closures/mod.rs
+++ b/exercises/closures/mod.rs
@@ -1,0 +1,5 @@
+mod closures1;
+mod closures2;
+mod closures3;
+mod closures4;
+mod closures5;

--- a/exercises/closures/mod.rs
+++ b/exercises/closures/mod.rs
@@ -4,3 +4,4 @@ mod closures3;
 mod closures4;
 mod closures5;
 mod closures6;
+mod closures7;

--- a/exercises/collections/mod.rs
+++ b/exercises/collections/mod.rs
@@ -1,1 +1,4 @@
-mod closures1;
+mod hashmap1;
+mod hashmap2;
+mod vec1;
+mod vec2;

--- a/exercises/collections/mod.rs
+++ b/exercises/collections/mod.rs
@@ -1,4 +1,1 @@
-mod hashmap1;
-mod hashmap2;
-mod vec1;
-mod vec2;
+mod closures1;

--- a/exercises/error_handling/errors4.rs
+++ b/exercises/error_handling/errors4.rs
@@ -1,4 +1,6 @@
 // errors4.rs
+// The code is excessively positive about the numbers given it. It should fail if
+// they aren't, returning the appropriate Result.
 // Make this test pass! Execute `rustlings hint errors4` for hints :)
 
 // I AM NOT DONE

--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -1,7 +1,8 @@
 // errors5.rs
 
 // This program uses a completed version of the code from errors4.
-// It won't compile right now! Why?
+// It won't compile right now! Why? What are all the possible return
+// types from main?
 // Execute `rustlings hint errors5` for hints!
 
 // I AM NOT DONE

--- a/exercises/lifetimes/README.md
+++ b/exercises/lifetimes/README.md
@@ -1,0 +1,16 @@
+# Lifetimes
+
+Lifetimes tell the compiler how to check whether references live long
+enough to be valid in any given situation. For example lifetimes say
+"make sure parameter 'a' lives as long as parameter 'b' so that return
+value is valid". 
+
+They are only necessary on borrows, i.e. references, 
+since copied parameters or moves are owned in their scope and cannot
+be referenced outside. Lifetimes mean that calling code of e.g. functions
+can be checked to make sure their arguments are valid. Lifetimes are 
+restrictive of their callers.
+## Further information
+
+- [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
+- [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/stable/rust-by-example/scope/lifetime.html)

--- a/exercises/lifetimes/lifetimes1.rs
+++ b/exercises/lifetimes/lifetimes1.rs
@@ -1,0 +1,29 @@
+// lifetimes1.rs
+//
+// The rust compiler needs to know how to check whether supplied references are
+// valid, so that it can feedback to the programmer if a reference is at risk
+// of going out of scope before it is used. Remember references are borrows
+// and do not own their own data. What if their owner goes out of scope?
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes1` if you need
+// hints.
+
+// I AM NOT DONE
+
+fn longest(x: &str, y: &str) -> &str {
+    if x.len() > y.len() {
+        x
+    } else {
+        y
+    }
+}
+
+fn main() {
+    let string1 = String::from("abcd");
+    let string2 = "xyz";
+
+    let result = longest(string1.as_str(), string2);
+    println!("The longest string is {}", result);
+}

--- a/exercises/lifetimes/lifetimes2.rs
+++ b/exercises/lifetimes/lifetimes2.rs
@@ -1,0 +1,29 @@
+// lifetimes2.rs
+//
+// So if the compiler is just validating the references passed
+// to the annotated parameters and the return type, what do
+// we need to change?
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes2` if you need
+// hints.
+
+// I AM NOT DONE
+
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() {
+        x
+    } else {
+        y
+    }
+}
+fn main() {
+    let string1 = String::from("long string is long");
+    let result;
+    {
+        let string2 = String::from("xyz");
+        result = longest(string1.as_str(), string2.as_str());
+    }
+    println!("The longest string is {}", result);
+}

--- a/exercises/lifetimes/lifetimes3.rs
+++ b/exercises/lifetimes/lifetimes3.rs
@@ -1,0 +1,23 @@
+// lifetimes3.rs
+//
+// Lifetimes are also needed when structs hold references.
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes3` if you need
+// hints.
+
+// I AM NOT DONE
+
+struct Book {
+    author: &str,
+    title: &str,
+}
+
+fn main() {
+    let name = String::from("Jill Smith");
+    let title= String::from("Fish Flying");
+    let book = Book {author: &name, title: &title};
+
+    println!("{} by {}", book.title, book.author);
+}

--- a/exercises/lifetimes/lifetimes4.rs
+++ b/exercises/lifetimes/lifetimes4.rs
@@ -1,0 +1,27 @@
+// lifetimes4.rs
+//
+// So that the compiler can check lifetimes of supplied attributes
+//
+// Make me compile
+//
+// Execute the command `rustlings hint lifetimes4` if you need
+// hints.
+
+// I AM NOT DONE
+
+#[derive(Debug)]
+struct Book<'a> {
+    author: &'a str,
+    title: &'a str,
+}
+
+fn main() {
+    let name = String::from("Jill Smith");
+    let book;
+    {
+        let title = String::from("Fish Flying");
+        book = Book { author: &name, title: &title };
+    }
+
+    println!("{:?}", book);
+}

--- a/exercises/lifetimes/mod.rs
+++ b/exercises/lifetimes/mod.rs
@@ -1,0 +1,4 @@
+mod lifetimes1;
+mod lifetimes2;
+mod lifetimes3;
+mod lifetimes4;

--- a/exercises/mod.rs
+++ b/exercises/mod.rs
@@ -24,3 +24,4 @@ mod tests;
 mod threads;
 mod traits;
 mod variables;
+mod lifetimes;

--- a/exercises/mod.rs
+++ b/exercises/mod.rs
@@ -25,3 +25,4 @@ mod threads;
 mod traits;
 mod variables;
 mod lifetimes;
+mod closures;

--- a/exercises/option/option1.rs
+++ b/exercises/option/option1.rs
@@ -1,4 +1,6 @@
 // option1.rs
+// How does the function signature of print_number differ from where
+// it is called in main?
 // Make me compile! Execute `rustlings hint option1` for hints
 
 // I AM NOT DONE

--- a/exercises/option/option2.rs
+++ b/exercises/option/option2.rs
@@ -1,4 +1,8 @@
 // option2.rs
+// You're gonna add if let and while let to the function below
+// where the todo: are
+// what's the difference between 'word' and 'optional_word'
+// and how do you get one from the other?
 // Make me compile! Execute `rustlings hint option2` for hints
 
 // I AM NOT DONE

--- a/exercises/option/option3.rs
+++ b/exercises/option/option3.rs
@@ -1,4 +1,5 @@
 // option3.rs
+// Let the compiler guide you. Also: https://doc.rust-lang.org/std/keyword.ref.html
 // Make me compile! Execute `rustlings hint option3` for hints
 
 // I AM NOT DONE

--- a/info.toml
+++ b/info.toml
@@ -183,9 +183,9 @@ of a value owned by a called function.
 You can replace 'reduce()' with a different function call. Update the closure
 so that it matches the signature of this new call, and change the code to return
 the correct type from the sum_letters function. (Using 'sum()' is cheating!)
-OR you can change the sort of iterator you get, so that you don't have to return a reference.
+OR you can change the way you get the iterator, so that you don't have to return a reference.
 Pay close attention to the documentation linked to in the exercise: which type
-parameters are the same in the function signatures, and which are different. And
+parameters are the same in the function signatures, and which are different? And
 how do the return types of the variations of getting an iterator differ from each other?"""
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -178,13 +178,15 @@ path = "exercises/closures/closures5.rs"
 mode = "test"
 hint = """
 Getting the signatures of closures right can be tough. I don't think you can write
-any version that fulfills the tests using 'reduce()': you can never return a borrow
+any version that fulfills the tests using 'reduce()' with 'iter()': you can never return a borrow
 of a value owned by a called function.
-You need to replace 'reduce()' with a different function call, update the closure
+You can replace 'reduce()' with a different function call. Update the closure
 so that it matches the signature of this new call, and change the code to return
 the correct type from the sum_letters function. (Using 'sum()' is cheating!)
+OR you can change the sort of iterator you get, so that you don't have to return a reference.
 Pay close attention to the documentation linked to in the exercise: which type
-parameters are the same in the function signatures, and which are different."""
+parameters are the same in the function signatures, and which are different. And
+how do the return types of the variations of getting an iterator differ from each other?"""
 
 [[exercises]]
 name = "closures6"

--- a/info.toml
+++ b/info.toml
@@ -160,14 +160,15 @@ name = "closures3"
 path = "exercises/closures/closures3.rs"
 mode = "compile"
 hint = """
-The compiler has got you covered with this. After all, why IS it called a closure?"""
+The compiler has got you covered with this. After all, why IS it called a closure?
+If you actually want to make it work, you can add a parameter to the function."""
 
 [[exercises]]
 name = "closures4"
 path = "exercises/closures/closures4.rs"
 mode = "test"
 hint = """
-Don't try to actually implement any comparison other than using cmp:
+Don't try to actually implement any comparison logic other than invoking cmp:
 https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html#tymethod.cmp
 e.g. x.cmp(y)"""
 
@@ -176,9 +177,22 @@ name = "closures5"
 path = "exercises/closures/closures5.rs"
 mode = "test"
 hint = """
-Honestly this was hard to write. Getting the signatures of closures right can be tough.
-Pay close attention to the documentation linked to in the exercise and which type
-parameters are the same in the function signatures."""
+Getting the signatures of closures right can be tough. I don't think you can write
+any version that fulfills the tests using 'reduce()': you can never return a borrow
+of a value owned by a called function.
+You need to replace 'reduce()' with a different function call, update the closure
+so that it matches the signature of this new call, and change the code to return
+the correct type from the sum_letters function. (Using 'sum()' is cheating!)
+Pay close attention to the documentation linked to in the exercise: which type
+parameters are the same in the function signatures, and which are different."""
+
+[[exercises]]
+name = "closures6"
+path = "exercises/closures/closures6.rs"
+mode = "compile"
+hint = """
+There are two ways to solve this, neither is difficult and both involve just removing
+the offending part. If you're thinking hard, you've missed the point."""
 
 # IF
 

--- a/info.toml
+++ b/info.toml
@@ -136,6 +136,50 @@ They are not the same. There are two solutions:
 1. Add a `return` ahead of `num * num;`
 2. remove `;`, make it to be `num * num`"""
 
+# CLOSURES
+
+[[exercises]]
+name = "closures1"
+path = "exercises/closures/closures1.rs"
+mode = "test"
+hint = """
+Take a look at this section of the book: https://doc.rust-lang.org/book/ch13-01-closures.html"""
+
+[[exercises]]
+name = "closures2"
+path = "exercises/closures/closures2.rs"
+mode = "compile"
+hint = """
+A bit taxing, but these should help:
+https://doc.rust-lang.org/rust-by-example/fn/closures/input_parameters.html
+https://doc.rust-lang.org/rust-by-example/fn/closures/anonymity.html
+https://doc.rust-lang.org/rust-by-example/fn/closures/input_functions.html"""
+
+[[exercises]]
+name = "closures3"
+path = "exercises/closures/closures3.rs"
+mode = "compile"
+hint = """
+The compiler has got you covered with this. After all, why IS it called a closure?"""
+
+[[exercises]]
+name = "closures4"
+path = "exercises/closures/closures4.rs"
+mode = "test"
+hint = """
+Don't try to actually implement any comparison other than using cmp:
+https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html#tymethod.cmp
+e.g. x.cmp(y)"""
+
+[[exercises]]
+name = "closures5"
+path = "exercises/closures/closures5.rs"
+mode = "test"
+hint = """
+Honestly this was hard to write. Getting the signatures of closures right can be tough.
+Pay close attention to the documentation linked to in the exercise and which type
+parameters are the same in the function signatures."""
+
 # IF
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -194,6 +194,14 @@ hint = """
 There are two ways to solve this, neither is difficult and both involve just removing
 the offending part. If you're thinking hard, you've missed the point."""
 
+[[exercises]]
+name = "closures7"
+path = "exercises/closures/closures7.rs"
+mode = "compile"
+hint = """
+This is where the info is https://doc.rust-lang.org/book/ch18-02-refutability.html
+So there isn't a satisfying solution, just an acceptance of the facts."""
+
 # IF
 
 [[exercises]]

--- a/info.toml
+++ b/info.toml
@@ -376,6 +376,37 @@ path = "exercises/enums/enums3.rs"
 mode = "test"
 hint = "No hints this time ;)"
 
+# LIFETIMES
+
+[[exercises]]
+name = "lifetimes1"
+path = "exercises/lifetimes/lifetimes1.rs"
+mode = "compile"
+hint = """
+Let the compiler guide you. Also take a look at the book if you need help:
+https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html"""
+
+[[exercises]]
+name = "lifetimes2"
+path = "exercises/lifetimes/lifetimes2.rs"
+mode = "compile"
+hint = """
+What is the compiler checking? How could you change how long an owned variable lives?"""
+
+[[exercises]]
+name = "lifetimes3"
+path = "exercises/lifetimes/lifetimes3.rs"
+mode = "compile"
+hint = """
+If you use a lifetime annotation in a struct's fields where else does it need to be added?"""
+
+[[exercises]]
+name = "lifetimes4"
+path = "exercises/lifetimes/lifetimes4.rs"
+mode = "compile"
+hint = """
+This is basically the same as lifetimes2 except with structs"""
+
 # MODULES
 
 [[exercises]]


### PR DESCRIPTION
Attempted first Pull Request for this repository. Unfortunately it contains 3 separate commits:

[docs: updated prefix comments](https://github.com/rust-lang/rustlings/commit/5a520921094ef2e9608567c1e42e7e77e4206060)
[feat: added lifetimes exercise directory](https://github.com/rust-lang/rustlings/commit/7c7520362c254af87633942abd60d64800cbf90a)
[feat: added closures exercises in closure directory](https://github.com/rust-lang/rustlings/commit/f9a4ff3b82ae5d0d3aeb8c86ead27230ac5ce91d)

The first is just a first attempt at adding something useful as first PR - some v. small changes to comments in errors and options exercises, in attempt to follow "Completion" section of README.md. Not sure how up to date this is though. Please let me know if should be something else, unnecessary etc.

Second is section of exercises that basically reproduce the book's lifetimes section. Nothing smart going on, it just seemed missing.

Third is a set of closures exercises.

These should all have been separate pull requests, I know. I'm still getting back into figuring out pull request, and branches etc. And if it seems like spam, also sorry. Enthusiasm kills! 

I'd really like to know what the maintainers would like me to do to most usefully contribute to the repo.

(Also been a while since using git, sorry if bad)
(This PR replaces another which I have closed)