### PR TITLE
change order of references in README.md

### DIFF
--- a/exercises/lifetimes/README.md
+++ b/exercises/lifetimes/README.md
@@ -13,5 +13,5 @@ restrictive of their callers.
 
 ## Further information
 
-- [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
 - [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/stable/rust-by-example/scope/lifetime.html)
+- [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)


### PR DESCRIPTION
Changed the order in which the references are presented. Now first reference is "Lifetimes (in Rust By Example)", showing a very brief introduction to the concept of lifetimes in references. Then, "Validating References with Lifetimes", where the whole concept is explained in full details.

The previous order didn't make sense as the second reference didn't contain anything new.

Also, first PR ever. Is there something missing? Should I use another name for my branch (something like "issue#")?