### PR TITLE
chore: update line reference in strings2 hint

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -438,8 +438,8 @@ path = "exercises/strings/strings2.rs"
 mode = "compile"
 hint = """
 Yes, it would be really easy to fix this by just changing the value bound to `word` to be a
-string slice instead of a `String`, wouldn't it?? There is a way to add one character to line
-12, though, that will coerce the `String` into a string slice.
+string slice instead of a `String`, wouldn't it?? There is a way to add one character to the
+if statement, though, that will coerce the `String` into a string slice.
 
 Side note: If you're interested in learning about how this kind of reference conversion works, you can jump ahead in the book and read this part in the smart pointers chapter: https://doc.rust-lang.org/stable/book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods"""
 

--- a/info.toml
+++ b/info.toml
@@ -439,7 +439,7 @@ mode = "compile"
 hint = """
 Yes, it would be really easy to fix this by just changing the value bound to `word` to be a
 string slice instead of a `String`, wouldn't it?? There is a way to add one character to line
-9, though, that will coerce the `String` into a string slice.
+12, though, that will coerce the `String` into a string slice.
 
 Side note: If you're interested in learning about how this kind of reference conversion works, you can jump ahead in the book and read this part in the smart pointers chapter: https://doc.rust-lang.org/stable/book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods"""
 


### PR DESCRIPTION
Resolves a side-effect of PR #1535. In making the boilerplate consistent, [several new lines](https://github.com/rust-lang/rustlings/commit/7eef5d15eef780f93e22b1b4e0185f7708219ea0#diff-0eb1285ec18690b4824b04771d7b390176ef133a218d6b45c614e947fe2b3b0f) were added - misaligning the hint.

The new offending line is [line 12](https://github.com/rust-lang/rustlings/blob/main/exercises/strings/strings2.rs#L12). That being said, it might be more stable to just remove the line reference altogether.
> _There is a way to add one character ~~to line 12~~, though, that will coerce the `String` into a string slice._