### PR TITLE
show stdout of the final line

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -38,6 +38,15 @@ pub fn verify<'a>(
         percentage += 100.0 / total as f32;
         bar.inc(1);
         bar.set_message(format!("({:.1} %)", percentage));
+        if bar.position() == total as u64 {
+            println!(
+                "Progress: You completed {} / {} exercises ({:.1} %).",
+                bar.position(),
+                total,
+                percentage
+            );
+            bar.finish();
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
I guess that the issue with the final line not being added when executing rustlings verify is due to a buffering problem. To flush the buffer, I added a println statement, and in my environment, it becomes expected stdout.

fix #1898 