### PR TITLE
Make `primitive_types3` require at least 100 elements

### DIFF
--- a/exercises/primitive_types/primitive_types3.rs
+++ b/exercises/primitive_types/primitive_types3.rs
@@ -14,5 +14,6 @@ fn main() {
         println!("Wow, that's a big array!");
     } else {
         println!("Meh, I eat arrays like that for breakfast.");
+        panic!("Array not big enough, more elements needed")
     }
 }


### PR DESCRIPTION
The current implementation of `primitive_types3` allows an array of any length to compile, hence invalidating the requirement in the top comment.
This PR adds a panic to the else clause so that it won't compile if the array is too small.
