### PR TITLE
feat: add cow1.rs exercise

### DIFF
--- a/exercises/standard_library_types/cow1.rs
+++ b/exercises/standard_library_types/cow1.rs
@@ -1,0 +1,48 @@
+// cow1.rs
+
+// This exercise explores the Cow, or Clone-On-Write type.
+// Cow is a clone-on-write smart pointer.
+// It can enclose and provide immutable access to borrowed data, and clone the data lazily when mutation or ownership is required.
+// The type is designed to work with general borrowed data via the Borrow trait.
+
+// I AM NOT DONE
+
+use std::borrow::Cow;
+
+fn abs_all<'a, 'b>(input: &'a mut Cow<'b, [i32]>) -> &'a mut Cow<'b, [i32]> {
+    for i in 0..input.len() {
+        let v = input[i];
+        if v < 0 {
+            // Clones into a vector if not already owned.
+            input.to_mut()[i] = -v;
+        }
+    }
+    input
+}
+
+fn main() {
+    // No clone occurs because `input` doesn't need to be mutated.
+    let slice = [0, 1, 2];
+    let mut input = Cow::from(&slice[..]);
+    match abs_all(&mut input) {
+        Cow::Borrowed(_) => println!("I borrowed the slice!"),
+        _ => panic!("expected borrowed value"),
+    }
+
+    // Clone occurs because `input` needs to be mutated.
+    let slice = [-1, 0, 1];
+    let mut input = Cow::from(&slice[..]);
+    match abs_all(&mut input) {
+        Cow::Owned(_) => println!("I modified the slice and now own it!"),
+        _ => panic!("expected owned value"),
+    }
+
+    // No clone occurs because `input` is already owned.
+    let slice = vec![-1, 0, 1];
+    let mut input = Cow::from(slice);
+    match abs_all(&mut input) {
+        // TODO
+        Cow::Borrowed(_) => println!("I own this slice!"),
+        _ => panic!("expected borrowed value"),
+    }
+}

--- a/info.toml
+++ b/info.toml
@@ -932,6 +932,17 @@ is too much of a struggle, consider reading through all of Chapter 16 in the boo
 https://doc.rust-lang.org/stable/book/ch16-00-concurrency.html
 """
 
+[[exercises]]
+name = "cow1"
+path = "exercises/standard_library_types/cow1.rs"
+mode = "compile"
+hint = """
+Since the vector is already owned, the `Cow` type doesn't need to clone it.
+
+Checkout https://doc.rust-lang.org/std/borrow/enum.Cow.html for documentation
+on the `Cow` type.
+"""
+
 # THREADS
 
 [[exercises]]


### PR DESCRIPTION
Adds an exercise for the `Cow` type based off of the official documentation at https://doc.rust-lang.org/std/borrow/enum.Cow.html