### PR TITLE
Update raw_value test's assertion value to meet exercise requirements

### DIFF
--- a/exercises/options/options1.rs
+++ b/exercises/options/options1.rs
@@ -30,6 +30,6 @@ mod tests {
     fn raw_value() {
         // TODO: Fix this test. How do you get at the value contained in the Option?
         let icecreams = maybe_icecream(12);
-        assert_eq!(icecreams, 5);
+        assert_eq!(icecreams, 0);
     }
 }


### PR DESCRIPTION
Based on exercise requirement, raw_value test should assert value against Some(0), not Some(5) when input of function is 12.