### PR TITLE
Add link to `std` in `strings3` hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -449,7 +449,7 @@ path = "exercises/strings/strings3.rs"
 mode = "test"
 hint = """
 There's tons of useful standard library functions for strings. Let's try and use some of
-them!
+them: <https://doc.rust-lang.org/std/string/struct.String.html#method.trim>!
 
 For the compose_me method: You can either use the `format!` macro, or convert the string
 slice into an owned string, which you can then freely extend."""


### PR DESCRIPTION
Seems like it's the first place, where `std` is introduced in Rustlings, and it's a good place to facilitate docs discovery for user. As _the book_ seems to have no Rustlings-sized solutions for this exercise.