### PR TITLE
fix(errors5): Add more context to exercise description

### DIFF
--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -1,7 +1,17 @@
 // errors5.rs
 
-// This program uses a completed version of the code from errors4.
-// It won't compile right now! Why?
+// This program uses an altered version of the code from errors4.
+
+// This exercise uses some concepts that we won't get to until later in the course, like `Box` and the
+// `From` trait. It's not important to understand them in detail right now, but you can read ahead if you like.
+
+// In short, this particular use case for boxes is for when you want to own a value and you care only that it is a 
+// type which implements a particular trait. To do so, The Box is declared as of type Box<dyn Trait> where Trait is the trait
+// the compiler looks for on any value used in that context. For this exercise, that context is the potential errors
+// which can be returned in a Result.
+
+// What can we use to describe both errors? In other words, is there a trait which both errors implement?
+
 // Execute `rustlings hint errors5` for hints!
 
 // I AM NOT DONE
@@ -11,7 +21,7 @@ use std::fmt;
 use std::num::ParseIntError;
 
 // TODO: update the return type of `main()` to make this compile.
-fn main() -> Result<(), ParseIntError> {
+fn main() -> Result<(), Box<dyn ???>> {
     let pretend_user_input = "42";
     let x: i64 = pretend_user_input.parse()?;
     println!("output={:?}", PositiveNonzeroInteger::new(x)?);

--- a/info.toml
+++ b/info.toml
@@ -536,21 +536,16 @@ name = "errors5"
 path = "exercises/error_handling/errors5.rs"
 mode = "compile"
 hint = """
-Hint: There are two different possible `Result` types produced within
-`main()`, which are propagated using `?` operators. How do we declare a
-return type from `main()` that allows both?
+Hint: There are two different possible `Result` types produced within `main()`, which are 
+propagated using `?` operators. How do we declare a return type from `main()` that allows both? 
 
-Another hint: under the hood, the `?` operator calls `From::from`
-on the error value to convert it to a boxed trait object, a
-`Box<dyn error::Error>`, which is polymorphic-- that means that lots of
-different kinds of errors can be returned from the same function because
-all errors act the same since they all implement the `error::Error` trait.
+Under the hood, the `?` operator calls `From::from` on the error value to convert it to a boxed
+trait object, a `Box<dyn error::Error>`. This boxed trait object is polymorphic, and since all
+errors implement the `error:Error` trait, we can capture lots of different errors in one "Box" 
+object. 
+
 Check out this section of the book:
 https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
-
-This exercise uses some concepts that we won't get to until later in the
-course, like `Box` and the `From` trait. It's not important to understand
-them in detail right now, but you can read ahead if you like.
 
 Read more about boxing errors:
 https://doc.rust-lang.org/stable/rust-by-example/error/multiple_error_types/boxing_errors.html


### PR DESCRIPTION
This change alleviates some of the awkwardness while going through the Rustlings suggested path. In its current iteration, errors5 asks the user to create a Box<dyn err:Error> without having learned about boxes or trait objects in any meaningful way. The new description and updated hint gives a brief use case for boxes as well as explaining exactly what the exercise is looking for.

The exercise has also been modified to scaffold out a basic Box<dyn ???> in order to point the user more precisely to what the exercise is asking for. 