### PR TITLE
fix: Ensure scripts have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Use gitattributes file to ensure script files have LF line endings. This solves a problem for users who wish to use DevContainers on Windows machines and the file has been cloned from the repository with CRLF line endings.