### PR TITLE
feat(main, verify): Show hint(s) after exercise completion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ struct Args {
     /// show the executable version
     #[argh(switch, short = 'v')]
     version: bool,
+    /// show hints on success
+    #[argh(switch)]
+    success_hints: bool,
     #[argh(subcommand)]
     nested: Option<Subcommands>,
 }
@@ -148,6 +151,7 @@ fn main() {
     let toml_str = &fs::read_to_string("info.toml").unwrap();
     let exercises = toml::from_str::<ExerciseList>(toml_str).unwrap().exercises;
     let verbose = args.nocapture;
+    let success_hints = args.success_hints;
 
     let command = args.nested.unwrap_or_else(|| {
         println!("{DEFAULT_OUT}\n");
@@ -229,7 +233,7 @@ fn main() {
         }
 
         Subcommands::Verify(_subargs) => {
-            verify(&exercises, (0, exercises.len()), verbose)
+            verify(&exercises, (0, exercises.len()), verbose, success_hints)
                 .unwrap_or_else(|_| std::process::exit(1));
         }
 
@@ -252,7 +256,7 @@ fn main() {
             }
         }
 
-        Subcommands::Watch(_subargs) => match watch(&exercises, verbose) {
+        Subcommands::Watch(_subargs) => match watch(&exercises, verbose, success_hints) {
             Err(e) => {
                 println!(
                     "Error: Could not watch your progress. Error message was {:?}.",
@@ -348,7 +352,7 @@ enum WatchStatus {
     Unfinished,
 }
 
-fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<WatchStatus> {
+fn watch(exercises: &[Exercise], verbose: bool, success_hints: bool) -> notify::Result<WatchStatus> {
     /* Clears the terminal with an ANSI escape code.
     Works in UNIX and newer Windows terminals. */
     fn clear_screen() {
@@ -364,7 +368,7 @@ fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<WatchStatus> {
     clear_screen();
 
     let to_owned_hint = |t: &Exercise| t.hint.to_owned();
-    let failed_exercise_hint = match verify(exercises.iter(), (0, exercises.len()), verbose) {
+    let failed_exercise_hint = match verify(exercises.iter(), (0, exercises.len()), verbose, success_hints) {
         Ok(_) => return Ok(WatchStatus::Finished),
         Err(exercise) => Arc::new(Mutex::new(Some(to_owned_hint(exercise)))),
     };
@@ -386,7 +390,7 @@ fn watch(exercises: &[Exercise], verbose: bool) -> notify::Result<WatchStatus> {
                             );
                         let num_done = exercises.iter().filter(|e| e.looks_done()).count();
                         clear_screen();
-                        match verify(pending_exercises, (num_done, exercises.len()), verbose) {
+                        match verify(pending_exercises, (num_done, exercises.len()), verbose, success_hints) {
                             Ok(_) => return Ok(WatchStatus::Finished),
                             Err(exercise) => {
                                 let mut failed_exercise_hint = failed_exercise_hint.lock().unwrap();

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -12,6 +12,7 @@ pub fn verify<'a>(
     exercises: impl IntoIterator<Item = &'a Exercise>,
     progress: (usize, usize),
     verbose: bool,
+    success_hints: bool,
 ) -> Result<(), &'a Exercise> {
     let (num_done, total) = progress;
     let bar = ProgressBar::new(total as u64);
@@ -25,9 +26,9 @@ pub fn verify<'a>(
 
     for exercise in exercises {
         let compile_result = match exercise.mode {
-            Mode::Test => compile_and_test(exercise, RunMode::Interactive, verbose),
-            Mode::Compile => compile_and_run_interactively(exercise),
-            Mode::Clippy => compile_only(exercise),
+            Mode::Test => compile_and_test(exercise, RunMode::Interactive, verbose, success_hints),
+            Mode::Compile => compile_and_run_interactively(exercise, success_hints),
+            Mode::Clippy => compile_only(exercise, success_hints),
         };
         if !compile_result.unwrap_or(false) {
             return Err(exercise);
@@ -46,12 +47,12 @@ enum RunMode {
 
 // Compile and run the resulting test harness of the given Exercise
 pub fn test(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
-    compile_and_test(exercise, RunMode::NonInteractive, verbose)?;
+    compile_and_test(exercise, RunMode::NonInteractive, verbose, false)?;
     Ok(())
 }
 
 // Invoke the rust compiler without running the resulting binary
-fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
+fn compile_only(exercise: &Exercise, success_hints: bool) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);
@@ -59,11 +60,11 @@ fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
     let _ = compile(exercise, &progress_bar)?;
     progress_bar.finish_and_clear();
 
-    Ok(prompt_for_completion(exercise, None))
+    Ok(prompt_for_completion(exercise, None, success_hints))
 }
 
 // Compile the given Exercise and run the resulting binary in an interactive mode
-fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
+fn compile_and_run_interactively(exercise: &Exercise, success_hints: bool) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {exercise}..."));
     progress_bar.enable_steady_tick(100);
@@ -84,12 +85,12 @@ fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
         }
     };
 
-    Ok(prompt_for_completion(exercise, Some(output.stdout)))
+    Ok(prompt_for_completion(exercise, Some(output.stdout), success_hints))
 }
 
 // Compile the given Exercise as a test harness and display
 // the output if verbose is set to true
-fn compile_and_test(exercise: &Exercise, run_mode: RunMode, verbose: bool) -> Result<bool, ()> {
+fn compile_and_test(exercise: &Exercise, run_mode: RunMode, verbose: bool, success_hints: bool) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Testing {exercise}..."));
     progress_bar.enable_steady_tick(100);
@@ -104,7 +105,7 @@ fn compile_and_test(exercise: &Exercise, run_mode: RunMode, verbose: bool) -> Re
                 println!("{}", output.stdout);
             }
             if let RunMode::Interactive = run_mode {
-                Ok(prompt_for_completion(exercise, None))
+                Ok(prompt_for_completion(exercise, None, success_hints))
             } else {
                 Ok(true)
             }
@@ -142,12 +143,11 @@ fn compile<'a, 'b>(
     }
 }
 
-fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> bool {
+fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>, success_hints: bool) -> bool {
     let context = match exercise.state() {
         State::Done => return true,
         State::Pending(context) => context,
     };
-
     match exercise.mode {
         Mode::Compile => success!("Successfully ran {}!", exercise),
         Mode::Test => success!("Successfully tested {}!", exercise),
@@ -167,7 +167,6 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
         Mode::Test => "The code is compiling, and the tests pass!",
         Mode::Clippy => clippy_success_msg,
     };
-
     println!();
     if no_emoji {
         println!("~*~ {success_msg} ~*~")
@@ -180,6 +179,13 @@ fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> 
         println!("Output:");
         println!("{}", separator());
         println!("{output}");
+        println!("{}", separator());
+        println!();
+    }
+    if success_hints {
+        println!("Hints:");
+        println!("{}", separator());
+        println!("{}", exercise.hint);
         println!("{}", separator());
         println!();
     }


### PR DESCRIPTION
Hello, I added an option in main.rs that we can use like this: 'rustlings --success-hints watch' or 'rustlings --success-hints verify'.
I had to change some functions in verify.rs to use this option as an additional boolean parameter, to pass it in the end to the prompt_completion function. In this function I added some println!() lines to display the hint(exercise.hint) in the same way the output is displayed too.
If the user uses this option with other subcommands like run, or lsp, nothing changes, no errors, I didn't handle these cases.
I also updated the help message for this.