### PR TITLE
Make changes to quiz1 so that tests match problem.

### DIFF
--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -21,6 +21,6 @@ fn verify_test() {
     let price3 = calculate_price_of_apples(65);
 
     assert_eq!(70, price1);
-    assert_eq!(80, price2);
+    assert_eq!(40, price2);
     assert_eq!(65, price3);
 }


### PR DESCRIPTION
40 or more implies quantities greater than or equal receive the discount. Therefore, when I pass in 40 during the test I should return 40 instead of 80.