### PR TITLE
remove hint comments when no hint exists

### DIFF
--- a/exercises/clippy/clippy3.rs
+++ b/exercises/clippy/clippy3.rs
@@ -1,8 +1,7 @@
 // clippy3.rs
 // 
 // Here's a couple more easy Clippy fixes, so you can see its utility.
-//
-// Execute `rustlings hint clippy3` or use the `hint` watch subcommand for a hint.
+// No hints.
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types1.rs
+++ b/exercises/primitive_types/primitive_types1.rs
@@ -2,9 +2,6 @@
 //
 // Fill in the rest of the line that has code missing! No hints, there's no
 // tricks, just get used to typing these :)
-//
-// Execute `rustlings hint primitive_types1` or use the `hint` watch subcommand
-// for a hint.
 
 // I AM NOT DONE
 

--- a/exercises/primitive_types/primitive_types2.rs
+++ b/exercises/primitive_types/primitive_types2.rs
@@ -2,9 +2,6 @@
 //
 // Fill in the rest of the line that has code missing! No hints, there's no
 // tricks, just get used to typing these :)
-//
-// Execute `rustlings hint primitive_types2` or use the `hint` watch subcommand
-// for a hint.
 
 // I AM NOT DONE
 


### PR DESCRIPTION
three files still point to a hint that isn't there.