### PR TITLE
fix: Added some extra tests to validate iterators5 solution

### DIFF
--- a/exercises/iterators/iterators5.rs
+++ b/exercises/iterators/iterators5.rs
@@ -77,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn count_complete_equals_for() {       
+    fn count_complete_equals_for() {
         let map = get_map();
         let progressStates = vec![Progress::Complete, Progress::Some, Progress::None];
         for progressState in progressStates {
@@ -100,19 +100,13 @@ mod tests {
     #[test]
     fn count_collection_some() {
         let collection = get_vec_map();
-        assert_eq!(
-            1,
-            count_collection_iterator(&collection, Progress::Some)
-        );
+        assert_eq!(1, count_collection_iterator(&collection, Progress::Some));
     }
 
     #[test]
     fn count_collection_none() {
         let collection = get_vec_map();
-        assert_eq!(
-            4,
-            count_collection_iterator(&collection, Progress::None)
-        );
+        assert_eq!(4, count_collection_iterator(&collection, Progress::None));
     }
 
     #[test]

--- a/exercises/iterators/iterators5.rs
+++ b/exercises/iterators/iterators5.rs
@@ -65,12 +65,27 @@ mod tests {
     }
 
     #[test]
-    fn count_equals_for() {
+    fn count_some() {
         let map = get_map();
-        assert_eq!(
-            count_for(&map, Progress::Complete),
-            count_iterator(&map, Progress::Complete)
-        );
+        assert_eq!(1, count_iterator(&map, Progress::Some));
+    }
+
+    #[test]
+    fn count_none() {
+        let map = get_map();
+        assert_eq!(2, count_iterator(&map, Progress::None));
+    }
+
+    #[test]
+    fn count_complete_equals_for() {       
+        let map = get_map();
+        let progressStates = vec![Progress::Complete, Progress::Some, Progress::None];
+        for progressState in progressStates {
+            assert_eq!(
+                count_for(&map, progressState),
+                count_iterator(&map, progressState)
+            );
+        }
     }
 
     #[test]
@@ -83,12 +98,34 @@ mod tests {
     }
 
     #[test]
-    fn count_collection_equals_for() {
+    fn count_collection_some() {
         let collection = get_vec_map();
         assert_eq!(
-            count_collection_for(&collection, Progress::Complete),
-            count_collection_iterator(&collection, Progress::Complete)
+            1,
+            count_collection_iterator(&collection, Progress::Some)
         );
+    }
+
+    #[test]
+    fn count_collection_none() {
+        let collection = get_vec_map();
+        assert_eq!(
+            4,
+            count_collection_iterator(&collection, Progress::None)
+        );
+    }
+
+    #[test]
+    fn count_collection_equals_for() {
+        let progressStates = vec![Progress::Complete, Progress::Some, Progress::None];
+        let collection = get_vec_map();
+
+        for progressState in progressStates {
+            assert_eq!(
+                count_collection_for(&collection, progressState),
+                count_collection_iterator(&collection, progressState)
+            );
+        }
     }
 
     fn get_map() -> HashMap<String, Progress> {


### PR DESCRIPTION
Firstly, I want to say that I've been really impressed with rustlings. This is my first foray into Rust programming and I've really enjoyed running through the exercises over the last few days so I wanted to contribute something in return.

Based on [this issue](https://github.com/rust-lang/rustlings/issues/1387), I've added some more detailed tests to the iterators5 exercise as I think the author has raised a valid point.

I've added new tests to validate that the output is correct for all progress types and I've also updated the tests that compare against the equivalent functions (that use for loops) to ensure that the output is the same for each type. 

Please let me know if there are any edits you would like me to make. Thanks!