### PR TITLE
Cleaned Up Unused Mutability

### DIFF
--- a/exercises/06_move_semantics/move_semantics2.rs
+++ b/exercises/06_move_semantics/move_semantics2.rs
@@ -11,7 +11,7 @@
 fn main() {
     let vec0 = vec![22, 44, 66];
 
-    let mut vec1 = fill_vec(vec0);
+    let vec1 = fill_vec(vec0);
 
     assert_eq!(vec0, vec![22, 44, 66]);
     assert_eq!(vec1, vec![22, 44, 66, 88]);

--- a/exercises/06_move_semantics/move_semantics3.rs
+++ b/exercises/06_move_semantics/move_semantics3.rs
@@ -12,7 +12,7 @@
 fn main() {
     let vec0 = vec![22, 44, 66];
 
-    let mut vec1 = fill_vec(vec0);
+    let vec1 = fill_vec(vec0);
 
     assert_eq!(vec1, vec![22, 44, 66, 88]);
 }

--- a/exercises/06_move_semantics/move_semantics4.rs
+++ b/exercises/06_move_semantics/move_semantics4.rs
@@ -13,7 +13,7 @@
 fn main() {
     let vec0 = vec![22, 44, 66];
 
-    let mut vec1 = fill_vec(vec0);
+    let vec1 = fill_vec(vec0);
 
     assert_eq!(vec1, vec![22, 44, 66, 88]);
 }


### PR DESCRIPTION
Eliminated unused mutability by reverting the variable vec1 to an immutable state.

The introduction of `mut` in the [initial commit](https://github.com/rust-lang/rustlings/commit/c859550e6ce35bf9923a930aecb80cc83c8f6dff) was essential, but [subsequent changes](https://github.com/rust-lang/rustlings/commit/51e237d5f97610294798710ef8ba5349c2fd50c7) have made mutability unnecessary.

This refinement streamlines the code by acknowledging that the variable no longer necessitates mutability. The adjustment not only improves code clarity and maintainability but also eliminates the `variable does not need to be mutable` warning, enhancing the overall code quality.