### PR TITLE
improve hint for iterators1

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -818,9 +818,9 @@ Step 1:
 We need to apply something to the collection `my_fav_fruits` before we start to go through
 it. What could that be? Take a look at the struct definition for a vector for inspiration:
 https://doc.rust-lang.org/std/vec/struct.Vec.html.
-Step 2 & step 2.1:
+Step 2 & step 3:
 Very similar to the lines above and below. You've got this!
-Step 3:
+Step 4:
 An iterator goes through all elements in a collection, but what if we've run out of
 elements? What should we expect here? If you're stuck, take a look at
 https://doc.rust-lang.org/std/iter/trait.Iterator.html for some ideas.


### PR DESCRIPTION
step 2.1 was renamed to step 3, and step 3 was renamed to step 4 in `iterators1.rs` (0bd7a0631a17a9d69af5746795a30efc9cf64e6e), but the hint was not updated accordingly.