### PR TITLE
chore(errors): fix grammar typo and wording in errors exercises

### DIFF
--- a/exercises/error_handling/errors2.rs
+++ b/exercises/error_handling/errors2.rs
@@ -3,7 +3,7 @@
 // Say we're writing a game where you can buy items with tokens. All items cost
 // 5 tokens, and whenever you purchase items there is a processing fee of 1
 // token. A player of the game will type in how many items they want to buy, and
-// the `total_cost` function will calculate the total cost of the tokens. Since
+// the `total_cost` function will calculate the total cost of the items. Since
 // the player typed in the quantity, though, we get it as a string-- and they
 // might have typed anything, not just numbers!
 //

--- a/info.toml
+++ b/info.toml
@@ -658,7 +658,7 @@ name = "errors1"
 path = "exercises/error_handling/errors1.rs"
 mode = "test"
 hint = """
-`Ok` and `Err` are one of the variants of `Result`, so what the tests are saying
+`Ok` and `Err` are the two variants of `Result`, so what the tests are saying
 is that `generate_nametag_text` should return a `Result` instead of an `Option`.
 
 To make this change, you'll need to:


### PR DESCRIPTION
chore(errors1): fix grammar typo in hint for exercise errors1

This commit corrects a grammar typo in the hint of the errors1 exercise, changing from:
"`Ok` and `Err` are one of the variants of `Result`,"
to:
"`Ok` and `Err` are the two variants of `Result`,"

---

chore(errors2): minor description wording change in errors2 exercise

This commit makes a minor change in the wording of the description of the errors2 exercise to avoid potential confusion, changing:

"A player of the game will type in how many items they want to buy, and the `total_cost` function will calculate the total cost of the tokens."
to
"A player of the game will type in how many items they want to buy, and the `total_cost` function will calculate the total cost of the items."