### PR TITLE
Split quick installation commands into two separate blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Just run:
 
 ```bash
 curl -L https://raw.githubusercontent.com/rust-lang/rustlings/main/install.sh | bash
-# Or if you want it to be installed to a different path:
+```
+Or if you want it to be installed to a different path:
+
+```bash
 curl -L https://raw.githubusercontent.com/rust-lang/rustlings/main/install.sh | bash -s mypath/
 ```
 


### PR DESCRIPTION
Hello! a quick QOL change to the README

Having the two quick installation commands in two separate code blocks makes it easy to copy them through the github's `copy to clipboard` button