### PR TITLE
Better error message when failing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,7 @@ git clone -q https://github.com/rust-lang/rustlings "$Path"
 
 cd "$Path"
 
-Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']);")
+Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']) if 'tag_name' in obj else sys.exit(f\"Error: {obj['message']}\");")
 CargoBin="${CARGO_HOME:-$HOME/.cargo}/bin"
 
 if [[ -z ${Version} ]]


### PR DESCRIPTION
### The Problem

The rustlings installation script threw me an error:
```
curl -L https://raw.githubusercontent.com/rust-lang/rustlings/main/install.sh | bash
```
>  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
>                                       Dload  Upload   Total   Spent    Left  Speed
> 100  4597  100  4597    0     0  13119      0 --:--:-- --:--:-- --:--:-- 13286
> Let's get you set up with Rustlings!
> Checking requirements...
> SUCCESS: Git is installed
> SUCCESS: cc is installed
> SUCCESS: rustup is installed
> SUCCESS: Rust is installed
> SUCCESS: Cargo is installed
> SUCCESS: Rust is up to date
> Cloning Rustlings at rustlings/...
> Traceback (most recent call last):
>   File "<string>", line 1, in <module>
> KeyError: 'tag_name'

After investigating, I found out that the reason for the error is this line in the installation script:
```bash
Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']);")
```
What happened is that `https://api.github.com/repos/rust-lang/rustlings/releases/latest` did not like my ip and returned an error JSON:
```json
{"message":"API rate limit exceeded for 1.1.1.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```
This resulted in the script ending with an unhelpful crash because the json did not contain a key named `tag_name`.

### Modifications

This PR modifies the script to throw a proper error when this happens.
That means that this line:
```bash
Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']);")
```
is changed to:
```bash
Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']) if 'tag_name' in obj else sys.exit(f\"Error: {obj['message']}\");")
```

### To Test
Download a "successful" json from the [original github link](https://api.github.com/repos/rust-lang/rustlings/releases/latest) and save this to a file named something like `good.json`.
then save the error json i sent above to a file named something like `bad.json`.
execute this and see the scripts succeeds like normal (assuming you have `python3` installed):
```bash
echo $(cat good.json | python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']) if 'tag_name' in obj else sys.exit(f\"Error: {obj['message']}\");")
```
execute this and see the script succeeds, but with an error message instead of a crash-like message:
```bash
echo $(cat bad.json | python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']) if 'tag_name' in obj else sys.exit(f\"Error: {obj['message']}\");")
```
> Error: API rate limit exceeded for 1.1.1.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

To make even more sure, you can edit the script itself in your local environment, and execute the full script (I did, and worked as it should in both circumstances)
I also needed to provide a absolute path to the json file when editing the full script, something like `cat ~/my-rust/bad.json` instead of `cat bad.json `
