### PR TITLE
fix(watch): make sure watch doesn't skip not passing exercises if you change a previous one

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -373,10 +373,20 @@ fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<WatchStatus> {
                             .into_iter()
                             .chain(
                                 exercises
-                                    .iter()
-                                    .filter(|e| !e.looks_done() && !filepath.ends_with(&e.path)),
+                                    .into_iter()
+                                    .take_while(|e| !filepath.ends_with(&e.path))
+                                    .filter(|e| !e.looks_done()),
+                            )
+                            .chain(
+                              exercises
+                                  .into_iter()
+                                  .skip_while(|e| !filepath.ends_with(&e.path)),
                             );
-                        let num_done = exercises.iter().filter(|e| e.looks_done()).count();
+                        let num_done = exercises
+                          .iter()
+                          .take_while(|e| !filepath.ends_with(&e.path))
+                          .filter(|e| e.looks_done())
+                          .count();
                         clear_screen();
                         match verify(pending_exercises, (num_done, exercises.len()), verbose) {
                             Ok(_) => return Ok(WatchStatus::Finished),


### PR DESCRIPTION
Hi. Thanks for all the rustling exercises, I loved working on them :crab:

I started with a local git clone of this repo and ran `rustlings watch`. During my journey I did not solve all of the tasks at once, and sometimes a whole week went away before I got time to open it up again. Hence, I always started with rebasing my local "solutions" branch onto the latest release - first one was 4.8 and I finished the course with 5.2.0. During the rebases I got some conflicts I had to resolve - no problem, I thought I can do it by running `rustlings watch` and fix broken files. However, it did not work as I imagined: after I solved the first broken file with conflicts in it, the watch command skipped all the other broken files and told me that I'm ready to learn something new. In case I restarted the watcher, it always picked the first broken exercise and skipped the others when I was ready with that one due to the missing `// I AM NOT DONE` comments.

In my fix I split the exercises into two arrays: the ones before the current file and the ones after it. The exercises in the first group could be skipped when they look done because the watcher already built them since their last modification. However, the files after the current exercise shouldn't be handled as done because we haven't verified yet that they are passing.

I hope this makes sense and you'll find my PR helpful.