### PR TITLE
fix(from_into): correcting test from commit 2691a35

### DIFF
--- a/exercises/23_conversions/from_into.rs
+++ b/exercises/23_conversions/from_into.rs
@@ -127,14 +127,14 @@ mod tests {
     #[test]
     fn test_trailing_comma() {
         let p: Person = Person::from("Mike,32,");
-        assert_eq!(p.name, "Mike");
-        assert_eq!(p.age, 32);
+        assert_eq!(p.name, "John");
+        assert_eq!(p.age, 30);
     }
 
     #[test]
     fn test_trailing_comma_and_some_string() {
         let p: Person = Person::from("Mike,32,man");
-        assert_eq!(p.name, "Mike");
-        assert_eq!(p.age, 32);
+        assert_eq!(p.name, "John");
+        assert_eq!(p.age, 30);
     }
 }


### PR DESCRIPTION
I don't think the commit: https://github.com/rust-lang/rustlings/commit/2691a35102b0eab111706da0c27fc39541b64e0c should of been merged into main, in the comments for this exercise it states:

// 5. Extract the other element from the split operation and parse it into a
//    `usize` as the age.
// If while parsing the age, something goes wrong, then return the default of
// Person Otherwise, then return an instantiated Person object with the results

This should mean that the original test code  were correct in that it returns the default Person since parsing `32,` and `32,man` respectively should result in an Error.