### PR TITLE
Rustlings depends on git for rustlings reset commands

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
             name = "rustlings";
             version = "5.5.1";
 
+            nativeBuildInputs = [ pkgs.git ];
             buildInputs = cargoBuildInputs;
 
             src = with pkgs.lib; cleanSourceWith {


### PR DESCRIPTION
Rustlings depends on git for rustlings reset commands.
Add "nativeBuildInputs  = [ pkgs.git ];" to avoid unexpected behaviors when running bulid tests.