### PR TITLE
chore: update hint for vecs2

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -260,8 +260,8 @@ name = "vecs2"
 path = "exercises/vecs/vecs2.rs"
 mode = "test"
 hint = """
-Hint 1: `i` is each element from the Vec as they are being iterated. Can you try
-multiplying this?
+Hint 1: In the code, the variable `element` represents an item from the Vec as it is being iterated.
+Can you try multiplying this?
 
 Hint 2: For the first function, there's a way to directly access the numbers stored
 in the Vec, using the * dereference operator. You can both access and write to the


### PR DESCRIPTION
Hello @shadows-withal 
I have seen pull request #1544, and I must admit I am somewhat disappointed with the phrase "`element` is each element" as it could be formulated differently. That's why I have decided that the entire sentence should be rewritten from scratch.
Imo for clarity we should try to avoid redundant statements whenever possible.