### PR TITLE
docs: fix ordering of exercises

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -3,22 +3,22 @@
 | Exercise               | Book Chapter        |
 | ---------------------- | ------------------- |
 | variables              | §3.1                |
+| primitive_types        | §3.2, §4.3          |
 | functions              | §3.3                |
 | if                     | §3.5                |
-| primitive_types        | §3.2, §4.3          |
-| vecs                   | §8.1                |
 | move_semantics         | §4.1, §4.2          |
 | structs                | §5.1, §5.3          |
 | enums                  | §6, §18.3           |
-| strings                | §8.2                |
 | modules                | §7                  |
+| vecs                   | §8.1                |
+| strings                | §8.2                |
 | hashmaps               | §8.3                |
-| options                | §10.1               |
 | error_handling         | §9                  |
 | generics               | §10                 |
+| options                | §10.1               |
 | traits                 | §10.2               |
-| tests                  | §11.1               |
 | lifetimes              | §10.3               |
+| tests                  | §11.1               |
 | standard_library_types | §13.2, §15.1, §16.3 |
 | threads                | §16.1, §16.2, §16.3 |
 | macros                 | §19.6               |


### PR DESCRIPTION
I've sorted the exercises in the README based on the first book chapter.
I think this will make it easier to find the exercise that matches the book chapter and also make it easier to get an overview of the chronological order.