### PR TITLE
fix(threads1): make program panic if threads are not joined

### DIFF
--- a/exercises/threads/threads1.rs
+++ b/exercises/threads/threads1.rs
@@ -1,31 +1,38 @@
 // threads1.rs
 // Execute `rustlings hint threads1` or use the `hint` watch subcommand for a hint.
-// This program should wait until all the spawned threads have finished before exiting.
+
+// This program spawns multiple threads that each run for at least 250ms,
+// and each thread returns how much time they took to complete.
+// The program should wait until all the spawned threads have finished and
+// should collect their return values into a vector.
 
 // I AM NOT DONE
 
 use std::thread;
-use std::time::Duration;
-
+use std::time::{Duration, Instant};
 
 fn main() {
-
     let mut handles = vec![];
     for i in 0..10 {
-        thread::spawn(move || {
+        handles.push(thread::spawn(move || {
+            let start = Instant::now();
             thread::sleep(Duration::from_millis(250));
             println!("thread {} is complete", i);
-        });
+            start.elapsed().as_millis()
+        }));
     }
 
-    let mut completed_threads = 0;
+    let mut results: Vec<u128> = vec![];
     for handle in handles {
         // TODO: a struct is returned from thread::spawn, can you use it?
-        completed_threads += 1;
     }
 
-    if completed_threads != 10 {
+    if results.len() != 10 {
         panic!("Oh no! All the spawned threads did not finish!");
     }
     
+    println!();
+    for (i, result) in results.into_iter().enumerate() {
+        println!("thread {} took {}ms", i, result);
+    }
 }

--- a/info.toml
+++ b/info.toml
@@ -969,7 +969,7 @@ A challenge with multi-threaded applications is that the main thread can
 finish before the spawned threads are completed.
 https://doc.rust-lang.org/book/ch16-01-threads.html#waiting-for-all-threads-to-finish-using-join-handles
 
-Collect the JoinHandles and wait for them to finish.
+Use the JoinHandles to wait for each thread to finish and collect their results.
 https://doc.rust-lang.org/std/thread/struct.JoinHandle.html
 """
 


### PR DESCRIPTION
Attempts to close #1298

- program verifies that threads have been joined by checking if `results` vector has been filled
- solution now involves recognizing that `JoinHandle::join` returns a `Result`, unpacking it, and adding the value to a vector