### PR TITLE
fix(nix/tests): Add `git` to Nix's rust build/test sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             version = "5.5.1";
 
             buildInputs = cargoBuildInputs;
+            nativeBuildInputs = [pkgs.git];
 
             src = with pkgs.lib; cleanSourceWith {
               src = self;


### PR DESCRIPTION
The integration test `reset_single_exercise` depends on Git...

Fixes the last error mentioned in #1652.
Many thanks to people at https://matrix.to/#/!bohcSYPVoePqBDWlvE:hackint.org's weekly mumble session for figuring out the root cause of this problem =)