### PR TITLE
Open next pending exercise with `rustlings next`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "edit"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c562aa71f7bc691fde4c6bf5f93ae5a5298b617c2eb44c76c87832299a17fbb4"
+dependencies = [
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +129,15 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -228,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,9 +300,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "log"
@@ -458,12 +492,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rustlings"
 version = "5.2.1"
 dependencies = [
  "argh",
  "assert_cmd",
  "console",
+ "edit",
  "glob",
  "home",
  "indicatif",
@@ -539,6 +583,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +648,17 @@ dependencies = [
  "same-file",
  "winapi 0.3.9",
  "winapi-util",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
 home = "0.5.3"
 glob = "0.3.0"
+edit = "0.1.4"
 
 [[bin]]
 name = "rustlings"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ To check your progress, you can run the following command:
 rustlings list
 ```
 
+To open the next pending exercise:
+```bash
+rustlings next
+# or EDITOR=vim rustlings next
+```
+> Please make sure to properly configure your `$EDITOR` env variable in your _.bashrc_ with `export EDITOR='vim'`. Or any of your favorite editor ;)
+
 ## Testing yourself
 
 After every couple of sections, there will be a quiz that'll test your knowledge on a bunch of sections at once. These quizzes are found in `exercises/quizN.rs`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ enum Subcommands {
     Reset(ResetArgs),
     Hint(HintArgs),
     List(ListArgs),
+    Next(NextArgs),
     Lsp(LspArgs),
 }
 
@@ -115,6 +116,20 @@ struct ListArgs {
     #[argh(switch, short = 's')]
     /// display only exercises that have been solved
     solved: bool,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "next")]
+/// Opens the next pending exercise in Rustlings using the EDITOR environment variable.
+/// Please set your EDITOR environment variable in your .bashrc or run EDITOR=vim rustlings next
+struct NextArgs {
+    #[argh(switch, short = 'p')]
+    /// print the path of the next pending exercise
+    path: bool,
+
+    #[argh(switch, short = 'n')]
+    /// print the name of the next pending exercise
+    name: bool,
 }
 
 fn main() {
@@ -208,6 +223,19 @@ fn main() {
                 percentage_progress
             );
             std::process::exit(0);
+        }
+
+        Subcommands::Next(subargs) => {
+            let exercise = find_exercise(&"next", &exercises);
+
+            if subargs.name {
+                println!("{}", exercise.name);
+            } else if subargs.path {
+                println!("{}", exercise.path.display());
+            } else {
+                edit::edit_file(&exercise.path)
+                    .expect("Couldn't open the default EDITOR, have you configured $EDITOR properly?");
+            }
         }
 
         Subcommands::Run(subargs) => {


### PR DESCRIPTION
**Problem:**
It is cumbersome to find the next pending exercise. 
[closes #1201](https://github.com/rust-lang/rustlings/issues/1201)

**Solution:**
Added a new command to open the next pending exercise in $EDITOR:
```bash
rustlings next
# or EDITOR=vim rustlings next
# or EDITOR=code rustlings next
```