### PR TITLE
Update move_semantics2 hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -195,7 +195,7 @@ all!
 2. Make `fill_vec` borrow its argument instead of taking ownership of it,
    and then copy the data within the function in order to return an owned
    `Vec<i32>`
-3. Make `fill_vec` *mutably* borrow its argument (which will need to be
+3. Make `fill_vec` *mutably* borrow a reference to its argument (which will need to be
    mutable), modify it directly, then not return anything. Then you can get rid
    of `vec1` entirely -- note that this will change what gets printed by the
    first `println!`"""


### PR DESCRIPTION
Add an additional clarification to the third option in the move_semantics2 hint that a reference should be provided.

I struggled a bit to understand the third option, since without a reference the suggestion would not pass the borrow checker. Adding the word reference should make it more clear what's expected. Here's the code I had implemented for this option:
```
fn main() {
    let mut vec0 = Vec::new();

    fill_vec(&mut vec0);

    // Do not change the following line!
    println!("{} has length {} content `{:?}`", "vec0", vec0.len(), vec0);

    vec0.push(88);

    // println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
}

fn fill_vec(vec: &mut Vec<i32>) -> () {
    vec.push(22);
    vec.push(44);
    vec.push(66);
}
```