### PR TITLE
fix(cli): make debugging in windows work

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -396,6 +396,8 @@ fn rustc_exists() -> bool {
     Command::new("rustc")
         .args(["--version"])
         .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
         .spawn()
         .and_then(|mut child| child.wait())
         .map(|status| status.success())


### PR DESCRIPTION
On windows, if `stderr` or `stdin` aren't also set to `Stdio::null()` the `spawn()` fails with `The handle is invalid`, and `rustlings` thinks that there's no `rustc` installed.