### PR TITLE
refactor: Update comment to use correct construct name 'Result' inste…

### DIFF
--- a/exercises/error_handling/errors1.rs
+++ b/exercises/error_handling/errors1.rs
@@ -3,7 +3,7 @@
 // This function refuses to generate text to be printed on a nametag if you pass
 // it an empty string. It'd be nicer if it explained what the problem was,
 // instead of just sometimes returning `None`. Thankfully, Rust has a similar
-// construct to `Option` that can be used to express error conditions. Let's use
+// construct to `Result` that can be used to express error conditions. Let's use
 // it!
 //
 // Execute `rustlings hint errors1` or use the `hint` watch subcommand for a


### PR DESCRIPTION
Refactor the comment in the code to provide a more accurate description of the construct being used. Replace the mention of **Option** with **Result**.