### PR TITLE
feat: added next up message with the path of next exercise

### DIFF
--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -54,6 +54,8 @@ pub struct Exercise {
     pub mode: Mode,
     // The hint text associated with the exercise
     pub hint: String,
+    // The path of the next exercise
+    pub next_path: Option<PathBuf>
 }
 
 // An enum to track of the state of an Exercise.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, prelude::*};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, RecvTimeoutError};
@@ -108,8 +108,10 @@ fn main() {
     }
 
     let toml_str = &fs::read_to_string("info.toml").unwrap();
-    let exercises = toml::from_str::<ExerciseList>(toml_str).unwrap().exercises;
+    let mut exercises = toml::from_str::<ExerciseList>(toml_str).unwrap().exercises;
     let verbose = args.nocapture;
+
+    edit_exercises(&mut exercises);
 
     let command = args.command.unwrap_or_else(|| {
         println!("{DEFAULT_OUT}\n");
@@ -242,6 +244,20 @@ fn main() {
                 println!("If you want to continue working on the exercises at a later point, you can simply run `rustlings watch` again");
             }
         },
+    }
+}
+
+fn edit_exercises(exercises: &mut Vec<Exercise>){
+    let siz = exercises.len();
+    for i in 0.. siz {
+        if i == siz - 1 {
+            exercises[i].next_path = None;
+            break;
+        }
+        let next_path = &exercises[i + 1].path;
+        let mut x = PathBuf::new();
+        x.push(next_path);
+        exercises[i].next_path = Some(x);
     }
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -171,6 +171,13 @@ fn prompt_for_completion(
 
     let no_emoji = env::var("NO_EMOJI").is_ok();
 
+    match &exercise.next_path {
+        Some(path) => {
+            println!("Next up: {:?}", path);
+        }
+        None => {}
+    }
+
     let clippy_success_msg = if no_emoji {
         "The code is compiling, and Clippy is happy!"
     } else {


### PR DESCRIPTION
Added a new property to Exercise, next_path. I populate this property, when loading the exercises.

While doing the exercises I found myself wanting this small piece of information which file I'm going to have to edit next, so while the 1 sec timeout runs out in the rustlings watch, I can be already switched to that. 