### PR TITLE
fix(installation): bump MinRustVersion to 1.70

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -53,7 +53,7 @@ function vercomp($v1, $v2) {
 }
 
 $rustVersion = $(rustc --version).Split(" ")[1]
-$minRustVersion = "1.56"
+$minRustVersion = "1.70"
 if ((vercomp $rustVersion $minRustVersion) -eq 2) {
     Write-Host "WARNING: Rust version is too old: $rustVersion - needs at least $minRustVersion"
     Write-Host "Please update Rust with 'rustup update'"

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ function vercomp() {
 }
 
 RustVersion=$(rustc --version | cut -d " " -f 2)
-MinRustVersion=1.58
+MinRustVersion=1.70
 vercomp "$RustVersion" $MinRustVersion || ec=$?
 if [ ${ec:-0} -eq 2 ]
 then


### PR DESCRIPTION
Since #1633 porting to Clap, min Rust version requirement changes.