### PR TITLE
feat(flake): Add defaults to commands in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,5 +60,18 @@
             clippy
           ] ++ cargoBuildInputs;
         };
+        apps = let
+          rustlings-app = {
+            type = "app";
+            program = "${rustlings}/bin/rustlings";
+          };
+        in {
+          default = rustlings-app;
+          rustlings = rustlings-app;
+        };
+        packages = {
+          inherit rustlings;
+          default = rustlings;
+        };
       });
 }


### PR DESCRIPTION
So that:
- `nix build .#`, and
- `nix run .#` both work.