### PR TITLE
Fix compiler error and clarify instructions

### DIFF
--- a/exercises/smart_pointers/cow1.rs
+++ b/exercises/smart_pointers/cow1.rs
@@ -67,10 +67,10 @@ mod tests {
     #[test]
     fn owned_mutation() -> Result<(), &'static str> {
         // Of course this is also the case if a mutation does occur. In this
-        // case the call to `to_mut()` returns a reference to the same data as
-        // before.
+        // case the call to `to_mut()` in the abs_all() function returns a
+        // reference to the same data as before.
         let slice = vec![-1, 0, 1];
-        let mut input = Cow::from(slice).to_mut();
+        let mut input = Cow::from(slice);
         match abs_all(&mut input) {
             // TODO
         }


### PR DESCRIPTION
Following the discussion on #1195 a [commit](https://github.com/rust-lang/rustlings/commit/720f33eee642eafab3c03bc7caed5f8690b481e8) added `.to_mut()` to the last `Cow::from(slice)` call. However that doesn't compile (or make sense for that matter, since it returns the mutable inner type). I think from reading the comments in [this commit](https://github.com/ComixHe/rustlings/commit/a75b94105ef220e07b3920a3c762ed1d9959bc3a) that the comments are talking about the `.to_mut()` call in the `abs_all()` function and the commit that added the call just misinterpreted what the comments say. At any rate, this makes it compile. 