### PR TITLE
`options2`: Convert the main function into tests

### DIFF
--- a/exercises/options/options2.rs
+++ b/exercises/options/options2.rs
@@ -3,23 +3,34 @@
 
 // I AM NOT DONE
 
-fn main() {
-    let optional_word = Some(String::from("rustlings"));
-    // TODO: Make this an if let statement whose value is "Some" type
-    word = optional_word {
-        println!("The word is: {}", word);
-    } else {
-        println!("The optional word doesn't contain anything");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_option() {
+        let target = "rustlings";
+        let optional_target = Some(target);
+
+        // TODO: Make this an if let statement whose value is "Some" type
+        if let Some(word) = optional_target {
+            assert_eq!(word, target);
+        }
     }
 
-    let mut optional_integers_vec: Vec<Option<i8>> = Vec::new();
-    for x in 1..10 {
-        optional_integers_vec.push(Some(x));
-    }
+    #[test]
+    fn layered_option() {
+        let mut range = 10;
+        let mut optional_integers: Vec<Option<i8>> = Vec::new();
+        for i in 0..(range + 1) {
+            optional_integers.push(Some(i));
+        }
 
-    // TODO: make this a while let statement - remember that vector.pop also adds another layer of Option<T>
-    // You can stack `Option<T>`'s into while let and if let
-    integer = optional_integers_vec.pop() {
-        println!("current value: {}", integer);
+        // TODO: make this a while let statement - remember that vector.pop also adds another layer of Option<T>
+        // You can stack `Option<T>`'s into while let and if let
+        while let Some(Some(integer)) = optional_integers.pop() {
+            assert_eq!(integer, range);
+            range -= 1;
+        }
     }
 }

--- a/exercises/options/options2.rs
+++ b/exercises/options/options2.rs
@@ -13,7 +13,7 @@ mod tests {
         let optional_target = Some(target);
 
         // TODO: Make this an if let statement whose value is "Some" type
-        if let Some(word) = optional_target {
+        word = optional_target {
             assert_eq!(word, target);
         }
     }
@@ -28,7 +28,7 @@ mod tests {
 
         // TODO: make this a while let statement - remember that vector.pop also adds another layer of Option<T>
         // You can stack `Option<T>`'s into while let and if let
-        while let Some(Some(integer)) = optional_integers.pop() {
+        integer = optional_integers.pop() {
             assert_eq!(integer, range);
             range -= 1;
         }

--- a/info.toml
+++ b/info.toml
@@ -545,7 +545,7 @@ is the easiest, but how do you do it safely so that it doesn't panic in your fac
 [[exercises]]
 name = "options2"
 path = "exercises/options/options2.rs"
-mode = "compile"
+mode = "test"
 hint = """
 check out:
 https://doc.rust-lang.org/rust-by-example/flow_control/if_let.html


### PR DESCRIPTION
Closes: #1109 

**Note**

The author of #1109 has elaborated on what the exercise lacks, and is comfortable with how the exercise currently is laid out.

**Changelog**

- Remove `main` function
- Make `options2` _test_, not _compile_