### PR TITLE
chore(ci): add action step to check if lockfile is synced

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Fetch & maybe update Cargo.lock
+      run: cargo fetch --locked
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
This PR prevents issues like #1430 from reoccurring.

---
[Issue #1430](https://github.com/rust-lang/rustlings/issues/1430) was caused by `Cargo.lock` being out of sync with `Cargo.toml`; in [the commit](https://github.com/rust-lang/rustlings/tree/9acefe8b3a2bed6e23dc31e9c1d5e9c5f6ab7596) preceding the merge of [PR #1435](https://github.com/rust-lang/rustlings/pull/1435), [`Cargo.toml`](https://github.com/rust-lang/rustlings/blob/568767601427cccf11ef8ea0dd20ad1ac0dbee1e/Cargo.toml#L3) had rustlings at version 5.4.1 and [`Cargo.lock`](https://github.com/rust-lang/rustlings/blob/568767601427cccf11ef8ea0dd20ad1ac0dbee1e/Cargo.lock#L462) had rustlings at 5.4.0.

Under "normal" (non-`nix`) conditions, unless the `--frozen` or `--locked` flags are passed to `cargo` calls, `cargo` will silently update `Cargo.lock` before continuing; `nix` doesn't like this however, and complains when running `nix develop`:
```
> error: the lock file /private/tmp/nix-build-rustlings.drv-0/source/Cargo.lock needs to be updated but --frozen was passed to prevent this
> If you want to try to generate the lock file without accessing the network, remove the --frozen flag and use --offline instead.
```
This happens because `nix develop` tries to build the [`devShell`](https://github.com/rust-lang/rustlings/blob/main/flake.nix#L51), which requires first building [the `rustlings` package defined in `flake.nix`](https://github.com/rust-lang/rustlings/blob/main/flake.nix#L22), and `rustPlatform.buildRustPackage` calls `cargoBuildHook` which [passes the `--frozen` flag to `cargo build`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/hooks/cargo-build-hook.sh#L36).

This small patch adds a fetch step before the build and test steps, which runs `cargo fetch --locked`, updating `Cargo.lock` if necessary before pulling dependencies (but not building them). If `Cargo.lock` was updated, `cargo fetch --locked` exits with a 101 status, failing the workflow. If not (so, when the manifest and lock file are in sync), dependencies are already downloaded and available for the following `cargo build` step, so this doesn't add additional time to check.

<img width="1016" alt="Screenshot 2023-06-11 at 17 03 24" src="https://github.com/rust-lang/rustlings/assets/74747193/9afa521b-f24b-4f66-ac97-b2016df6bbcb">
