### PR TITLE
refactor(box1): prefer todo! over unimplemented!

### DIFF
--- a/exercises/standard_library_types/box1.rs
+++ b/exercises/standard_library_types/box1.rs
@@ -10,7 +10,7 @@
 // elements: the value of the current item and the next item. The last item is a value called `Nil`.
 //
 // Step 1: use a `Box` in the enum definition to make the code compile
-// Step 2: create both empty and non-empty cons lists by replacing `unimplemented!()`
+// Step 2: create both empty and non-empty cons lists by replacing `todo!()`
 //
 // Note: the tests should not be changed
 //
@@ -33,11 +33,11 @@ fn main() {
 }
 
 pub fn create_empty_list() -> List {
-    unimplemented!()
+    todo!()
 }
 
 pub fn create_non_empty_list() -> List {
-    unimplemented!()
+    todo!()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`todo!` better matches the exercise's intent than `unimplemented!`

> The difference between `unimplemented!` and `todo!` is that while `todo!` conveys an intent of implementing the functionality later and the message is "not yet implemented", `unimplemented!` makes no such claims. Its message is "not implemented". Also some IDEs will mark `todo!`s.

Furthermore, all other exercise's use `todo!`, so it's also a matter of consistency.