### PR TITLE
fix #1267

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::exercise::{Exercise, Mode};
-use crate::verify::test;
+use crate::verify::{test, compile_only};
 use indicatif::ProgressBar;
 
 // Invoke the rust compiler on the path of the given exercise,
@@ -12,7 +12,10 @@ pub fn run(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
     match exercise.mode {
         Mode::Test => test(exercise, verbose)?,
         Mode::Compile => compile_and_run(exercise)?,
-        Mode::Clippy => compile_and_run(exercise)?,
+        Mode::Clippy => match compile_only(exercise).unwrap() {
+            true => return Err(()),
+            false => return Ok(()),
+        },
     }
     Ok(())
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -48,7 +48,7 @@ pub fn test(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
 }
 
 // Invoke the rust compiler without running the resulting binary
-fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
+pub fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);


### PR DESCRIPTION
question description: rustlings run clippy3 will notice error but rustlings watch and rustlings verify is ok; 
fix: when the run function match Mode::Clippy type and then execute compile_and_run; maybe should execute compile_only