### PR TITLE
fix(macros4.rs): Add rustfmt::skip to prevent auto-fix.

### DIFF
--- a/exercises/macros/macros4.rs
+++ b/exercises/macros/macros4.rs
@@ -3,6 +3,7 @@
 
 // I AM NOT DONE
 
+#[rustfmt::skip]
 macro_rules! my_macro {
     () => {
         println!("Check out my macro!");


### PR DESCRIPTION
The `macros4.rs` challenge can automatically be solved by rustfmt without the user noticing.

Adding `#[rustfmt::skip]` above the `macro_rules!` line fixes this issue.