### PR TITLE
feat: added test function to hashmaps2.rs

### DIFF
--- a/exercises/hashmaps/hashmaps2.rs
+++ b/exercises/hashmaps/hashmaps2.rs
@@ -80,4 +80,13 @@ mod tests {
         let count = basket.values().sum::<u32>();
         assert!(count > 11);
     }
+    
+    #[test]
+    fn all_fruit_types_in_basket() {
+        let mut basket = get_fruit_basket();
+        fruit_basket(&mut basket);
+        for amount in basket.values() {
+            assert_ne!(amount, &0);
+        }
+    }
 }


### PR DESCRIPTION
The existing test functions only check if a kind of fruit exists in the hashmap, but not if the amount of fruits is higher than zero. This new test function solves this.