### PR TITLE
fix(primitives-4.rs): update hint so it's less confusing

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -216,7 +216,7 @@ mode = "test"
 hint = """
 Take a look at the Understanding Ownership -> Slices -> Other Slices section of the book:
 https://doc.rust-lang.org/book/ch04-03-slices.html
-and use the starting and ending indices of the items in the Array
+and use the starting and ending (plus one) indices of the items in the Array
 that you want to end up in the slice.
 
 If you're curious why the first argument of `assert_eq!` does not


### PR DESCRIPTION
Hi there, first day at rustlings, enjoying the learning system. Thanks!!

This is a small PR to fix what (in my opinion) is a bit confusing hint.

Current hint:
>  use the starting and ending indices of the items in the Array

Problem:
In the documentation it's explained that is ending `PLUS ONE` (which is also expected I guess). I tried the hint literally in the excercise and it wasn't working.

I hope this is useful :) 