### PR TITLE
Remove confusing aside in 23_conversions/from_str.rs

### DIFF
--- a/exercises/23_conversions/from_str.rs
+++ b/exercises/23_conversions/from_str.rs
@@ -44,10 +44,6 @@ enum ParsePersonError {
 // 6. If while extracting the name and the age something goes wrong, an error
 //    should be returned
 // If everything goes well, then return a Result of a Person object
-//
-// As an aside: `Box<dyn Error>` implements `From<&'_ str>`. This means that if
-// you want to return a string error message, you can do so via just using
-// return `Err("my error message".into())`.
 
 impl FromStr for Person {
     type Err = ParsePersonError;


### PR DESCRIPTION
The advice tell us how to return as String error message. Unless I missed something, we can't even return a String error message in this exercise (we have to return a ParsePersonError), so this advice is more confusing than anything and should better be removed.