### PR TITLE
Optimize: add the exercise file path to the bottom of the output log

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -127,6 +127,7 @@ fn compile_and_test(
                 exercise
             );
             println!("{}", output.stdout);
+            println!("View: {}", exercise);
             Err(())
         }
     }
@@ -149,6 +150,7 @@ fn compile<'a>(
                 exercise
             );
             println!("{}", output.stderr);
+            println!("View: {}", exercise);
             Err(())
         }
     }


### PR DESCRIPTION
When an exercise compilation error occurs, append the file path to the bottom of the log, making it easy for developers to quickly open the file.

eg:
```sh
Progress: [##>---------------------------------------------------------] 4/96 (4.2 %)
Progress: [###>--------------------------------------------------------] 5/96 (5.2 %)
⚠️  Compiling of exercises/variables/variables3.rs failed! Please try again. Here's the output:
error[E0381]: used binding `x` isn't initialized
  --> exercises/variables/variables3.rs:10:27
   |
9  |     let x: i32;
   |         - binding declared here but left uninitialized
10 |     println!("Number {}", x);
   |                           ^ `x` used here but it isn't initialized
   |
   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider assigning a value
   |
9  |     let x: i32 = 0;
   |                +++

error: aborting due to previous error

For more information about this error, try `rustc --explain E0381`.

View: exercises/variables/variables3.rs
```