### PR TITLE
Simplify and shrink development container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,6 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
-  "waitFor": "onCreateCommand",
-  "onCreateCommand": ".devcontainer/setup.sh",
+  "image": "mcr.microsoft.com/devcontainers/rust:1",
   "updateContentCommand": "cargo build",
-  "postCreateCommand": "",
-  "postAttachCommand": {
-    "server": "rustlings watch"
-  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,5 @@
   "updateContentCommand": "cargo build",
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/target/debug"
-  },
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "rust-lang.rust-analyzer"
-      ]
-    }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "image": "mcr.microsoft.com/devcontainers/rust:1",
   "updateContentCommand": "cargo build",
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/target/debug"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# Update current shell environment variables after install to find rustup
-. "$HOME/.cargo/env"
-rustup install stable
-bash install.sh


### PR DESCRIPTION
This replaces a very large "universal" image with the typical rust base. I also trimmed down some non-functioning/excess config obviated by the presence of the container's toolchain and Dev Container lifecycle (no checkout needed).