### PR TITLE
Fixed formatting of `enums3` with rustfmt

### DIFF
--- a/exercises/enums/enums3.rs
+++ b/exercises/enums/enums3.rs
@@ -20,7 +20,7 @@ struct State {
     color: (u8, u8, u8),
     position: Point,
     quit: bool,
-    message: String
+    message: String,
 }
 
 impl State {
@@ -32,7 +32,9 @@ impl State {
         self.quit = true;
     }
 
-    fn echo(&mut self, s: String) { self.message = s }
+    fn echo(&mut self, s: String) {
+        self.message = s
+    }
 
     fn move_position(&mut self, p: Point) {
         self.position = p;


### PR DESCRIPTION
`enums3` was not properly formatted.

In VSCode with FormatOnSave, these lines change as soon as you save, hence showing differences before you even start working on the exercise, which might cause confusion.