### PR TITLE
Add message if run next success

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -50,6 +50,11 @@ enum RunMode {
 // Compile and run the resulting test harness of the given Exercise
 pub fn test(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
     compile_and_test(exercise, RunMode::NonInteractive, verbose, false)?;
+    println!(
+        "Exercise {} is done. Remove {} line to go to the next exercise.",
+        style(exercise).bold(),
+        style("`I AM NOT DONE`").bold()
+    );
     Ok(())
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -189,7 +189,7 @@ fn run_test_exercise_does_not_prompt() {
         .current_dir("tests/fixture/state")
         .assert()
         .code(0)
-        .stdout(predicates::str::contains("I AM NOT DONE").not());
+        .stdout(predicates::str::contains("Exercise pending_test_exercise.rs is done. Remove `I AM NOT DONE` line to go to the next exercise."));
 }
 
 #[test]


### PR DESCRIPTION
Nothing happens when execute `rustlings run next` command if `// I AM NOT DONE` was not removed from exercise and exercise compiles without errors and tests are passed.