### PR TITLE
style: format errors5 & errors6 with rustfmt

### DIFF
--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -7,7 +7,7 @@
 // For now, think of the `Box<dyn ...>` type as an "I want anything that does ???" type, which, given
 // Rust's usual standards for runtime safety, should strike you as somewhat lenient!
 
-// In short, this particular use case for boxes is for when you want to own a value and you care only that it is a 
+// In short, this particular use case for boxes is for when you want to own a value and you care only that it is a
 // type which implements a particular trait. To do so, The Box is declared as of type Box<dyn Trait> where Trait is the trait
 // the compiler looks for on any value used in that context. For this exercise, that context is the potential errors
 // which can be returned in a Result.
@@ -46,7 +46,7 @@ impl PositiveNonzeroInteger {
         match value {
             x if x < 0 => Err(CreationError::Negative),
             x if x == 0 => Err(CreationError::Zero),
-            x => Ok(PositiveNonzeroInteger(x as u64))
+            x => Ok(PositiveNonzeroInteger(x as u64)),
         }
     }
 }

--- a/exercises/error_handling/errors6.rs
+++ b/exercises/error_handling/errors6.rs
@@ -16,7 +16,7 @@ use std::num::ParseIntError;
 #[derive(PartialEq, Debug)]
 enum ParsePosNonzeroError {
     Creation(CreationError),
-    ParseInt(ParseIntError)
+    ParseInt(ParseIntError),
 }
 
 impl ParsePosNonzeroError {
@@ -27,14 +27,11 @@ impl ParsePosNonzeroError {
     // fn from_parseint...
 }
 
-fn parse_pos_nonzero(s: &str)
-    -> Result<PositiveNonzeroInteger, ParsePosNonzeroError>
-{
+fn parse_pos_nonzero(s: &str) -> Result<PositiveNonzeroInteger, ParsePosNonzeroError> {
     // TODO: change this to return an appropriate error instead of panicking
     // when `parse()` returns an error.
     let x: i64 = s.parse().unwrap();
-    PositiveNonzeroInteger::new(x)
-        .map_err(ParsePosNonzeroError::from_creation)
+    PositiveNonzeroInteger::new(x).map_err(ParsePosNonzeroError::from_creation)
 }
 
 // Don't change anything below this line.
@@ -53,7 +50,7 @@ impl PositiveNonzeroInteger {
         match value {
             x if x < 0 => Err(CreationError::Negative),
             x if x == 0 => Err(CreationError::Zero),
-            x => Ok(PositiveNonzeroInteger(x as u64))
+            x => Ok(PositiveNonzeroInteger(x as u64)),
         }
     }
 }


### PR DESCRIPTION
Quick formatting fix using `rustfmt` on `errors5.rs` and `errors6.rs`. 