### PR TITLE
feat(macros-readme): Add link to MacroKata

### DIFF
--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -4,6 +4,10 @@ Rust's macro system is very powerful, but also kind of difficult to wrap your
 head around. We're not going to teach you how to write your own fully-featured
 macros. Instead, we'll show you how to use and create them.
 
+If you'd like to learn more about writing your own macros, the 
+[macrokata](https://github.com/tfpk/macrokata) project has a similar style
+of exercises to Rustlings, but is all about learning to write Macros.
+
 ## Further information
 
 - [Macros](https://doc.rust-lang.org/book/ch19-06-macros.html)


### PR DESCRIPTION
I recently created a series of exercises focused on writing fully featured Macros; since rustlings doesn't have an extensive course
on this. I considered merging them into rustlings (and I'd be happy to look at doing so); but since they focus heavily on using cargo-expand to show what the macros are; I didn't want to force rustlings to have a dependency on nightly.

Hopefully this resource can help your users out too!