### PR TITLE
fix: unify undisclosed type notation in errors5.rs

### DIFF
--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -4,7 +4,7 @@
 
 // This exercise uses some concepts that we won't get to until later in the course, like `Box` and the
 // `From` trait. It's not important to understand them in detail right now, but you can read ahead if you like.
-// For now, think of the `Box<dyn ...>` type as an "I want anything that does ???" type, which, given
+// For now, think of the `Box<dyn ???>` type as an "I want anything that does ???" type, which, given
 // Rust's usual standards for runtime safety, should strike you as somewhat lenient!
 
 // In short, this particular use case for boxes is for when you want to own a value and you care only that it is a


### PR DESCRIPTION
I had to re-read the edited line a few times to understand that "..." and "???" refer to the same thing. I think, applying this change will keep the notation consistent across the comment and the body of the exercise, since `main`'s signature is initially defined with question marks as well.
```rust
fn main() -> Result<(), Box<dyn ???>>
```