### PR TITLE
Fix comment in errors2

### DIFF
--- a/exercises/error_handling/errors2.rs
+++ b/exercises/error_handling/errors2.rs
@@ -9,9 +9,9 @@
 //
 // Right now, this function isn't handling the error case at all (and isn't
 // handling the success case properly either). What we want to do is: if we call
-// the `parse` function on a string that is not a number, that function will
-// return a `ParseIntError`, and in that case, we want to immediately return
-// that error from our function and not try to multiply and add.
+// the `total_cost` function on a string that is not a number, that function
+// will return a `ParseIntError`, and in that case, we want to immediately
+// return that error from our function and not try to multiply and add.
 //
 // There are at least two ways to implement this that are both correct-- but one
 // is a lot shorter!


### PR DESCRIPTION
Fixes a trivial comment that references `parse` function, but that function does not exist. It exists as `total_cost`