### PR TITLE
feat(options2): better test for layered_option

### DIFF
--- a/exercises/options/options2.rs
+++ b/exercises/options/options2.rs
@@ -18,17 +18,22 @@ mod tests {
 
     #[test]
     fn layered_option() {
-        let mut range = 10;
-        let mut optional_integers: Vec<Option<i8>> = Vec::new();
-        for i in 0..(range + 1) {
+        let range = 10;
+        let mut optional_integers: Vec<Option<i8>> = vec![None];
+
+        for i in 1..(range + 1) {
             optional_integers.push(Some(i));
         }
 
+        let mut cursor = range;
+
         // TODO: make this a while let statement - remember that vector.pop also adds another layer of Option<T>
-        // You can stack `Option<T>`'s into while let and if let
+        // You can stack `Option<T>`s into while let and if let
         integer = optional_integers.pop() {
-            assert_eq!(integer, range);
-            range -= 1;
+            assert_eq!(integer, cursor);
+            cursor -= 1;
         }
+
+        assert_eq!(cursor, 0);
     }
 }


### PR DESCRIPTION
The existing test can be solved with the following:

```rs
while let Some(integer) = optional_integers.pop() {
    assert_eq!(integer.unwrap(), range);
```

Similarly with `expect(...)`, `unwrap_or(0)`, `unwrap_or_default()`, etc. However, none of these solutions use the learning point of stacking `Option<T>`s.

The updated test can _only_ be solved by stacking `Option<T>`s:

```rs
while let Some(Some(integer)) = optional_integers.pop() {
    assert_eq!(integer, cursor);
```

With the updated test, using `unwrap` or `expect` will panic when it hits the `None` value, and using `unwrap_or` or `unwrap_or_default` will cause the final `assert_eq!(cursor, 0)`  to panic.