### PR TITLE
fix(traits5): make exercise prefer trait-based solution

### DIFF
--- a/exercises/traits/traits5.rs
+++ b/exercises/traits/traits5.rs
@@ -18,16 +18,20 @@ pub trait OtherTrait {
     }
 }
 
-struct SomeStruct {
-    name: String,
-}
+struct SomeStruct {}
+struct OtherStruct {}
 
 impl SomeTrait for SomeStruct {}
 impl OtherTrait for SomeStruct {}
+impl SomeTrait for OtherStruct {}
+impl OtherTrait for OtherStruct {}
 
 // YOU MAY ONLY CHANGE THE NEXT LINE
 fn some_func(item: ??) -> bool {
     item.some_function() && item.other_function()
 }
 
-fn main() {}
+fn main() {
+    some_func(SomeStruct {});
+    some_func(OtherStruct {});
+}


### PR DESCRIPTION
closes #1088

By adding usages of `some_func` to `main`, as well as having a second Struct which implements the traits, the solution for this exercise is to use traits. Without the usages, the exercise can be solved by substituting `SomeStruct` for `??`.