### PR TITLE
chore: minor typo fix

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -248,7 +248,7 @@ starting and ending (plus one) indices of the items in the `Array` that you
 want to end up in the slice.
 
 If you're curious why the first argument of `assert_eq!` does not have an
-ampersand for a reference since the second argument is areference, take a look
+ampersand for a reference since the second argument is a reference, take a look
 at the coercion chapter of the nomicon:
 https://doc.rust-lang.org/nomicon/coercions.html"""
 


### PR DESCRIPTION
primitive types 4 hint:
areference -> a reference