### PR TITLE
Clarified hint text

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -145,7 +145,7 @@ after the `->`. This is where the function's return type should be -- take a
 look at the `is_even` function for an example!
 
 Also: Did you figure out that, technically, `u32` would be the more fitting type
-for the prices here, since they can't be negative? If so, kudos!"""
+for the inputs of the functions here, since the original prices shouldn't be negative? If so, kudos!"""
 
 [[exercises]]
 name = "functions5"


### PR DESCRIPTION
The hint says that `u32` would be more fitting for the prices. But this is only true for the original price and thus as an extension the parameters of the functions, not the type of the return value of `sale_prince`, as this could be negative for `original_price` values between 0 and 10 (specifically it will be negative for the input values of 1, 2, 4, 6 and 8).

Code for the exercise:
```rust
fn main() {
    let original_price = 51;
    println!("Your sale price is {}", sale_price(original_price));
}

fn sale_price(price: i32) -> i32 {
    if is_even(price) {
        price - 10
    } else {
        price - 3
    }
}

fn is_even(num: i32) -> bool {
    num % 2 == 0
}
```

PS. I know this might be pedantic and certainly will be very far down on the list of priorities, but I have stumbled over this hint multiple times, and the first time I encountered it I thought I was missing something and was quite stumped, just to figure out that the comment possible meant something else.