### PR TITLE
docs: clarify instructions on iterators5.rs

### DIFF
--- a/exercises/iterators/iterators5.rs
+++ b/exercises/iterators/iterators5.rs
@@ -2,13 +2,11 @@
 // Let's define a simple model to track Rustlings exercise progress. Progress
 // will be modelled using a hash map. The name of the exercise is the key and
 // the progress is the value. Two counting functions were created to count the
-// number of exercises with a given progress. These counting functions use
-// imperative style for loops. Recreate this counting functionality using
-// iterators. Only the two iterator methods (count_iterator and
-// count_collection_iterator) need to be modified.
+// number of exercises with a given progress. Recreate this counting
+// functionality using iterators. Try not to use imperative loops (for, while).
+// Only the two iterator methods (count_iterator and count_collection_iterator)
+// need to be modified.
 // Execute `rustlings hint iterators5` or use the `hint` watch subcommand for a hint.
-//
-// Make the code compile and the tests pass.
 
 // I AM NOT DONE
 


### PR DESCRIPTION
Tiny tweak: I changed the sentence that referenced the imperative implementation in iterators5.rs.

The imperative implementation was already removed and replaced with `todo!()`, so the reference could be confusing.