### PR TITLE
chore(box1): moved main to tests module in order to print its content

### DIFF
--- a/exercises/19_smart_pointers/box1.rs
+++ b/exercises/19_smart_pointers/box1.rs
@@ -26,14 +26,6 @@ pub enum List {
     Nil,
 }
 
-fn main() {
-    println!("This is an empty cons list: {:?}", create_empty_list());
-    println!(
-        "This is a non-empty cons list: {:?}",
-        create_non_empty_list()
-    );
-}
-
 pub fn create_empty_list() -> List {
     todo!()
 }
@@ -45,6 +37,15 @@ pub fn create_non_empty_list() -> List {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn main() {
+        println!("This is an empty cons list: {:?}", create_empty_list());
+        println!(
+            "This is a non-empty cons list: {:?}",
+            create_non_empty_list()
+        );
+    }
 
     #[test]
     fn test_create_empty_list() {


### PR DESCRIPTION
Moved `fn main()` to inside `mod tests` in order to print its content when running tests.