### PR TITLE
Fix `bash: line 105: v1[$i]: unbound variable` in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ function vercomp() {
         done
     fi
 
-    for i in `seq 0 $max_len`
+    for i in `seq 0 $((max_len-1))`
     do
         # Fill empty fields with zeros in v1
         if [ -z "${v1[$i]}" ]

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ function vercomp() {
 }
 
 RustVersion=$(rustc --version | cut -d " " -f 2)
-MinRustVersion=1.56
+MinRustVersion=1.58
 vercomp "$RustVersion" $MinRustVersion || ec=$?
 if [ ${ec:-0} -eq 2 ]
 then


### PR DESCRIPTION
Hello!

I've made two changes to the install script:

- change the implementation of `vercomp` to stop it looping beyond the end of the version numbers
- increased `MinRustVersion` from `1.56` to `1.58`, as this was the lowest version of rustc that compiled rustlings without errors

When I first tried to use the install script, I got this error:

```
bash: line 105: v1[$i]: unbound variable
```

This was because my current version of rustc was 1.56.0, the same as `MinRustVersion`. I think this was causing the loop at https://github.com/rust-lang/rustlings/blob/0ea42f60bd559dd7f99c2d7019898505488f7734/install.sh#L102 to reach `max_len` (3 in this case), which was outside the range of array indices (0..2). **Please note that I suck at bash so I could be wrong**. 

Then I got errors while building rustlings, such as

```
error: there is no argument named `thread_id`
  --> src/exercise.rs:23:24
   |
23 |     format!("./temp_{}_{thread_id}", process::id())
   |                        ^^^^^^^^^^^
```

I increased my version of rustc until it compiled without errors using version `1.58.0`. 

Now I'm looking forward to learning Rust! 

```
▶ rustc --version
rustc 1.56.0 (09c42c458 2021-10-18)

▶ uname -a
Darwin AlexandersMBP3 22.2.0 Darwin Kernel Version 22.2.0: Fri Nov 11 02:08:47 PST 2022; root:xnu-8792.61.2~4/RELEASE_X86_64 x86_64
```
