### PR TITLE
fix(intro2): Changed intro2 to be a name error, not a format string error

### DIFF
--- a/exercises/00_intro/intro2.rs
+++ b/exercises/00_intro/intro2.rs
@@ -8,5 +8,5 @@
 // I AM NOT DONE
 
 fn main() {
-    println!("Hello {}!");
+    printline!("Hello there!")
 }

--- a/info.toml
+++ b/info.toml
@@ -13,7 +13,7 @@ name = "intro2"
 path = "exercises/00_intro/intro2.rs"
 mode = "compile"
 hint = """
-Add an argument after the format string."""
+The compiler is informing us that we've got the name of the print macro wrong, and has suggested an alternative."""
 
 # VARIABLES
 


### PR DESCRIPTION
I think intro2 is too difficult to be the very first real exercise, and we're scaring away some students unnecessarily. 

**TL;DR: I've made a tweak to intro2 to cause a much friendlier compiler error.**

## My Case Against The Existing Exercise

The existing error for `intro2` is more difficult to understand compared with subsequent exercises. That's not right, the Rustlings exercises are otherwise in ascending order of difficulty. The first one should be the easiest!

The existing intro2 error is:

```rust
error: 1 positional argument in format string, but no arguments were given
  --> exercises/intro/intro2.rs:11:21
     println!("Hello {}!");
                     ^^
error: aborting due to previous error
```

This is *terrifying* as an error! There's not even a hint or compiler help to aid us! Even existing programmers coming from other languages might be stumped:
- How do they know what a format string is? 
- How are they supposed to know that `{}` is called a 'positional argument'?
- There IS an argument there, it's the string argument to `println!` (they might reasonably think).

I don't think there's a need to teach the student about format strings right here, we're about to use them multiple times in a much friendlier way in the very next exercise: `variables`.

If this exercise were named `formatstring1` I would understand, but it's not, it's named `intro2`:
**This is a poor intro to Rustlings, but one we can fix easily.**


## My Case For The Proposed Change

I propose the first exercise should both showcase Rust's fantastic errors AND show that the compiler can often tell you how to solve your mistakes with help text. 

I propose changing `intro2` to the following, but I would agree with any proposal that has a clear error with correct compiler help text.

```rust
printline!("Hello there!");
```

The compiler error for this is much simpler, AND comes with a correct help suggestion. The error is:

```rust
error: cannot find macro `printline` in this scope
   --> exercises/00_intro/intro2.rs:11:5
    |
11  |     printline!("Hello there!")
    |     ^^^^^^^^^ help: a macro with a similar name exists: `println`
    |
   ::: /home/oatman/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/macros.rs:138:1
    |
138 | macro_rules! println {
    | -------------------- similarly named macro `println` defined here

error: aborting due to previous error
```

The student only needs to read the help line to know how to fix the error. :tada: 
