### PR TITLE
fix: Update structs3 hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -386,11 +386,9 @@ name = "structs3"
 path = "exercises/structs/structs3.rs"
 mode = "test"
 hint = """
-The new method needs to panic if the weight is physically impossible :), how do we do that in Rust?
-
 For is_international: What makes a package international? Seems related to the places it goes through right?
 
-For calculate_transport_fees: Bigger is more expensive usually, we don't have size, but something may fit the bill here :)
+For get_fees: This method takes an additional argument, is there a field in the Package struct that this relates to?
 
 Have a look in The Book, to find out more about method implementations: https://doc.rust-lang.org/book/ch05-03-method-syntax.html"""
 


### PR DESCRIPTION
- Removed reference to panic! since this exercise has been updated so that this step is no longer required https://github.com/rust-lang/rustlings/issues/685
- Updated hint for `get_fees` to use the name of the function to be implemented rather than the name of the test, and to make the hint a bit more helpful