### PR TITLE
Update hint for `exercises/conversions/as_ref_mut.rs`

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -1160,4 +1160,6 @@ name = "as_ref_mut"
 path = "exercises/conversions/as_ref_mut.rs"
 mode = "test"
 hint = """
-Add AsRef<str> as a trait bound to the functions."""
+Hint 1: Add AsRef<str> as a trait bound to the functions.
+Hint 2: This function doesn't need to return anything as it's holding a mutable 
+reference, but consider the data type you'd want it to hold."""


### PR DESCRIPTION
It appears that the tasks for `exercises/conversions/as_ref_mut.rs` were updated [about 6 months ago](https://github.com/rust-lang/rustlings/blame/main/exercises/conversions/as_ref_mut.rs#L22) without updating the hint for the task. I'm not the most clear on the wording we'd want to use here for it, so I'm open to any feedback on this from the maintainers. 