### PR TITLE
Fix all_fruits_types_in_basket to fail if all fruit kinds are not  included

### DIFF
--- a/exercises/11_hashmaps/hashmaps2.rs
+++ b/exercises/11_hashmaps/hashmaps2.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Hash, PartialEq, Eq, Debug)]
 enum Fruit {
     Apple,
     Banana,
@@ -26,6 +26,14 @@ enum Fruit {
     Lychee,
     Pineapple,
 }
+
+const FRUIT_KINDS: [Fruit; 5] = [
+    Fruit::Apple,
+    Fruit::Banana,
+    Fruit::Mango,
+    Fruit::Lychee,
+    Fruit::Pineapple,
+];
 
 fn fruit_basket(basket: &mut HashMap<Fruit, u32>) {
     let fruit_kinds = vec![
@@ -81,12 +89,15 @@ mod tests {
         let count = basket.values().sum::<u32>();
         assert!(count > 11);
     }
-    
+
     #[test]
     fn all_fruit_types_in_basket() {
         let mut basket = get_fruit_basket();
         fruit_basket(&mut basket);
-        for amount in basket.values() {
+        for fruit_kind in FRUIT_KINDS {
+            let amount = basket
+                .get(&fruit_kind)
+                .expect(format!("Fruit kind {:?} was not found in basket", fruit_kind).as_str());
             assert_ne!(amount, &0);
         }
     }

--- a/exercises/11_hashmaps/hashmaps2.rs
+++ b/exercises/11_hashmaps/hashmaps2.rs
@@ -27,14 +27,6 @@ enum Fruit {
     Pineapple,
 }
 
-const FRUIT_KINDS: [Fruit; 5] = [
-    Fruit::Apple,
-    Fruit::Banana,
-    Fruit::Mango,
-    Fruit::Lychee,
-    Fruit::Pineapple,
-];
-
 fn fruit_basket(basket: &mut HashMap<Fruit, u32>) {
     let fruit_kinds = vec![
         Fruit::Apple,
@@ -92,9 +84,17 @@ mod tests {
 
     #[test]
     fn all_fruit_types_in_basket() {
+        let fruit_kinds = vec![
+            Fruit::Apple,
+            Fruit::Banana,
+            Fruit::Mango,
+            Fruit::Lychee,
+            Fruit::Pineapple,
+        ];
+
         let mut basket = get_fruit_basket();
         fruit_basket(&mut basket);
-        for fruit_kind in FRUIT_KINDS {
+        for fruit_kind in fruit_kinds {
             let amount = basket
                 .get(&fruit_kind)
                 .expect(format!("Fruit kind {:?} was not found in basket", fruit_kind).as_str());


### PR DESCRIPTION
This is a redo of PR #1626 which I flaked on. This accounts for the new file structure and the formatting request.