### PR TITLE
fix(run): correct "PAS" in `integration_tests.rs`

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -176,7 +176,7 @@ fn run_single_test_success_with_output() {
         .current_dir("tests/fixture/success/")
         .assert()
         .code(0)
-        .stdout(predicates::str::contains("THIS TEST TOO SHALL PAS"));
+        .stdout(predicates::str::contains("THIS TEST TOO SHALL PASS"));
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn run_single_test_success_without_output() {
         .current_dir("tests/fixture/success/")
         .assert()
         .code(0)
-        .stdout(predicates::str::contains("THIS TEST TOO SHALL PAS").not());
+        .stdout(predicates::str::contains("THIS TEST TOO SHALL PASS").not());
 }
 
 #[test]


### PR DESCRIPTION
`run_single_test_success_with_output` and `run_single_test_success_without_output` check the stdout from this test:
https://github.com/rust-lang/rustlings/blob/a02b27975018f69c51147f5f8d9638a5f4e26811/tests/fixture/success/testSuccess.rs#L3

but are missing the final "S" in "PASS".