### PR TITLE
fixed exercise to cover all bases

### DIFF
--- a/exercises/hashmaps/hashmaps3.rs
+++ b/exercises/hashmaps/hashmaps3.rs
@@ -53,7 +53,8 @@ mod tests {
             + "England,France,4,2\n"
             + "France,Italy,3,1\n"
             + "Poland,Spain,2,0\n"
-            + "Germany,England,2,1\n";
+            + "Germany,England,2,1\n"
+            + "England,Spain,1,0\n";
         results
     }
 
@@ -73,7 +74,7 @@ mod tests {
     fn validate_team_score_1() {
         let scores = build_scores_table(get_results());
         let team = scores.get("England").unwrap();
-        assert_eq!(team.goals_scored, 5);
+        assert_eq!(team.goals_scored, 6);
         assert_eq!(team.goals_conceded, 4);
     }
 
@@ -82,6 +83,6 @@ mod tests {
         let scores = build_scores_table(get_results());
         let team = scores.get("Spain").unwrap();
         assert_eq!(team.goals_scored, 0);
-        assert_eq!(team.goals_conceded, 2);
+        assert_eq!(team.goals_conceded, 3);
     }
 }


### PR DESCRIPTION
The current version needs an extra entry that I added on line 57. This allows the tests to be thorough on what the exercise intended. An example of this can best be expressed on one of the answer repositories Here: https://github.com/nestoralonso/rustlings-answers/compare/answers...PerryCameron:rustlings-answers:answers