### PR TITLE
fix(options3): panic when not matching to avoid false positives

### DIFF
--- a/exercises/options/options3.rs
+++ b/exercises/options/options3.rs
@@ -13,7 +13,7 @@ fn main() {
 
     match y {
         Some(p) => println!("Co-ordinates are {},{} ", p.x, p.y),
-        _ => println!("no match"),
+        _ => panic!("no match!"),
     }
     y; // Fix without deleting this line.
 }


### PR DESCRIPTION
Closes #1503

I searched through the other `match` statements and did not really find any similar situations, so I only changed this file.