### PR TITLE
fix(traits4): Updated `compare_license_types` to Use References

### DIFF
--- a/exercises/traits/traits4.rs
+++ b/exercises/traits/traits4.rs
@@ -33,7 +33,7 @@ mod tests {
         let some_software = SomeSoftware {};
         let other_software = OtherSoftware {};
 
-        assert!(compare_license_types(some_software, other_software));
+        assert!(compare_license_types(&some_software, &other_software));
     }
 
     #[test]
@@ -41,6 +41,6 @@ mod tests {
         let some_software = SomeSoftware {};
         let other_software = OtherSoftware {};
 
-        assert!(compare_license_types(other_software, some_software));
+        assert!(compare_license_types(&other_software, &some_software));
     }
 }


### PR DESCRIPTION
* The `compare_license_types` function shouldn’t take ownership of its parameters