### PR TITLE
fix(enums3): add test for message

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -17,6 +17,7 @@ struct State {
     color: (u8, u8, u8),
     position: Point,
     quit: bool,
+    message: String
 }
 
 impl State {
@@ -28,9 +29,7 @@ impl State {
         self.quit = true;
     }
 
-    fn echo(&self, s: String) {
-        println!("{}", s);
-    }
+    fn echo(&mut self, s: String) { self.message = s }
 
     fn move_position(&mut self, p: Point) {
         self.position = p;
@@ -52,6 +51,7 @@ mod tests {
             quit: false,
             position: Point { x: 0, y: 0 },
             color: (0, 0, 0),
+            message: "hello world".to_string(),
         };
         state.process(Message::ChangeColor(255, 0, 255));
         state.process(Message::Echo(String::from("hello world")));
@@ -62,5 +62,6 @@ mod tests {
         assert_eq!(state.position.x, 10);
         assert_eq!(state.position.y, 15);
         assert_eq!(state.quit, true);
+        assert_eq!(state.message, "hello world");
     }
 }


### PR DESCRIPTION
closes #1548

I've changed the exercie slightly so that all code paths are tested. Even the Echo code path asserts the message. In my issue I managed to pass the test without implementing anything for the `Message::Echo` match logic.

```rust
match message {
            Message::Move(point) => {self.move_position(point)},
            Message::Echo(string) => {}, // I pass the exercie without implementing this.
            Message::ChangeColor(x, y, z) => { self.change_color((x, y, z))},
            Message::Quit => { self.quit() },
        }
```