### PR TITLE
fix: test name typo

### DIFF
--- a/exercises/conversions/as_ref_mut.rs
+++ b/exercises/conversions/as_ref_mut.rs
@@ -57,7 +57,7 @@ mod tests {
     }
 
     #[test]
-    fn mult_box() {
+    fn mut_box() {
         let mut num: Box<u32> = Box::new(3);
         num_sq(&mut num);
         assert_eq!(*num, 9);


### PR DESCRIPTION
Fix a small test name typo