### PR TITLE
Correct borrowing

### DIFF
--- a/exercises/traits/traits4.rs
+++ b/exercises/traits/traits4.rs
@@ -33,7 +33,7 @@ mod tests {
         let some_software = SomeSoftware {};
         let other_software = OtherSoftware {};
 
-        assert!(compare_license_types(some_software, other_software));
+        assert!(compare_license_types(&some_software, &other_software));
     }
 
     #[test]
@@ -41,6 +41,6 @@ mod tests {
         let some_software = SomeSoftware {};
         let other_software = OtherSoftware {};
 
-        assert!(compare_license_types(other_software, some_software));
+        assert!(compare_license_types(&other_software, &some_software));
     }
 }


### PR DESCRIPTION
The previous code does not allow a good solution by just changing the function parameters, unless I am mistaken.

This code allows "&dyn Licensed" to be substituted for "??" and works well.