### PR TITLE
fix(move_semantics2): fix line number comment

### DIFF
--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -1,5 +1,5 @@
 // move_semantics2.rs
-// Make me compile without changing line 13 or moving line 10!
+// Make me compile without changing line 17 or moving line 14!
 // Execute `rustlings hint move_semantics2` or use the `hint` watch subcommand for a hint.
 
 // Expected output:


### PR DESCRIPTION
Commit fef8314 added three lines of comments, which left the line numbers expected to stay unchanged mentioned on line 2 out of date.