### PR TITLE
chore: update enums3.rs addressing extra parentheses usage with tuples

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -38,6 +38,7 @@ impl State {
 
     fn process(&mut self, message: Message) {
         // TODO: create a match expression to process the different message variants
+        // Remember: When passing a tuple as a function argument, you'll need extra parentheses: fn function((t, u, p, l, e))
     }
 }
 
@@ -52,7 +53,7 @@ mod tests {
             position: Point { x: 0, y: 0 },
             color: (0, 0, 0),
         };
-        state.process(Message::ChangeColor((255, 0, 255))); // Remember: The extra parentheses mark a tuple type.
+        state.process(Message::ChangeColor(255, 0, 255));
         state.process(Message::Echo(String::from("hello world")));
         state.process(Message::Move(Point { x: 10, y: 15 }));
         state.process(Message::Quit);


### PR DESCRIPTION
The circumstances surrounding tuples and additional parentheses are in regard to passing an argument to a function. Otherwise, I could not find any reference stating that extra parentheses indicate a tuple.

If I create a tuple such as let tup = (('a',)) I receive the following warning:

unnecessary parentheses around assigned value '#[warn(unused_parens)] on by default'

Furthermore, if I made an attempt to indicate a tuple with a single element by doing double parentheses
let tup = (('a'))
the rustfmt will automatically remove the extra parentheses and assume I meant to indicate a char type. Similar to Python, the comma after the lone element is what will indicate the value being a tuple. ('a',)