### PR TITLE
fix(quiz1): Inaccurate instructions

### DIFF
--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -5,7 +5,7 @@
 // - If
 
 // Mary is buying apples. One apple usually costs 2 Rustbucks, but if you buy
-// 40 or more at once, each apple only costs 1! Write a function that calculates
+// more than 40 at once, each apple only costs 1! Write a function that calculates
 // the price of an order of apples given the quantity bought. No hints this time!
 
 // I AM NOT DONE


### PR DESCRIPTION
The code checks for an assertion of `assert_eq!(80, price2);` which means that we only double the cost when the number of apples >= 41, not 40; Changing the language here makes the instructions clear