### PR TITLE
Fix E0531 in quiz2.rs

### DIFF
--- a/exercises/quiz2.rs
+++ b/exercises/quiz2.rs
@@ -27,7 +27,8 @@ pub enum Command {
 }
 
 mod my_module {
-    use super::Command;
+    use Command;
+    use Command::*;
 
     // TODO: Complete the function signature!
     pub fn transformer(input: ???) -> ??? {
@@ -44,7 +45,7 @@ mod my_module {
 mod tests {
     // TODO: What do we have to import to have `transformer` in scope?
     use ???;
-    use super::Command;
+    use Command;
 
     #[test]
     fn it_works() {


### PR DESCRIPTION
Hi,

completing the exercise makes rustc complain about E0531:
<pre>
   ⚠️  Compiling of exercises/quiz2.rs failed! Please try again. Here's the output:
   error[E0531]: cannot find tuple struct or tuple variant `Append` in this scope
   help: consider importing this tuple variant
      |
   30 |     use Command::Append;
      |
</pre>

If the suggestion given by rustc is added to the code, the tests fail in a weird way:
<pre>
   thread 'tests::it_works' panicked at 'assertion failed: `(left == right)`
   left: `" ALL ROADS LEAD TO ROME! "`,
   right: `"all roads lead to rome!"`', exercises/quiz2.rs:62:9
</pre>

I'm not even sure what is happening, just that adding a use clause for Command::* is needed. I don't think this is really clear for people just learning Rust, and given that completing another use clause is also part of the quiz, I think this change would improve the quiz.