### PR TITLE
refactor(arc1): improve readability by avoiding implicit dereference

### DIFF
--- a/exercises/smart_pointers/arc1.rs
+++ b/exercises/smart_pointers/arc1.rs
@@ -32,7 +32,7 @@ fn main() {
     for offset in 0..8 {
         let child_numbers = // TODO
         joinhandles.push(thread::spawn(move || {
-            let sum: u32 = child_numbers.iter().filter(|n| *n % 8 == offset).sum();
+            let sum: u32 = child_numbers.iter().filter(|&&n| n % 8 == offset).sum();
             println!("Sum of offset {} is {}", offset, sum);
         }));
     }


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rustlings/pull/968, it is better to avoir implicit stuff in tutorials. This PR thus replaces an implicit dereference with an explicit type.