### PR TITLE
fix: Revert deref change

### DIFF
--- a/exercises/conversions/as_ref_mut.rs
+++ b/exercises/conversions/as_ref_mut.rs
@@ -17,7 +17,7 @@ fn char_counter<T>(arg: T) -> usize {
     arg.as_ref().chars().count()
 }
 
-// Squares a number using AsMut. Add the trait bound as is appropriate and
+// Squares a number using as_mut(). Add the trait bound as is appropriate and
 // implement the function body.
 fn num_sq<T>(arg: &mut T) {
     ???
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn mult_box() {
         let mut num: Box<u32> = Box::new(3);
-        num_sq(&mut *num);
+        num_sq(&mut num);
         assert_eq!(*num, 9);
     }
 }


### PR DESCRIPTION
Revert the addition of a deref in PR #1192 by me, which should not be there.

Apologies for the inconvenience caused.

Also remove me from the contributors list if neccessary as this was my only contribution. 