### PR TITLE
feat(lifetimekata): Add info about Lifetimekata project

### DIFF
--- a/exercises/lifetimes/README.md
+++ b/exercises/lifetimes/README.md
@@ -11,6 +11,11 @@ be referenced outside. Lifetimes mean that calling code of e.g. functions
 can be checked to make sure their arguments are valid. Lifetimes are 
 restrictive of their callers.
 
+If you'd like to learn more about lifetime annotations, the 
+[lifetimekata](https://tfpk.github.io/lifetimekata/) project 
+has a similar style of exercises to Rustlings, but is all about 
+learning to write lifetime annotations.
+
 ## Further information
 
 - [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)


### PR DESCRIPTION
Much like Macrokata, Lifetimekata is a project we've been using to teach lifetimes at the University of New South Wales. 

I've added it here because I think it'll be useful for people who have finished your lifetimes exercises. 