### PR TITLE
fix(hashmaps3): fix typo in todo hint

### DIFF
--- a/exercises/hashmaps/hashmaps3.rs
+++ b/exercises/hashmaps/hashmaps3.rs
@@ -37,7 +37,7 @@ fn build_scores_table(results: String) -> HashMap<String, Team> {
         let team_2_score: u8 = v[3].parse().unwrap();
         // TODO: Populate the scores table with details extracted from the
         // current line. Keep in mind that goals scored by team_1
-        // will be number of goals conceded from team_2, and similarly
+        // will be the number of goals conceded from team_2, and similarly
         // goals scored by team_2 will be the number of goals conceded by
         // team_1.
     }


### PR DESCRIPTION
Small typo fix in `exercises/hashmaps/hashmaps3.rs`.