### PR TITLE
Port to Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,25 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
 ]
 
 [[package]]
@@ -16,6 +30,34 @@ name = "anstyle"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "argh"
@@ -77,9 +119,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -97,6 +139,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
@@ -208,6 +296,12 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "home"
@@ -330,9 +424,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "mio"
@@ -493,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -505,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -526,6 +620,7 @@ version = "5.5.1"
 dependencies = [
  "argh",
  "assert_cmd",
+ "clap",
  "console",
  "glob",
  "home",
@@ -603,10 +698,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.29"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "2.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -664,6 +765,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,16 @@ edition = "2021"
 
 [dependencies]
 argh = "0.1"
-indicatif = "0.17"
+indicatif = "0.17.6"
 console = "0.15"
 notify = "4.0"
-toml = "0.7"
-regex = "1.9"
+toml = "0.7.6"
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.105"
-home = "0.5.5"
-glob = "0.3.1"
+serde_json = "1.0.81"
+home = "0.5.3"
+glob = "0.3.0"
+clap = { version = "4.4.0", features = ["derive"] }
 
 [[bin]]
 name = "rustlings"
@@ -27,4 +28,4 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.3"
-glob = "0.3.1"
+glob = "0.3.0"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -97,7 +97,10 @@ fn run_single_test_no_filename() {
         .arg("run")
         .current_dir("tests/fixture/")
         .assert()
-        .code(1);
+        .code(2)
+        .stderr(predicates::str::contains(
+            "required arguments were not provided",
+        ));
 }
 
 #[test]
@@ -125,9 +128,9 @@ fn reset_no_exercise() {
         .unwrap()
         .arg("reset")
         .assert()
-        .code(1)
+        .code(2)
         .stderr(predicates::str::contains(
-            "positional arguments not provided",
+            "required arguments were not provided",
         ));
 }
 


### PR DESCRIPTION
The arguments from the PR https://github.com/rust-lang/rustlings/pull/715 that replaced Clap with argh are not valid anymore.

## Arguments for argh

### Clap is heavy

Currently, this branch has only 7 more dependencies. The difference in compilation time is not significant.

Compiling the `main` branch:
```console
$ hyperfine -- "rm -r target && cargo b -r"
Benchmark 1: rm -r target && cargo b -r
  Time (mean ± σ):     11.496 s ±  0.206 s    [User: 89.523 s, System: 5.787 s]
  Range (min … max):   11.161 s … 11.822 s    10 runs
```

Compiling this `clap` branch:
```console
$ hyperfine -- "rm -r target && cargo b -r"
Benchmark 1: rm -r target && cargo b -r
  Time (mean ± σ):     13.415 s ±  0.290 s    [User: 115.880 s, System: 6.849 s]
  Range (min … max):   12.859 s … 13.865 s    10 runs
```

The benchmarks show that the compilation time increased by only 15% on my system. But remember, we are talking about just 2 additional seconds!

If you really want to save an additional second of compilation time, then you could disable the default features `color` and `suggestions` for example. But I don't think that it is worth it since the compilation is done only once!

### argh makes the code easier to read

This argument is only valid for version 2 of Clap. In this PR, version  4 has been used.

Currently, the opposite is true. As you can see in the git diff, the code has less boilerplate now since the Derive API of Clap has been used.

## Arguments for Clap

Clap is used by most Rust CLI projects and the community is used to its API. There is a huge ecosystem around it.

The argument that the code has less boilerplate with Clap's Derive API was mentioned above.

Clap has additional features like suggestions and colors:

![image](https://github.com/rust-lang/rustlings/assets/76752051/1ac9cf17-ca40-4add-9bcf-e5baf6b39f60)

It has better highlighting (above: argh, below: Clap):

![image](https://github.com/rust-lang/rustlings/assets/76752051/92f40680-f10b-414c-9e11-83b7c4a7bc19)

## Clap vs bpaf?

Please see the another PR for `bpaf` first: https://github.com/rust-lang/rustlings/pull/1634