### PR TITLE
feat: add refcell1 exercise

### DIFF
--- a/exercises/19_smart_pointers/refcell1.rs
+++ b/exercises/19_smart_pointers/refcell1.rs
@@ -1,0 +1,52 @@
+// refcell1.rs
+//
+// Interior mutability is a design pattern in Rust that allows you to mutate 
+// data even when there are immutable references to that data; 
+// normally, this action is disallowed by the borrowing rules.  
+
+// The RefCell<T> type represents single ownership over the data it holds.
+// Recall the borrowing rules in Rust:
+//      1. At any given time, you can have either (but not both) one mutable 
+//      reference or any number of immutable references.
+//      2. References must always be valid.
+
+// With references and Box<T>, the borrowing rules’ invariants are enforced at 
+// compile time. With RefCell<T>, these invariants are enforced at runtime. 
+// With references, if you break these rules, you’ll get a compiler error. 
+// With RefCell<T>, if you break these rules, your program will panic and exit.
+// The RefCell<T> type is useful when you’re sure your code follows the 
+// borrowing rules but the compiler is unable to understand and guarantee that.
+
+// I AM NOT DONE
+
+use std::cell::RefCell;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct User {
+    name: RefCell<String>,
+}
+
+#[allow(dead_code)]
+impl User {
+    fn name(&self) -> String {
+        self.name.borrow().to_string()
+    }
+
+    // Note: do not use &mut self!
+    fn set_name(&self, name: String) {
+        todo!()
+    }
+}
+
+fn main() {
+    let u = User {
+        name: RefCell::new("Alice".to_string()),
+    };
+    println!("My name is {}!", *u.name.borrow());
+
+    let new_name = "Bob".to_string();
+    u.set_name(new_name.clone());
+
+    println!("My name is {}!", *u.name.borrow());
+}

--- a/info.toml
+++ b/info.toml
@@ -1106,6 +1106,20 @@ Check out https://doc.rust-lang.org/std/borrow/enum.Cow.html for documentation
 on the `Cow` type.
 """
 
+[[exercises]]
+name = "refcell1"
+path = "exercises/19_smart_pointers/refcell1.rs"
+mode = "compile"
+hint = """
+Remember that RefCell<T> allows for an immutable object to be modified.
+
+Use the .borrow_mut() method on the RefCell to get a mutable reference to
+the underlying data.
+
+See https://doc.rust-lang.org/book/ch15-05-interior-mutability.html for more
+information on RefCell.
+"""
+
 # THREADS
 
 [[exercises]]


### PR DESCRIPTION
Adds a basic exercise to introduce the concept of a `RefCell`. This API is not necessarily for beginners but is useful to have knowledge of. 