### PR TITLE
fix(quiz2): incorrect value in test

### DIFF
--- a/exercises/quiz2.rs
+++ b/exercises/quiz2.rs
@@ -58,7 +58,7 @@ mod tests {
         ]);
         assert_eq!(output[0], "HELLO");
         assert_eq!(output[1], "all roads lead to rome!");
-        assert_eq!(output[2], "foobar");
+        assert_eq!(output[2], "foofoo");
         assert_eq!(output[3], "barbarbarbarbarbar");
     }
 }


### PR DESCRIPTION
There's nowhere for "bar" to come from, as shown by the next line.