### PR TITLE
Fix(Installation) Added .git to end of Repo's https URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ fi
 
 Path=${1:-rustlings/}
 echo "Cloning Rustlings at $Path..."
-git clone -q https://github.com/rust-lang/rustlings "$Path"
+git clone -q https://github.com/rust-lang/rustlings.git "$Path"
 
 cd "$Path"
 


### PR DESCRIPTION
The install.sh script didn't work for me, after I changed this locally it worked. URL needs to end in .git