### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -33,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666629043,
-        "narHash": "sha256-Yoq6Ut2F3Ol73yO9hG93x6ts5c4F5BhKTbcF3DtBEAw=",
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b39fd6e4edef83cb4a135ebef98751ce23becc33",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {
@@ -52,6 +55,21 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
Without this, I get the following error and the devshell doesn't load:

```
error: builder for '/nix/store/r1sxxq6083m1bcvhp768vlhmwgyzz44c-rustlings.drv' failed with exit code 101;
       last 10 log lines:
       > Finished cargoSetupPostUnpackHook
       > patching sources
       > Executing cargoSetupPostPatchHook
       > Validating consistency between /build/source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
       > Finished cargoSetupPostPatchHook
       > configuring
       > building
       > Executing cargoBuildHook
       > ++ env CC_x86_64-unknown-linux-gnu=/nix/store/0vln6gxc9b2wr9yhbn0aspy6badlj638-gcc-wrapper-11.3.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/0vln6gxc9b2wr9yhbn0aspy6badlj638-gcc-wrapper-11.3.0/bin/c++ CC_x86_64-unknown-linux-gnu=/nix/store/0vln6gxc9b2wr9yhbn0aspy6badlj638-gcc-wrapper-11.3.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/0vln6gxc9b2wr9yhbn0aspy6badlj638-gcc-wrapper-11.3.0/bin/c++ cargo build -j 32 --target x86_64-unknown-linux-gnu --frozen --release
       > error: package `clap v4.4.2` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.64.0
       For full logs, run 'nix log /nix/store/r1sxxq6083m1bcvhp768vlhmwgyzz44c-rustlings.drv'.
error: 1 dependencies of derivation '/nix/store/kn2568q7w9sr9xsr4kk7r1y43f76c1kk-nix-shell-env.drv' failed to build
error: getting status of '/home/charles/.cache/direnv/8590b55e2092037c392bdf1a74d782ffaa1dfa36/flake-profile.851284': No such file or directory
```

Most notably, rustc is updated to 1.72.0 and rust-analyzer is updated to 2023-09-04 by this change.