### PR TITLE
change edition to 2021 in exercices.rs

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -121,7 +121,7 @@ impl Exercise {
                     r#"[package]
 name = "{}"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 [[bin]]
 name = "{}"
 path = "{}.rs""#,


### PR DESCRIPTION
workaround for this issue https://github.com/rust-lang/rustlings/issues/1022