### PR TITLE
refactor(cow1):  replace main with tests

### DIFF
--- a/exercises/smart_pointers/cow1.rs
+++ b/exercises/smart_pointers/cow1.rs
@@ -4,6 +4,9 @@
 // Cow is a clone-on-write smart pointer.
 // It can enclose and provide immutable access to borrowed data, and clone the data lazily when mutation or ownership is required.
 // The type is designed to work with general borrowed data via the Borrow trait.
+//
+// This exercise is meant to show you what to expect when passing data to Cow.
+// Fix the unit tests by checking for Cow::Owned(_) and Cow::Borrowed(_) at the TODO markers.
 
 // I AM NOT DONE
 
@@ -20,29 +23,52 @@ fn abs_all<'a, 'b>(input: &'a mut Cow<'b, [i32]>) -> &'a mut Cow<'b, [i32]> {
     input
 }
 
-fn main() {
-    // No clone occurs because `input` doesn't need to be mutated.
-    let slice = [0, 1, 2];
-    let mut input = Cow::from(&slice[..]);
-    match abs_all(&mut input) {
-        Cow::Borrowed(_) => println!("I borrowed the slice!"),
-        _ => panic!("expected borrowed value"),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_mutation() -> Result<(), &'static str> {
+        // Clone occurs because `input` needs to be mutated.
+        let slice = [-1, 0, 1];
+        let mut input = Cow::from(&slice[..]);
+        match abs_all(&mut input) {
+            Cow::Owned(_) => Ok(()),
+            _ => Err("Expected owned value"),
+        }
     }
 
-    // Clone occurs because `input` needs to be mutated.
-    let slice = [-1, 0, 1];
-    let mut input = Cow::from(&slice[..]);
-    match abs_all(&mut input) {
-        Cow::Owned(_) => println!("I modified the slice and now own it!"),
-        _ => panic!("expected owned value"),
+    #[test]
+    fn reference_no_mutation() -> Result<(), &'static str> {
+        // No clone occurs because `input` doesn't need to be mutated.
+        let slice = [0, 1, 2];
+        let mut input = Cow::from(&slice[..]);
+        match abs_all(&mut input) {
+            // TODO
+        }
     }
 
-    // No clone occurs because `input` is already owned.
-    let slice = vec![-1, 0, 1];
-    let mut input = Cow::from(slice);
-    match abs_all(&mut input) {
-        // TODO
-        Cow::Borrowed(_) => println!("I own this slice!"),
-        _ => panic!("expected borrowed value"),
+    #[test]
+    fn owned_no_mutation() -> Result<(), &'static str> {
+        // We can also pass `slice` without `&` so Cow owns it directly.
+        // In this case no mutation occurs and thus also no clone,
+        // but the result is still owned because it always was.
+        let slice = vec![0, 1, 2];
+        let mut input = Cow::from(slice);
+        match abs_all(&mut input) {
+            // TODO
+        }
+    }
+
+    #[test]
+    fn owned_mutation() -> Result<(), &'static str> {
+        // Of course this is also the case if a mutation does occur.
+        // In this case the call to `to_mut()` returns a reference to
+        // the same data as before.
+        let slice = vec![-1, 0, 1];
+        let mut input = Cow::from(slice);
+        match abs_all(&mut input) {
+            // TODO
+        }
     }
 }

--- a/info.toml
+++ b/info.toml
@@ -1010,11 +1010,11 @@ https://doc.rust-lang.org/stable/book/ch16-00-concurrency.html
 [[exercises]]
 name = "cow1"
 path = "exercises/smart_pointers/cow1.rs"
-mode = "compile"
+mode = "test"
 hint = """
-Since the vector is already owned, the `Cow` type doesn't need to clone it.
+If Cow already owns the data it doesn't need to clone it when to_mut() is called.
 
-Checkout https://doc.rust-lang.org/std/borrow/enum.Cow.html for documentation
+Check out https://doc.rust-lang.org/std/borrow/enum.Cow.html for documentation
 on the `Cow` type.
 """
 


### PR DESCRIPTION
Following the discussion in #1195 this is the best I could come up with. The issue for me (and apparently a few other learners) was that the code needed to complete the exercise was not _missing_, but was rather there but wrong.

In the end, what made the difference between this exercise and others (for me) was that in this exercise I was supposed to learn what to *expect* of an output. So I think it makes sense here to let the learner modify the tests and not the code itself.

Side note: once [`assert_match!`](https://doc.rust-lang.org/std/assert_matches/macro.assert_matches.html) becomes stable I'd like to integrate it here just to expose the learner to it and because it makes the tests much clearer to read. This is how I had written it before realizing that probably most people don't use nightly to play through rustlings. 😆 

```rust
#[test]
fn reference_no_mutation() {
    // No clone occurs because `input` doesn't need to be mutated.
    let slice = [0, 1, 2];
    let mut input = Cow::from(&slice[..]);
    assert_match!(
        abs_all(&mut input),
        Cow::Borrowed(_),
        "Expected borrowed value"
    );
}
````