### PR TITLE
fix nix environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,17 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        cargoBuildInputs = with pkgs; lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.CoreServices
+        ];
+
         rustlings =
           pkgs.rustPlatform.buildRustPackage {
             name = "rustlings";
             version = "5.2.1";
 
-            buildInputs = with pkgs; lib.optionals stdenv.isDarwin [
-              darwin.apple_sdk.frameworks.CoreServices
-            ];
+            buildInputs = cargoBuildInputs;
 
             src = with pkgs.lib; cleanSourceWith {
               src = self;
@@ -53,7 +56,9 @@
             rustc
             rust-analyzer
             rustlings
-          ];
+            rustfmt
+            clippy
+          ] ++ cargoBuildInputs;
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,8 @@
       in
       {
         devShell = pkgs.mkShell {
+          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
           buildInputs = with pkgs; [
             cargo
             rustc

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
             name = "rustlings";
             version = "5.2.1";
 
+            buildInputs = with pkgs; lib.optionals stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.CoreServices
+            ];
+
             src = with pkgs.lib; cleanSourceWith {
               src = self;
               # a function that returns a bool determining if the path should be included in the cleaned source

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,6 @@
 use glob::glob;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::error::Error;
 use std::process::Command;
 
@@ -64,6 +65,12 @@ impl RustAnalyzerProject {
 
     /// Use `rustc` to determine the default toolchain
     pub fn get_sysroot_src(&mut self) -> Result<(), Box<dyn Error>> {
+        // check if RUST_SRC_PATH is set
+        if let Ok(path) = env::var("RUST_SRC_PATH") {
+            self.sysroot_src = path;
+            return Ok(());
+        }
+
         let toolchain = Command::new("rustc")
             .arg("--print")
             .arg("sysroot")


### PR DESCRIPTION
In addition to the issue described in #1292 it also sets correctly RUST_SRC_PATH and patches `rustlings lsp` to make use of it if available. Otherwise the path for `sysroot_src` is computed wrongly making `rust-analyzer` fail.