### PR TITLE
fix: Remove superfluous &self indirection

### DIFF
--- a/exercises/enums/enums2.rs
+++ b/exercises/enums/enums2.rs
@@ -10,7 +10,7 @@ enum Message {
 
 impl Message {
     fn call(&self) {
-        println!("{:?}", &self);
+        println!("{:?}", self);
     }
 }
 


### PR DESCRIPTION
Remove unneeded level or indirection when calling `println!`. Since the method parameter is of type `&self`, it's already a borrow.