### PR TITLE
fix(enums3): modify message string in test

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -59,7 +59,7 @@ mod tests {
             message: "hello world".to_string(),
         };
         state.process(Message::ChangeColor(255, 0, 255));
-        state.process(Message::Echo(String::from("hello world")));
+        state.process(Message::Echo(String::from("Hello world!")));
         state.process(Message::Move(Point { x: 10, y: 15 }));
         state.process(Message::Quit);
 
@@ -67,6 +67,6 @@ mod tests {
         assert_eq!(state.position.x, 10);
         assert_eq!(state.position.y, 15);
         assert_eq!(state.quit, true);
-        assert_eq!(state.message, "hello world");
+        assert_eq!(state.message, "Hello world!");
     }
 }


### PR DESCRIPTION
Otherwise it won't actually test the change of state.message and it would fail to check if the user missed changing state.message

This happened to me as I had a catch-all line in `match`