### PR TITLE
docs: reword `clippy1` exercise to be more readable

### DIFF
--- a/exercises/22_clippy/clippy1.rs
+++ b/exercises/22_clippy/clippy1.rs
@@ -3,8 +3,8 @@
 // The Clippy tool is a collection of lints to analyze your code so you can
 // catch common mistakes and improve your Rust code.
 //
-// For these exercises the code will fail to compile when there are clippy
-// warnings check clippy's suggestions from the output to solve the exercise.
+// For these exercises the code will fail to compile when there are Clippy
+// warnings. Check Clippy's suggestions from the output to solve the exercise.
 //
 // Execute `rustlings hint clippy1` or use the `hint` watch subcommand for a
 // hint.


### PR DESCRIPTION
Not sure if I should use `Clippy` or `clippy` though 🤔...