### PR TITLE
docs: sort exercise to book chapter mapping by exercise

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -17,11 +17,11 @@
 | error_handling         | §9                  |
 | generics               | §10                 |
 | traits                 | §10.2               |
-| tests                  | §11.1               |
 | lifetimes              | §10.3               |
+| tests                  | §11.1               |
 | iterators              | §13.2-4             |
-| threads                | §16.1-3             |
 | smart_pointers         | §15, §16.3          |
+| threads                | §16.1-3             |
 | macros                 | §19.6               |
 | clippy                 | §21.4               |
 | conversions            | n/a                 |


### PR DESCRIPTION
Hi!
It looks like the "Exercise to Book Chapter" table in `exercises/README.md` does not have up to date sorting order in relation with the exercises order. This PR is simply sorting it.