### PR TITLE
chore: update hint for vecs2 

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -260,8 +260,8 @@ name = "vecs2"
 path = "exercises/vecs/vecs2.rs"
 mode = "test"
 hint = """
-Hint 1: `i` is each element from the Vec as they are being iterated. Can you try
-multiplying this?
+Hint 1: In the code, the variable `element` represents an item from the Vec as it is being iterated.
+Can you try multiplying this?
 
 Hint 2: For the first function, there's a way to directly access the numbers stored
 in the Vec, using the * dereference operator. You can both access and write to the


### PR DESCRIPTION
It needs an update to match with exercise as it was recently updated to fix clarity.
https://github.com/rust-lang/rustlings/commit/7bab78c66d4c0fff4b9f7ca082964353215265e3 <- in this commit