### PR TITLE
Switch `arc` and `rc` exercises order

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -916,6 +916,20 @@ and try other types!
 """
 
 [[exercises]]
+name = "rc1"
+path = "exercises/standard_library_types/rc1.rs"
+mode = "compile"
+hint = """
+This is a straightforward exercise to use the Rc<T> type. Each Planet has
+ownership of the Sun, and uses Rc::clone() to increment the reference count of the Sun.
+After using drop() to move the Planets out of scope individually, the reference count goes down.
+In the end the sun only has one reference again, to itself. See more at:
+https://doc.rust-lang.org/book/ch15-04-rc.html
+
+* Unfortunately Pluto is no longer considered a planet :(
+"""
+
+[[exercises]]
 name = "arc1"
 path = "exercises/standard_library_types/arc1.rs"
 mode = "compile"
@@ -930,20 +944,6 @@ thread-local copy of the numbers.
 This is a simple exercise if you understand the underlying concepts, but if this
 is too much of a struggle, consider reading through all of Chapter 16 in the book:
 https://doc.rust-lang.org/stable/book/ch16-00-concurrency.html
-"""
-
-[[exercises]]
-name = "rc1"
-path = "exercises/standard_library_types/rc1.rs"
-mode = "compile"
-hint = """
-This is a straightforward exercise to use the Rc<T> type. Each Planet has
-ownership of the Sun, and uses Rc::clone() to increment the reference count of the Sun.
-After using drop() to move the Planets out of scope individually, the reference count goes down.
-In the end the sun only has one reference again, to itself. See more at:
-https://doc.rust-lang.org/book/ch15-04-rc.html
-
-* Unfortunately Pluto is no longer considered a planet :(
 """
 
 [[exercises]]


### PR DESCRIPTION
`rc` should totally be introduced _before_ `arc`