### PR TITLE
Revert #1164

### DIFF
--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -5,7 +5,7 @@
 // - If
 
 // Mary is buying apples. One apple usually costs 2 Rustbucks, but if you buy
-// 40 or more at once, each apple only costs 1! Write a function that calculates
+// more than 40 at once, each apple only costs 1! Write a function that calculates
 // the price of an order of apples given the quantity bought. No hints this time!
 
 // I AM NOT DONE

--- a/exercises/quiz1.rs
+++ b/exercises/quiz1.rs
@@ -18,9 +18,11 @@
 fn verify_test() {
     let price1 = calculate_price_of_apples(35);
     let price2 = calculate_price_of_apples(40);
-    let price3 = calculate_price_of_apples(65);
+    let price3 = calculate_price_of_apples(41);
+    let price4 = calculate_price_of_apples(65);
 
     assert_eq!(70, price1);
     assert_eq!(80, price2);
-    assert_eq!(65, price3);
+    assert_eq!(41, price3);
+    assert_eq!(65, price4);
 }


### PR DESCRIPTION
#1164 introduced an error rather than fixing it. Second assert states that 40 apples have a price of 80, therefore, 40 apples still cost 2 Rustbucks per apple.