### PR TITLE
feat: add support for exercises that depend on crates

### DIFF
--- a/exercises/crates/mockall/mocks1/Cargo.toml
+++ b/exercises/crates/mockall/mocks1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mocks1"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+mockall = "0.11.4"
+
+[[bin]]
+name = "mocks1"
+path = "mocks1.rs"

--- a/exercises/crates/mockall/mocks1/mocks1.rs
+++ b/exercises/crates/mockall/mocks1/mocks1.rs
@@ -1,0 +1,45 @@
+// mocks1.rs
+//
+// Mockall is a powerful mock object library for Rust. It provides tools to create 
+// mock versions of almost any trait or struct. They can be used in unit tests as 
+// a stand-in for the real object.
+// 
+// These tests each contain an expectation that defines some behaviour we expect on
+// calls to the function "foo". Add the "foo" function call and get the tests to pass 
+//
+// I AM NOT DONE
+ 
+use mockall::*;
+use mockall::predicate::*;
+
+#[automock]
+trait MyTrait {
+    fn foo(&self) -> bool;
+}
+
+fn follow_path_from_trait(x: &dyn MyTrait) -> String {
+    if ??? {
+        String::from("Followed path A")
+    }
+    else {
+        String::from("Followed path B")
+    }
+}
+
+#[test]
+fn can_follow_path_a() {
+    let mut mock = MockMyTrait::new();
+    mock.expect_foo()
+        .times(1)
+        .returning(||true);
+    assert_eq!(follow_path_from_trait(&mock), "Followed path A");
+}
+
+#[test]
+fn can_follow_path_b() {    
+    let mut mock = MockMyTrait::new();
+    mock.expect_foo()
+        .times(1)
+        .returning(||false);
+    assert_eq!(follow_path_from_trait(&mock), "Followed path B");
+}

--- a/info.toml
+++ b/info.toml
@@ -1319,3 +1319,10 @@ path = "exercises/23_conversions/as_ref_mut.rs"
 mode = "test"
 hint = """
 Add `AsRef<str>` or `AsMut<u32>` as a trait bound to the functions."""
+
+[[exercises]]
+name = "mocks1"
+path = "exercises/crates/mockall/mocks1/Cargo.toml"
+mode = "cratetest"
+hint = """
+x.foo() needs to be called in the if conditional to get the tests to pass."""

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -55,7 +55,7 @@ pub struct Exercise {
     pub name: String,
     // The path to the file containing the exercise's source code
     pub path: PathBuf,
-    // The mode of the exercise (Test, Compile, Clippy, CrateCompile or CrateTest
+    // The mode of the exercise (Test, Compile, Clippy, CrateCompile or CrateTest)
     pub mode: Mode,
     // The hint text associated with the exercise
     pub hint: String,

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,8 +11,8 @@ use indicatif::ProgressBar;
 // the output from the test harnesses (if the mode of the exercise is test)
 pub fn run(exercise: &Exercise, verbose: bool) -> Result<(), ()> {
     match exercise.mode {
-        Mode::Test => test(exercise, verbose)?,
-        Mode::Compile => compile_and_run(exercise)?,
+        Mode::Test | Mode::CrateTest => test(exercise, verbose)?,
+        Mode::Compile | Mode::CrateCompile => compile_and_run(exercise)?,
         Mode::Clippy => compile_and_run(exercise)?,
     }
     Ok(())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -28,8 +28,12 @@ pub fn verify<'a>(
 
     for exercise in exercises {
         let compile_result = match exercise.mode {
-            Mode::Test | Mode::CrateTest => compile_and_test(exercise, RunMode::Interactive, verbose, success_hints),
-            Mode::Compile | Mode::CrateCompile => compile_and_run_interactively(exercise, success_hints),
+            Mode::Test | Mode::CrateTest => {
+                compile_and_test(exercise, RunMode::Interactive, verbose, success_hints)
+            }
+            Mode::Compile | Mode::CrateCompile => {
+                compile_and_run_interactively(exercise, success_hints)
+            }
             Mode::Clippy => compile_only(exercise, success_hints),
         };
         if !compile_result.unwrap_or(false) {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -28,8 +28,8 @@ pub fn verify<'a>(
 
     for exercise in exercises {
         let compile_result = match exercise.mode {
-            Mode::Test => compile_and_test(exercise, RunMode::Interactive, verbose, success_hints),
-            Mode::Compile => compile_and_run_interactively(exercise, success_hints),
+            Mode::Test | Mode::CrateTest => compile_and_test(exercise, RunMode::Interactive, verbose, success_hints),
+            Mode::Compile | Mode::CrateCompile => compile_and_run_interactively(exercise, success_hints),
             Mode::Clippy => compile_only(exercise, success_hints),
         };
         if !compile_result.unwrap_or(false) {
@@ -164,8 +164,8 @@ fn prompt_for_completion(
         State::Pending(context) => context,
     };
     match exercise.mode {
-        Mode::Compile => success!("Successfully ran {}!", exercise),
-        Mode::Test => success!("Successfully tested {}!", exercise),
+        Mode::Compile | Mode::CrateCompile => success!("Successfully ran {}!", exercise),
+        Mode::Test | Mode::CrateTest => success!("Successfully tested {}!", exercise),
         Mode::Clippy => success!("Successfully compiled {}!", exercise),
     }
 
@@ -178,8 +178,8 @@ fn prompt_for_completion(
     };
 
     let success_msg = match exercise.mode {
-        Mode::Compile => "The code is compiling!",
-        Mode::Test => "The code is compiling, and the tests pass!",
+        Mode::Compile | Mode::CrateCompile => "The code is compiling!",
+        Mode::Test | Mode::CrateTest => "The code is compiling, and the tests pass!",
         Mode::Clippy => clippy_success_msg,
     };
     println!();


### PR DESCRIPTION
Based on my suggestion in this [issue](https://github.com/rust-lang/rustlings/issues/1481), I've added support for exercises that rely on crates. I've also added a simple mockall exercise as an example (I'm happy to add more of these if the feature is accepted). 

I think this would be a worthwhile addition to rustlings. It would be great if in the future crate authors have the option to push some simple exercises to get people started with their crate.

Please let me know what you think, I'm happy to make some updates. Thanks!