### PR TITLE
fix: quiz1 - price is cheaper for 40 or more

### DIFF
--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -21,6 +21,6 @@ fn verify_test() {
     let price3 = calculate_price_of_apples(65);
 
     assert_eq!(70, price1);
-    assert_eq!(80, price2);
+    assert_eq!(40, price2);
     assert_eq!(65, price3);
 }


### PR DESCRIPTION
The description says that the discount is for >= 40
but the test for the value of 40 doesn't apply the discount.
