### PR TITLE
chore: fix prompt error for exercise #80 (rc1.rs)

### DIFF
--- a/exercises/smart_pointers/rc1.rs
+++ b/exercises/smart_pointers/rc1.rs
@@ -6,6 +6,7 @@
 // Make this code compile by using the proper Rc primitives to express that the sun has multiple owners.
 
 // I AM NOT DONE
+
 use std::rc::Rc;
 
 #[derive(Debug)]


### PR DESCRIPTION
Thanks for this awesome project!

I found a minor issue that missed a blank line, which causes the prompt incorrect like below:

```rust
You can keep working on this exercise,
or jump into the next one by removing the `I AM NOT DONE` comment:

 6 |  // Make this code compile by using the proper Rc primitives to express that the sun has multiple owners.
 7 |  
 8 |  // I AM NOT DONE
 9 |  use std::rc::Rc;
```