### PR TITLE
docs: fix windows installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 Then, you can run:
 
 ```ps1
-Start-BitsTransfer -Source ps1.rustlings.cool -Destination $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
+Start-BitsTransfer -Source https://ps1.rustlings.cool -Destination $env:TMP/install_rustlings.ps1; Unblock-File $env:TMP/install_rustlings.ps1; Invoke-Expression $env:TMP/install_rustlings.ps1
 ```
 
 To install Rustlings. Same as on MacOS/Linux, you will have access to the `rustlings` command after it. Keep in mind that this works best in PowerShell, and any other terminals may give you errors.


### PR DESCRIPTION
Currently, the windows installation instructions download a script from the URL `ps1.rustlings.cool`. This URL isn't detected as a URL in some cases, which means that PowerShell tries to load the data from a local file called `ps1.rustlings.cool`.

This was breaking my install, and adding the `https://` fixed it.