### PR TITLE
fix(errors1): change Result to Option in exersise description

### DIFF
--- a/exercises/error_handling/errors1.rs
+++ b/exercises/error_handling/errors1.rs
@@ -3,7 +3,7 @@
 // This function refuses to generate text to be printed on a nametag if you pass
 // it an empty string. It'd be nicer if it explained what the problem was,
 // instead of just sometimes returning `None`. Thankfully, Rust has a similar
-// construct to `Result` that can be used to express error conditions. Let's use
+// construct to `Option` that can be used to express error conditions. Let's use
 // it!
 //
 // Execute `rustlings hint errors1` or use the `hint` watch subcommand for a


### PR DESCRIPTION
The way this description war written implied that similar but else than `Result` should be used. Which is not correct according to hint and provided tests. I have updated it to say that something like `Option` can be used to solve the exercise. 

If the intention was to mention `Result` explicitly to make the exercise easier, then I would phrase it like this:
> Rust has a similar construct to `Option` - `Result`, that can be used to express error conditions.