### PR TITLE
docs: add more information to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This will install Rustlings and give you access to the `rustlings` command. Run 
 Basically: Clone the repository at the latest tag, finally run `nix develop` or `nix-shell`.
 
 ```bash
-# find out the latest version at https://github.com/rust-lang/rustlings/releases/latest (on edit 5.2.1)
-git clone -b 5.2.1 --depth 1 https://github.com/rust-lang/rustlings
+# find out the latest version at https://github.com/rust-lang/rustlings/releases/latest
+git clone --depth 1 https://github.com/rust-lang/rustlings
 cd rustlings
 # if nix version > 2.3
 nix develop


### PR DESCRIPTION
For installation on Nix, the version git tag '5.2.1' seems out of date (there's no `flake.nix` file yet).