### PR TITLE
fix(macros-readme): update the book link to the more recent version of the book

### DIFF
--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -7,4 +7,4 @@ macros. Instead, we'll show you how to use and create them.
 ## Further information
 
 - [Macros](https://doc.rust-lang.org/book/ch19-06-macros.html)
-- [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html)
+- [The Little Book of Rust Macros](https://veykril.github.io/tlborm/)


### PR DESCRIPTION
The README for the macros exercise linked to the discontinued versions of the macros book. The newer version, however, is already linked in the macros4 hint:
https://github.com/rust-lang/rustlings/blob/300cdc27dd0eb06939e187f86dd5833d146339a3/info.toml#L1029-L1041
