### PR TITLE
style: explicitly use Arc::clone

### DIFF
--- a/exercises/threads/threads2.rs
+++ b/exercises/threads/threads2.rs
@@ -17,7 +17,7 @@ fn main() {
     let status = Arc::new(JobStatus { jobs_completed: 0 });
     let mut handles = vec![];
     for _ in 0..10 {
-        let status_shared = status.clone();
+        let status_shared = Arc::clone(&status);
         let handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(250));
             // TODO: You must take an action before you update a shared value

--- a/exercises/threads/threads3.rs
+++ b/exercises/threads/threads3.rs
@@ -26,8 +26,8 @@ impl Queue {
 
 fn send_tx(q: Queue, tx: mpsc::Sender<u32>) -> () {
     let qc = Arc::new(q);
-    let qc1 = qc.clone();
-    let qc2 = qc.clone();
+    let qc1 = Arc::clone(&qc);
+    let qc2 = Arc::clone(&qc);
 
     thread::spawn(move || {
         for val in &qc1.first_half {


### PR DESCRIPTION
The [Rust book](https://doc.rust-lang.org/book/ch15-04-rc.html?highlight=clone()#cloning-an-rc-increases-the-reference-count) recommends `Arc::clone` over just `.clone()` to highlight the fact that this doesn't perform a deep copy the way other types' implementations do.