### PR TITLE
docs: Added comment for handling equal numbers in if/if1.rs `bigger` function

### DIFF
--- a/exercises/03_if/if1.rs
+++ b/exercises/03_if/if1.rs
@@ -6,7 +6,7 @@
 
 pub fn bigger(a: i32, b: i32) -> i32 {
     // Complete this function to return the bigger number!
-    // If both numbers are equal, any of them is returned.
+    // If both numbers are equal, any of them can be returned.
     // Do not use:
     // - another function call
     // - additional variables

--- a/exercises/03_if/if1.rs
+++ b/exercises/03_if/if1.rs
@@ -6,6 +6,7 @@
 
 pub fn bigger(a: i32, b: i32) -> i32 {
     // Complete this function to return the bigger number!
+    // If both numbers are equal, any of them is returned.
     // Do not use:
     // - another function call
     // - additional variables


### PR DESCRIPTION
Added a clarifying comment in the `if/if1.rs bigger` function to explicitly mention the behavior when both input numbers are equal.