### PR TITLE
fix: remove extra " typo in info.toml

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -746,7 +746,7 @@ path = "exercises/quiz3.rs"
 mode = "test"
 hint = """
 To find the best solution to this challenge you're going to need to think back to your
-knowledge of traits, specifically Trait Bound Syntax -  you may also need this: "use std::fmt::Display;""""
+knowledge of traits, specifically Trait Bound Syntax -  you may also need this: `use std::fmt::Display;`."""
 
 # TESTS
 


### PR DESCRIPTION
When I run `rustlings watch`, main.rs panics when trying to read info.toml which is caused by the extra " character on line 748 in the info.toml file. 

edit - realized we would want to keep `"use std::fmt::Display;"` so open to a better fix that the parser will be happy with