### PR TITLE
chore: clarified cow owned_no_mutation comments

### DIFF
--- a/exercises/smart_pointers/cow1.rs
+++ b/exercises/smart_pointers/cow1.rs
@@ -52,7 +52,8 @@ mod tests {
     fn owned_no_mutation() -> Result<(), &'static str> {
         // We can also pass `slice` without `&` so Cow owns it directly.
         // In this case no mutation occurs and thus also no clone,
-        // but the result is still owned because it always was.
+        // but the result is still owned because it was never borrowed
+        // or mutated.
         let slice = vec![0, 1, 2];
         let mut input = Cow::from(slice);
         match abs_all(&mut input) {


### PR DESCRIPTION
I was initially confused by this comment describing Cow when owned without mutation. I changed it slightly to clarify why Cow maintains ownership a little better