### PR TITLE
Removed verbose instructions from the uninstall section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ for you:
 rm -rf rustlings # or your custom folder name, if you chose and or renamed it
 ```
 
-Second, since Rustlings got installed via `cargo install`, it's only reasonable to assume that you can also remove it using Cargo, and
-exactly that is the case. Run `cargo uninstall` to remove the `rustlings` binary:
+Second, run `cargo uninstall` to remove the `rustlings` binary:
 
 ```bash
 cargo uninstall rustlings


### PR DESCRIPTION
The truncated lines from the uninstall instructions are gratuitous. Removing them makes the section more concise and clear.