### PR TITLE
Remove unneeded Arc

### DIFF
--- a/exercises/20_threads/threads3.rs
+++ b/exercises/20_threads/threads3.rs
@@ -27,22 +27,18 @@ impl Queue {
 }
 
 fn send_tx(q: Queue, tx: mpsc::Sender<u32>) -> () {
-    let qc = Arc::new(q);
-    let qc1 = Arc::clone(&qc);
-    let qc2 = Arc::clone(&qc);
-
     thread::spawn(move || {
-        for val in &qc1.first_half {
+        for val in q.first_half {
             println!("sending {:?}", val);
-            tx.send(*val).unwrap();
+            tx.send(val).unwrap();
             thread::sleep(Duration::from_secs(1));
         }
     });
 
     thread::spawn(move || {
-        for val in &qc2.second_half {
+        for val in q.second_half {
             println!("sending {:?}", val);
-            tx.send(*val).unwrap();
+            tx.send(val).unwrap();
             thread::sleep(Duration::from_secs(1));
         }
     });


### PR DESCRIPTION
`Arc` is not needed since a partial move into the threads is possible.