### PR TITLE
Formatted readmes so as not to exceed a line length of 120 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@
 
 </div>
 
-Greetings and welcome to `rustlings`. This project contains small exercises to get you used to reading and writing Rust code. This includes reading and responding to compiler messages!
+Greetings and welcome to `rustlings`. This project contains small exercises to get you used to reading and writing Rust
+code. This includes reading and responding to compiler messages!
 
 _...looking for the old, web-based version of Rustlings? Try [here](https://github.com/rust-lang/rustlings/tree/rustlings-1)_
 
 Alternatively, for a first-time Rust learner, there are several other resources:
 
-- [The Book](https://doc.rust-lang.org/book/index.html) - The most comprehensive resource for learning Rust, but a bit theoretical sometimes. You will be using this along with Rustlings!
-- [Rust By Example](https://doc.rust-lang.org/rust-by-example/index.html) - Learn Rust by solving little exercises! It's almost like `rustlings`, but online
+- [The Book](https://doc.rust-lang.org/book/index.html) - The most comprehensive resource for learning Rust, but a bit
+  theoretical sometimes. You will be using this along with Rustlings!
+- [Rust By Example](https://doc.rust-lang.org/rust-by-example/index.html) - Learn Rust by solving little exercises! It's
+  almost like `rustlings`, but online
 
 ## Getting Started
 
 _Note: If you're on MacOS, make sure you've installed Xcode and its developer tools by typing `xcode-select --install`._
 _Note: If you're on Linux, make sure you've installed gcc. Deb: `sudo apt install gcc`. Yum: `sudo yum -y install gcc`._
 
-You will need to have Rust installed. You can get it by visiting https://rustup.rs. This'll also install Cargo, Rust's package/project manager.
+You will need to have Rust installed. You can get it by visiting https://rustup.rs. This'll also install Cargo, Rust's
+package/project manager.
 
 ## MacOS/Linux
 
@@ -27,6 +31,7 @@ Just run:
 ```bash
 curl -L https://raw.githubusercontent.com/rust-lang/rustlings/main/install.sh | bash
 ```
+
 Or if you want it to be installed to a different path:
 
 ```bash
@@ -63,9 +68,11 @@ Then, you can run:
 Start-BitsTransfer -Source https://raw.githubusercontent.com/rust-lang/rustlings/main/install.ps1 -Destination $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
 ```
 
-To install Rustlings. Same as on MacOS/Linux, you will have access to the `rustlings` command after it. Keep in mind that this works best in PowerShell, and any other terminals may give you errors.
+To install Rustlings. Same as on MacOS/Linux, you will have access to the `rustlings` command after it. Keep in mind
+that this works best in PowerShell, and any other terminals may give you errors.
 
-If you get a permission denied message, you might have to exclude the directory where you cloned Rustlings in your antivirus.
+If you get a permission denied message, you might have to exclude the directory where you cloned Rustlings in your
+antivirus.
 
 ## Browser
 
@@ -94,15 +101,21 @@ Then, same as above, run `rustlings` to get started.
 
 ## Doing exercises
 
-The exercises are sorted by topic and can be found in the subdirectory `rustlings/exercises/<topic>`. For every topic there is an additional README file with some resources to get you started on the topic. We really recommend that you have a look at them before you start.
+The exercises are sorted by topic and can be found in the subdirectory `rustlings/exercises/<topic>`. For every topic
+there is an additional README file with some resources to get you started on the topic. We really recommend that you
+have a look at them before you start.
 
-The task is simple. Most exercises contain an error that keeps them from compiling, and it's up to you to fix it! Some exercises are also run as tests, but rustlings handles them all the same. To run the exercises in the recommended order, execute:
+The task is simple. Most exercises contain an error that keeps them from compiling, and it's up to you to fix it! Some
+exercises are also run as tests, but rustlings handles them all the same. To run the exercises in the recommended order,
+execute:
 
 ```bash
 rustlings watch
 ```
 
-This will try to verify the completion of every exercise in a predetermined order (what we think is best for newcomers). It will also rerun automatically every time you change a file in the `exercises/` directory. If you want to only run it once, you can use:
+This will try to verify the completion of every exercise in a predetermined order (what we think is best for newcomers).
+It will also rerun automatically every time you change a file in the `exercises/` directory. If you want to only run it
+once, you can use:
 
 ```bash
 rustlings verify
@@ -143,20 +156,23 @@ rustlings list
 
 ## Testing yourself
 
-After every couple of sections, there will be a quiz that'll test your knowledge on a bunch of sections at once. These quizzes are found in `exercises/quizN.rs`.
+After every couple of sections, there will be a quiz that'll test your knowledge on a bunch of sections at once. These
+quizzes are found in `exercises/quizN.rs`.
 
 ## Enabling `rust-analyzer`
 
-Run the command `rustlings lsp` which will generate a `rust-project.json` at the root of the project, this allows [rust-analyzer](https://rust-analyzer.github.io/) to parse each exercise.
+Run the command `rustlings lsp` which will generate a `rust-project.json` at the root of the project, this allows
+[rust-analyzer](https://rust-analyzer.github.io/) to parse each exercise.
 
 ## Continuing On
 
-Once you've completed Rustlings, put your new knowledge to good use! Continue practicing your Rust skills by building your own projects, contributing to Rustlings, or finding other open-source projects to contribute to.
+Once you've completed Rustlings, put your new knowledge to good use! Continue practicing your Rust skills by building
+your own projects, contributing to Rustlings, or finding other open-source projects to contribute to.
 
 ## Uninstalling Rustlings
 
-If you want to remove Rustlings from your system, there are two steps. First, you'll need to remove the exercises folder that the install script created
-for you:
+If you want to remove Rustlings from your system, there are two steps. First, you'll need to remove the exercises folder
+that the install script created for you:
 
 ```bash
 rm -rf rustlings # or your custom folder name, if you chose and or renamed it

--- a/exercises/clippy/README.md
+++ b/exercises/clippy/README.md
@@ -1,6 +1,7 @@
 # Clippy
 
-The Clippy tool is a collection of lints to analyze your code so you can catch common mistakes and improve your Rust code.
+The Clippy tool is a collection of lints to analyze your code so you can catch common mistakes and improve your Rust
+code.
 
 If you used the installation script for Rustlings, Clippy should be already installed.
 If not you can install it manually via `rustup component add clippy`.

--- a/exercises/conversions/README.md
+++ b/exercises/conversions/README.md
@@ -2,22 +2,31 @@
 
 Rust offers a multitude of ways to convert a value of a given type into another type.
 
-The simplest form of type conversion is a type cast expression. It is denoted with the binary operator `as`. For instance, `println!("{}", 1 + 1.0);` would not compile, since `1` is an integer while `1.0` is a float. However, `println!("{}", 1 as f32 + 1.0)` should compile. The exercise [`using_as`](using_as.rs) tries to cover this.
+The simplest form of type conversion is a type cast expression. It is denoted with the binary operator `as`. For
+instance, `println!("{}", 1 + 1.0);` would not compile, since `1` is an integer while `1.0` is a float. However,
+`println!("{}", 1 as f32 + 1.0)` should compile. The exercise [`using_as`](using_as.rs) tries to cover this.
 
-Rust also offers traits that facilitate type conversions upon implementation. These traits can be found under the [`convert`](https://doc.rust-lang.org/std/convert/index.html) module.
+Rust also offers traits that facilitate type conversions upon implementation. These traits can be found under the
+[`convert`](https://doc.rust-lang.org/std/convert/index.html) module.
 The traits are the following:
 
 - `From` and `Into` covered in [`from_into`](from_into.rs)
 - `TryFrom` and `TryInto` covered in [`try_from_into`](try_from_into.rs)
 - `AsRef` and `AsMut` covered in [`as_ref_mut`](as_ref_mut.rs)
 
-Furthermore, the `std::str` module offers a trait called [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) which helps with converting strings into target types via the `parse` method on strings. If properly implemented for a given type `Person`, then `let p: Person = "Mark,20".parse().unwrap()` should both compile and run without panicking.
+Furthermore, the `std::str` module offers a trait called [`FromStr`][fromstr]
+which helps with converting strings into target types via the `parse` method on strings. If properly implemented for a
+given type `Person`, then `let p: Person = "Mark,20".parse().unwrap()` should both compile and run without panicking.
 
-These should be the main ways ***within the standard library*** to convert data into your desired types.
+These should be the main ways **_within the standard library_** to convert data into your desired types.
 
 ## Further information
 
 These are not directly covered in the book, but the standard library has a great documentation for it.
 
 - [conversions](https://doc.rust-lang.org/std/convert/index.html)
-- [`FromStr` trait](https://doc.rust-lang.org/std/str/trait.FromStr.html)
+- [`FromStr` trait][fromstr]
+
+<!-- Links -->
+
+[fromstr]: https://doc.rust-lang.org/std/str/trait.FromStr.html

--- a/exercises/enums/README.md
+++ b/exercises/enums/README.md
@@ -1,8 +1,10 @@
 # Enums
 
 Rust allows you to define types called "enums" which enumerate possible values.
-Enums are a feature in many languages, but their capabilities differ in each language. Rust’s enums are most similar to algebraic data types in functional languages, such as F#, OCaml, and Haskell.
-Useful in combination with enums is Rust's "pattern matching" facility, which makes it easy to run different code for different values of an enumeration.
+Enums are a feature in many languages, but their capabilities differ in each language. Rust’s enums are most similar to
+algebraic data types in functional languages, such as F#, OCaml, and Haskell.
+Useful in combination with enums is Rust's "pattern matching" facility, which makes it easy to run different code for
+different values of an enumeration.
 
 ## Further information
 

--- a/exercises/error_handling/README.md
+++ b/exercises/error_handling/README.md
@@ -2,7 +2,8 @@
 
 Most errors aren’t serious enough to require the program to stop entirely.
 Sometimes, when a function fails, it’s for a reason that you can easily interpret and respond to.
-For example, if you try to open a file and that operation fails because the file doesn’t exist, you might want to create the file instead of terminating the process.
+For example, if you try to open a file and that operation fails because the file doesn’t exist, you might want to create
+the file instead of terminating the process.
 
 ## Further information
 

--- a/exercises/generics/README.md
+++ b/exercises/generics/README.md
@@ -2,7 +2,8 @@
 
 Generics is the topic of generalizing types and functionalities to broader cases.
 This is extremely useful for reducing code duplication in many ways, but can call for rather involving syntax.
-Namely, being generic requires taking great care to specify over which types a generic type is actually considered valid.
+Namely, being generic requires taking great care to specify over which types a generic type is actually considered
+valid.
 The simplest and most common use of generics is for type parameters.
 
 ## Further information

--- a/exercises/hashmaps/README.md
+++ b/exercises/hashmaps/README.md
@@ -1,8 +1,9 @@
 # Hashmaps
 
-A *hash map* allows you to associate a value with a particular key.
-You may also know this by the names [*unordered map* in C++](https://en.cppreference.com/w/cpp/container/unordered_map),
-[*dictionary* in Python](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) or an *associative array* in other languages.
+A _hash map_ allows you to associate a value with a particular key.
+You may also know this by the names [_unordered map_ in C++](https://en.cppreference.com/w/cpp/container/unordered_map),
+[_dictionary_ in Python](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) or an _associative array_
+in other languages.
 
 This is the other data structure that we've been talking about before, when
 talking about Vecs.

--- a/exercises/smart_pointers/README.md
+++ b/exercises/smart_pointers/README.md
@@ -1,6 +1,7 @@
 # Smart Pointers
 
-In Rust, smart pointers are variables that contain an address in memory and reference some other data, but they also have additional metadata and capabilities.
+In Rust, smart pointers are variables that contain an address in memory and reference some other data, but they also
+have additional metadata and capabilities.
 Smart pointers in Rust often own the data they point to, while references only borrow data.
 
 ## Further Information

--- a/exercises/threads/README.md
+++ b/exercises/threads/README.md
@@ -1,7 +1,9 @@
 # Threads
 
-In most current operating systems, an executed program’s code is run in a process, and the operating system manages multiple processes at once.
-Within your program, you can also have independent parts that run simultaneously. The features that run these independent parts are called threads.
+In most current operating systems, an executed program’s code is run in a process, and the operating system manages
+multiple processes at once.
+Within your program, you can also have independent parts that run simultaneously. The features that run these
+independent parts are called threads.
 
 ## Further information
 

--- a/exercises/traits/README.md
+++ b/exercises/traits/README.md
@@ -2,7 +2,8 @@
 
 A trait is a collection of methods.
 
-Data types can implement traits. To do so, the methods making up the trait are defined for the data type. For example, the `String` data type implements the `From<&str>` trait. This allows a user to write `String::from("hello")`.
+Data types can implement traits. To do so, the methods making up the trait are defined for the data type. For example,
+the `String` data type implements the `From<&str>` trait. This allows a user to write `String::from("hello")`.
 
 In this way, traits are somewhat similar to Java interfaces and C++ abstract classes.
 


### PR DESCRIPTION
Although some IDEs come with markdown renderer, other's don't. I used Neovim to complete the rustlings exercises and preferred to just look at the raw markdown file in my editor alongside the exercise, instead of rendering it in the browser.

I noticed that some files had short line lengths that could fit on screen, and others were very long. This PR just reformats the readmes to 120 character long lines so that it can fit on a reasonably sized screen without having to use a markdown renderer.

Hopefully others who use text editors or don't want to render the markdown can find this useful.