### PR TITLE
docs(options1): fix and clarify 24 hour time instruction

### DIFF
--- a/exercises/options/options1.rs
+++ b/exercises/options/options1.rs
@@ -8,8 +8,8 @@
 // all, so there'll be no more left :(
 // TODO: Return an Option!
 fn maybe_icecream(time_of_day: u16) -> Option<u16> {
-    // We use the 24-hour system here, so 10PM is a value of 22
-    // The Option output should gracefully handle cases where time_of_day > 24.
+    // We use the 24-hour system here, so 10PM is a value of 22 and 12AM is a value of 0
+    // The Option output should gracefully handle cases where time_of_day > 23.
     ???
 }
 


### PR DESCRIPTION
This PR fixes a corner case in the instructions for the options1 exercise which conflicts with the ordinary understanding of 24-hour time. The corner case was not checked for by any of the asserts in the exercise, so I was unable to find a current issue. The problem is that 24 is not a valid hour for 24-hour time, so None should be returned when `time_of_day > 23`, not when `time_of_day > 24` as in the main branch. Additionally, I added an extra (and redundant) explanation that “12 AM is a value of 0” in order to hopefully hint that the 24 hours in “24-hour time” are 0-23.

I considered and abandoned (for this commit) adding additional `assert_eq!` invocations for when time_of_day is 0 or 24.