### PR TITLE
Fix progress bar

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,10 @@ fn watch(
                                     .iter()
                                     .filter(|e| !e.looks_done() && !filepath.ends_with(&e.path)),
                             );
-                        let num_done = exercises.iter().filter(|e| e.looks_done()).count();
+                        let num_done = exercises
+                            .iter()
+                            .filter(|e| e.looks_done() && !filepath.ends_with(&e.path))
+                            .count();
                         clear_screen();
                         match verify(
                             pending_exercises,


### PR DESCRIPTION
Fix #1691 
The saved exercise was counted twice, the second time was inside the verify function with `bar.inc(1)`.
Now the count after saving is consistent with the count at startup.
Please let me know if there's any doubt about this fix.