### PR TITLE
Apply uninlined-format-args clippy lint

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -20,7 +20,7 @@ fn temp_file() -> String {
         .filter(|c| c.is_alphanumeric())
         .collect();
 
-    format!("./temp_{}_{}", process::id(), thread_id)
+    format!("./temp_{}_{thread_id}", process::id())
 }
 
 // The mode of the exercise.

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,12 +121,12 @@ fn main() {
     let args: Args = argh::from_env();
 
     if args.version {
-        println!("v{}", VERSION);
+        println!("v{VERSION}");
         std::process::exit(0);
     }
 
     if args.nested.is_none() {
-        println!("\n{}\n", WELCOME);
+        println!("\n{WELCOME}\n");
     }
 
     if !Path::new("info.toml").exists() {
@@ -150,7 +150,7 @@ fn main() {
     let verbose = args.nocapture;
 
     let command = args.nested.unwrap_or_else(|| {
-        println!("{}\n", DEFAULT_OUT);
+        println!("{DEFAULT_OUT}\n");
         std::process::exit(0);
     });
     match command {
@@ -179,11 +179,11 @@ fn main() {
                 };
                 if solve_cond && (filter_cond || subargs.filter.is_none()) {
                     let line = if subargs.paths {
-                        format!("{}\n", fname)
+                        format!("{fname}\n")
                     } else if subargs.names {
                         format!("{}\n", e.name)
                     } else {
-                        format!("{:<17}\t{:<46}\t{:<7}\n", e.name, fname, status)
+                        format!("{:<17}\t{fname:<46}\t{status:<7}\n", e.name)
                     };
                     // Somehow using println! leads to the binary panicking
                     // when its output is piped.
@@ -266,7 +266,7 @@ fn main() {
                     "{emoji} All exercises completed! {emoji}",
                     emoji = Emoji("🎉", "★")
                 );
-                println!("\n{}\n", FENISH_LINE);
+                println!("\n{FENISH_LINE}\n");
             }
             Ok(WatchStatus::Unfinished) => {
                 println!("We hope you're enjoying learning about Rust!");
@@ -289,7 +289,7 @@ fn spawn_watch_shell(
                 let input = input.trim();
                 if input == "hint" {
                     if let Some(hint) = &*failed_exercise_hint.lock().unwrap() {
-                        println!("{}", hint);
+                        println!("{hint}");
                     }
                 } else if input == "clear" {
                     println!("\x1B[2J\x1B[1;1H");
@@ -306,10 +306,10 @@ fn spawn_watch_shell(
                     println!("Watch mode automatically re-evaluates the current exercise");
                     println!("when you edit a file's contents.")
                 } else {
-                    println!("unknown command: {}", input);
+                    println!("unknown command: {input}");
                 }
             }
-            Err(error) => println!("error reading command: {}", error),
+            Err(error) => println!("error reading command: {error}"),
         }
     });
 }
@@ -329,7 +329,7 @@ fn find_exercise<'a>(name: &str, exercises: &'a [Exercise]) -> &'a Exercise {
             .iter()
             .find(|e| e.name == name)
             .unwrap_or_else(|| {
-                println!("No exercise found for '{}'!", name);
+                println!("No exercise found for '{name}'!");
                 std::process::exit(1)
             })
     }
@@ -392,7 +392,7 @@ fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<WatchStatus> {
             Err(RecvTimeoutError::Timeout) => {
                 // the timeout expired, just check the `should_quit` variable below then loop again
             }
-            Err(e) => println!("watch error: {:?}", e),
+            Err(e) => println!("watch error: {e:?}"),
         }
         // Check if we need to exit
         if should_quit.load(Ordering::SeqCst) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -35,7 +35,7 @@ pub fn reset(exercise: &Exercise) -> Result<(), ()> {
 // This is strictly for non-test binaries, so output is displayed
 fn compile_and_run(exercise: &Exercise) -> Result<(), ()> {
     let progress_bar = ProgressBar::new_spinner();
-    progress_bar.set_message(format!("Compiling {}...", exercise));
+    progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);
 
     let compilation_result = exercise.compile();
@@ -52,7 +52,7 @@ fn compile_and_run(exercise: &Exercise) -> Result<(), ()> {
         }
     };
 
-    progress_bar.set_message(format!("Running {}...", exercise));
+    progress_bar.set_message(format!("Running {exercise}..."));
     let result = compilation.run();
     progress_bar.finish_and_clear();
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -48,7 +48,7 @@ pub fn test(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
 // Invoke the rust compiler without running the resulting binary
 fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
-    progress_bar.set_message(format!("Compiling {}...", exercise));
+    progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);
 
     let _ = compile(exercise, &progress_bar)?;
@@ -60,12 +60,12 @@ fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
 // Compile the given Exercise and run the resulting binary in an interactive mode
 fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
-    progress_bar.set_message(format!("Compiling {}...", exercise));
+    progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);
 
     let compilation = compile(exercise, &progress_bar)?;
 
-    progress_bar.set_message(format!("Running {}...", exercise));
+    progress_bar.set_message(format!("Running {exercise}..."));
     let result = compilation.run();
     progress_bar.finish_and_clear();
 
@@ -86,7 +86,7 @@ fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
 // the output if verbose is set to true
 fn compile_and_test(exercise: &Exercise, run_mode: RunMode, verbose: bool) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
-    progress_bar.set_message(format!("Testing {}...", exercise));
+    progress_bar.set_message(format!("Testing {exercise}..."));
     progress_bar.enable_steady_tick(100);
 
     let compilation = compile(exercise, &progress_bar)?;
@@ -165,16 +165,16 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
 
     println!();
     if no_emoji {
-        println!("~*~ {} ~*~", success_msg)
+        println!("~*~ {success_msg} ~*~")
     } else {
-        println!("🎉 🎉  {} 🎉 🎉", success_msg)
+        println!("🎉 🎉  {success_msg} 🎉 🎉")
     }
     println!();
 
     if let Some(output) = prompt_output {
         println!("Output:");
         println!("{}", separator());
-        println!("{}", output);
+        println!("{output}");
         println!("{}", separator());
         println!();
     }


### PR DESCRIPTION
This lint should also be applied to the excersies, but I am not certain how to run it for all non-crate individual files.

To re-run:

```
rustup run nightly cargo clippy --fix -- -A clippy::all -W clippy::uninlined_format_args
```