### PR TITLE
chore(errors4): improved comment

### DIFF
--- a/exercises/error_handling/errors4.rs
+++ b/exercises/error_handling/errors4.rs
@@ -16,7 +16,7 @@ enum CreationError {
 
 impl PositiveNonzeroInteger {
     fn new(value: i64) -> Result<PositiveNonzeroInteger, CreationError> {
-        // Hmm...? Why is this only returning an Ok value?
+        // Hmm... Why is this always returning an Ok value?
         Ok(PositiveNonzeroInteger(value as u64))
     }
 }


### PR DESCRIPTION
I was a bit confused about this comment since I thought there was supposed to be something more than the Ok value there. But the problem is that the Ok value is always returned. Switching only -> always to signify that better.