### PR TITLE
Use u32 instead of i32

### DIFF
--- a/exercises/structs/structs3.rs
+++ b/exercises/structs/structs3.rs
@@ -13,13 +13,15 @@
 struct Package {
     sender_country: String,
     recipient_country: String,
-    weight_in_grams: i32,
+    weight_in_grams: u32,
 }
 
 impl Package {
-    fn new(sender_country: String, recipient_country: String, weight_in_grams: i32) -> Package {
-        if weight_in_grams <= 0 {
-            panic!("Can not ship a weightless package.")
+    fn new(sender_country: String, recipient_country: String, weight_in_grams: u32) -> Package {
+        if weight_in_grams < 10 {
+            // This is not how you should handle errors in Rust,
+            // but we will learn about error handling later.
+            panic!("Can not ship a package with weight below 10 grams.")
         } else {
             Package {
                 sender_country,
@@ -33,7 +35,7 @@ impl Package {
         // Something goes here...
     }
 
-    fn get_fees(&self, cents_per_gram: i32) -> ??? {
+    fn get_fees(&self, cents_per_gram: u32) -> ??? {
         // Something goes here...
     }
 }
@@ -48,7 +50,7 @@ mod tests {
         let sender_country = String::from("Spain");
         let recipient_country = String::from("Austria");
 
-        Package::new(sender_country, recipient_country, -2210);
+        Package::new(sender_country, recipient_country, 5);
     }
 
     #[test]


### PR DESCRIPTION
I think that we should teach using the fitting type. Using `i32` and then matching if the value is <= 0 is a bad practice. Therefore, I used `u32` instead. We could also check if `u32` is zero instead of `< 10`. That would also be fine. But the point is that there is no reason that either the price or the weigth are negative (unless we talk about antimatter, but I don't think that you would want to ship that 🤣)

I also added a message about the panic on input validation to make it clear that this is not how one should handle errors in Rust. But we didn't get to `Result` yet.

Ignore the typo in the branch name :P