### PR TITLE
Remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Automatically Load nix devShell w/dotenv
-use flake


### PR DESCRIPTION
direnv is used in many development environments other than nix, so having a nix-specific .envrc in this Rust package is unhelpful. If one doesn't use nix (I don't!) having it attempt to enable flakes is unhelpful at best:

```
Your branch is up to date with 'upstream/main'.
direnv: error /Users/offby1/projects/rustlings/.envrc is blocked. Run `direnv allow` to approve its content
```

If I allow it, but don't have nix installed:

```
$ direnv allow
direnv: loading ~/projects/rustlings/.envrc
direnv: using flake
environment:1270: nix: command not found
```

While this does not generate an _error_ per se, it is noise every time I chdir into the project.

It's probably relevant that *direnv* doesn't have a `.envrc` committed to their own project repository, so I'm at least not an outlier in my use of this tool :D 