### PR TITLE
fix: Add a deref in the test code

### DIFF
--- a/exercises/conversions/as_ref_mut.rs
+++ b/exercises/conversions/as_ref_mut.rs
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn mult_box() {
         let mut num: Box<u32> = Box::new(3);
-        num_sq(&mut num);
+        num_sq(&mut *num);
         assert_eq!(*num, 9);
     }
 }


### PR DESCRIPTION
This change makes it possible to finish the last exercise without touching the test code, seems like an overlook when code was added since there's nothing in the hints about this extension neither.

It's virtually impossible to write a the `num_sq` function to take the Box since it doesn't implement `MulAssign`.