### PR TITLE
fix(verify): progress bar percent now updates with the number of files verified

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -13,13 +13,15 @@ pub fn verify<'a>(
     progress: (usize, usize),
     verbose: bool,
 ) -> Result<(), &'a Exercise> {
-    let (num_done, total) = progress;
+    let (mut num_done, total) = progress;
     let bar = ProgressBar::new(total as u64);
     bar.set_style(ProgressStyle::default_bar()
         .template("Progress: [{bar:60.green/red}] {pos}/{len} {msg}")
         .progress_chars("#>-")
     );
     bar.set_position(num_done as u64);
+    bar.set_message(format!("({:.1} %)", 0.));
+
     for exercise in exercises {
         let compile_result = match exercise.mode {
             Mode::Test => compile_and_test(exercise, RunMode::Interactive, verbose),
@@ -29,9 +31,10 @@ pub fn verify<'a>(
         if !compile_result.unwrap_or(false) {
             return Err(exercise);
         }
+        num_done += 1;
         let percentage = num_done as f32 / total as f32 * 100.0;
-        bar.set_message(format!("({:.1} %)", percentage));
         bar.inc(1);
+        bar.set_message(format!("({:.1} %)", percentage));
     }
     Ok(())
 }


### PR DESCRIPTION
Noticed that the percent of exercises completed did not update in the progress bar when the sub-commands verify or watch were run. The percentage would update when working through the exercises - when the loop section section of the watch routine in src/main.rs had been entered.

Fixed the verify function in src/verify.rs so that the percentage would update by counting the number of exercises verified. A cleaner solution would be to use the _percent_ key in the progress bar template (https://docs.rs/indicatif/latest/indicatif/index.html#templates) to implicitly change the progress percentage instead of explicitly manipulating the message to display the progress percentage. The _percent_ key, however, does not show any digits after the decimal point (maybe another feature to implement there).

PS. First time contributing to a public project. Please point out if there are any deficiencies in the PR.

Thank you