### PR TITLE
fix(move_semantics2): add expected output comment

### DIFF
--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -2,6 +2,10 @@
 // Make me compile without changing line 13 or moving line 10!
 // Execute `rustlings hint move_semantics2` or use the `hint` watch subcommand for a hint.
 
+// Expected output:
+// vec0 has length 3 content `[22, 44, 66]`
+// vec1 has length 4 content `[22, 44, 66, 88]`
+
 // I AM NOT DONE
 
 fn main() {


### PR DESCRIPTION
You can easily get this to compile with the following code
```rust
fn main() {
    let vec0 = Vec::new();

    let mut vec1 = fill_vec(vec0.clone()); // just add .clone()

    // Do not change the following line!
    println!("{} has length {} content `{:?}`", "vec0", vec0.len(), vec0);

    vec1.push(88);

    println!("{} has length {} content `{:?}`", "vec1", vec1.len(), vec1);
}

fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
    let mut vec = vec;

    vec.push(22);
    vec.push(44);
    vec.push(66);

    vec
}
```

which will make it compile and output
```
vec0 has length 0 content `[]`
vec1 has length 4 content `[22, 44, 66, 88]`
```

Adding the comment of expected output at least lets people know what they should be aiming for.