### PR TITLE
additional test for fees

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -78,5 +78,6 @@ mod tests {
         let package = Package::new(sender_country, recipient_country, 1500);
 
         assert_eq!(package.get_fees(cents_per_gram), 4500);
+        assert_eq!(package.get_fees(cents_per_gram*2), 9000);
     }
 }

--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -78,6 +78,6 @@ mod tests {
         let package = Package::new(sender_country, recipient_country, 1500);
 
         assert_eq!(package.get_fees(cents_per_gram), 4500);
-        assert_eq!(package.get_fees(cents_per_gram*2), 9000);
+        assert_eq!(package.get_fees(cents_per_gram * 2), 9000);
     }
 }


### PR DESCRIPTION
There is only one condition to test get_fees. 
Returning 4500 would get a green test.
A additional Test with double price per gram would make things harder. 