### PR TITLE
feat: Add VSCode extension recommendation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ exercises/clippy/Cargo.toml
 exercises/clippy/Cargo.lock
 rust-project.json
 .idea
-.vscode
+.vscode/*
+!.vscode/extensions.json
 *.iml
 *.o

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer"
+    ]
+}


### PR DESCRIPTION
VSCode supports recommending extensions through a file : https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions

This is what the prompt looks like:    
![image](https://user-images.githubusercontent.com/11901979/193287224-f2fbd37c-b84c-4759-bb30-daa55a8a04e7.png)

I think this allows us to help newcomers set-up their tooling easily, and that the recommended extension ([rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)) is pretty consensual.

Usually I am in favour of leaving IDE config files out of repositories, but I think this is a good fit for rustlings.

Let me know your thoughts!