### PR TITLE
Optimizations 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,10 +533,10 @@ dependencies = [
  "indicatif",
  "notify-debouncer-mini",
  "predicates",
- "regex",
  "serde",
  "serde_json",
  "toml",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ glob = "0.3.0"
 home = "0.5.9"
 indicatif = "0.17.8"
 notify-debouncer-mini = "0.4.1"
-regex = "1.10.3"
 serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }
 toml = "0.8.10"
+winnow = "0.6.5"
 
 [[bin]]
 name = "rustlings"

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use std::fs::{self, remove_file, File};
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
-use std::process::{self, Command};
+use std::process::{self, exit, Command};
 use std::{array, env, mem};
 use winnow::ascii::{space0, Caseless};
 use winnow::combinator::opt;
@@ -15,7 +15,8 @@ const RUSTC_NO_DEBUG_ARGS: &[&str] = &["-C", "strip=debuginfo"];
 const CONTEXT: usize = 2;
 const CLIPPY_CARGO_TOML_PATH: &str = "./exercises/22_clippy/Cargo.toml";
 
-fn not_done(input: &str) -> bool {
+// Checks if the line contains the "I AM NOT DONE" comment.
+fn contains_not_done_comment(input: &str) -> bool {
     (
         space0::<_, ()>,
         "//",
@@ -219,12 +220,15 @@ path = "{}.rs""#,
 
     pub fn state(&self) -> State {
         let source_file = File::open(&self.path).unwrap_or_else(|e| {
-            panic!(
-                "We were unable to open the exercise file {}! {e}",
-                self.path.display()
-            )
+            println!(
+                "Failed to open the exercise file {}: {e}",
+                self.path.display(),
+            );
+            exit(1);
         });
         let mut source_reader = BufReader::new(source_file);
+
+        // Read the next line into `buf` without the newline at the end.
         let mut read_line = |buf: &mut String| -> io::Result<_> {
             let n = source_reader.read_line(buf)?;
             if buf.ends_with('\n') {
@@ -236,70 +240,72 @@ path = "{}.rs""#,
             Ok(n)
         };
 
-        let mut matched_line_ind: usize = 0;
+        let mut current_line_number: usize = 1;
         let mut prev_lines: [_; CONTEXT] = array::from_fn(|_| String::with_capacity(256));
         let mut line = String::with_capacity(256);
 
         loop {
-            match read_line(&mut line) {
-                Ok(0) => break,
-                Ok(_) => {
-                    if not_done(&line) {
-                        let mut context = Vec::with_capacity(2 * CONTEXT + 1);
-                        for (ind, prev_line) in prev_lines
-                            .into_iter()
-                            .rev()
-                            .take(matched_line_ind)
-                            .enumerate()
-                        {
-                            context.push(ContextLine {
-                                line: prev_line,
-                                // TODO
-                                number: matched_line_ind - CONTEXT + ind + 1,
-                                important: false,
-                            });
-                        }
+            let n = read_line(&mut line).unwrap_or_else(|e| {
+                println!(
+                    "Failed to read the exercise file {}: {e}",
+                    self.path.display(),
+                );
+                exit(1);
+            });
 
-                        context.push(ContextLine {
-                            line,
-                            number: matched_line_ind + 1,
-                            important: true,
-                        });
-
-                        for ind in 0..CONTEXT {
-                            let mut next_line = String::with_capacity(256);
-                            let Ok(n) = read_line(&mut next_line) else {
-                                break;
-                            };
-
-                            if n == 0 {
-                                break;
-                            }
-
-                            context.push(ContextLine {
-                                line: next_line,
-                                number: matched_line_ind + ind + 2,
-                                important: false,
-                            });
-                        }
-
-                        return State::Pending(context);
-                    }
-
-                    matched_line_ind += 1;
-                    for prev_line in &mut prev_lines {
-                        mem::swap(&mut line, prev_line);
-                    }
-                    line.clear();
-                }
-                Err(e) => panic!(
-                    "We were unable to read the exercise file {}! {e}",
-                    self.path.display()
-                ),
+            // Reached the end of the file and didn't find the comment.
+            if n == 0 {
+                return State::Done;
             }
-        }
 
-        State::Done
+            if contains_not_done_comment(&line) {
+                let mut context = Vec::with_capacity(2 * CONTEXT + 1);
+                for (ind, prev_line) in prev_lines
+                    .into_iter()
+                    .take(current_line_number - 1)
+                    .enumerate()
+                    .rev()
+                {
+                    context.push(ContextLine {
+                        line: prev_line,
+                        number: current_line_number - 1 - ind,
+                        important: false,
+                    });
+                }
+
+                context.push(ContextLine {
+                    line,
+                    number: current_line_number,
+                    important: true,
+                });
+
+                for ind in 0..CONTEXT {
+                    let mut next_line = String::with_capacity(256);
+                    let Ok(n) = read_line(&mut next_line) else {
+                        break;
+                    };
+
+                    if n == 0 {
+                        break;
+                    }
+
+                    context.push(ContextLine {
+                        line: next_line,
+                        number: current_line_number + 1 + ind,
+                        important: false,
+                    });
+                }
+
+                return State::Pending(context);
+            }
+
+            current_line_number += 1;
+            // Recycle the buffers.
+            for prev_line in &mut prev_lines {
+                mem::swap(&mut line, prev_line);
+            }
+            line.clear();
+        }
     }
 
     // Check that the exercise looks to be solved using self.state()
@@ -428,17 +434,17 @@ mod test {
 
     #[test]
     fn test_not_done() {
-        assert!(not_done("// I AM NOT DONE"));
-        assert!(not_done("/// I AM NOT DONE"));
-        assert!(not_done("//  I AM NOT DONE"));
-        assert!(not_done("///  I AM NOT DONE"));
-        assert!(not_done("// I AM NOT DONE "));
-        assert!(not_done("// I AM NOT DONE!"));
-        assert!(not_done("// I am not done"));
-        assert!(not_done("// i am NOT done"));
+        assert!(contains_not_done_comment("// I AM NOT DONE"));
+        assert!(contains_not_done_comment("/// I AM NOT DONE"));
+        assert!(contains_not_done_comment("//  I AM NOT DONE"));
+        assert!(contains_not_done_comment("///  I AM NOT DONE"));
+        assert!(contains_not_done_comment("// I AM NOT DONE "));
+        assert!(contains_not_done_comment("// I AM NOT DONE!"));
+        assert!(contains_not_done_comment("// I am not done"));
+        assert!(contains_not_done_comment("// i am NOT done"));
 
-        assert!(!not_done("I AM NOT DONE"));
-        assert!(!not_done("// NOT DONE"));
-        assert!(!not_done("DONE"));
+        assert!(!contains_not_done_comment("I AM NOT DONE"));
+        assert!(!contains_not_done_comment("// NOT DONE"));
+        assert!(!contains_not_done_comment("DONE"));
     }
 }

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -5,7 +5,7 @@ use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{self, Command};
 use std::{array, env, mem};
-use winnow::ascii::{space0, space1};
+use winnow::ascii::{space0, Caseless};
 use winnow::combinator::opt;
 use winnow::Parser;
 
@@ -21,13 +21,7 @@ fn not_done(input: &str) -> bool {
         "//",
         opt('/'),
         space0,
-        'I',
-        space1,
-        "AM",
-        space1,
-        "NOT",
-        space1,
-        "DONE",
+        Caseless("I AM NOT DONE"),
     )
         .parse_next(&mut &*input)
         .is_ok()
@@ -438,15 +432,13 @@ mod test {
         assert!(not_done("/// I AM NOT DONE"));
         assert!(not_done("//  I AM NOT DONE"));
         assert!(not_done("///  I AM NOT DONE"));
-        assert!(not_done("// I  AM NOT DONE"));
-        assert!(not_done("// I AM  NOT DONE"));
-        assert!(not_done("// I AM NOT  DONE"));
         assert!(not_done("// I AM NOT DONE "));
         assert!(not_done("// I AM NOT DONE!"));
+        assert!(not_done("// I am not done"));
+        assert!(not_done("// i am NOT done"));
 
         assert!(!not_done("I AM NOT DONE"));
         assert!(!not_done("// NOT DONE"));
         assert!(!not_done("DONE"));
-        assert!(!not_done("// i am not done"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,17 +149,15 @@ fn main() {
                 let filter_cond = filters
                     .iter()
                     .any(|f| exercise.name.contains(f) || fname.contains(f));
-                let status = if exercise.looks_done() {
+                let looks_done = exercise.looks_done();
+                let status = if looks_done {
                     exercises_done += 1;
                     "Done"
                 } else {
                     "Pending"
                 };
-                let solve_cond = {
-                    (exercise.looks_done() && solved)
-                        || (!exercise.looks_done() && unsolved)
-                        || (!solved && !unsolved)
-                };
+                let solve_cond =
+                    (looks_done && solved) || (!looks_done && unsolved) || (!solved && !unsolved);
                 if solve_cond && (filter_cond || filter.is_none()) {
                     let line = if paths {
                         format!("{fname}\n")

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn main() {
                 .collect::<Vec<_>>();
 
             for exercise in &exercises {
-                let fname = format!("{}", exercise.path.display());
+                let fname = exercise.path.to_string_lossy();
                 let filter_cond = filters
                     .iter()
                     .any(|f| exercise.name.contains(f) || fname.contains(f));

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,31 +128,45 @@ fn main() {
                 println!("{:<17}\t{:<46}\t{:<7}", "Name", "Path", "Status");
             }
             let mut exercises_done: u16 = 0;
-            let filters = filter.clone().unwrap_or_default().to_lowercase();
-            exercises.iter().for_each(|e| {
-                let fname = format!("{}", e.path.display());
+            let lowercase_filter = filter
+                .as_ref()
+                .map(|s| s.to_lowercase())
+                .unwrap_or_default();
+            let filters = lowercase_filter
+                .split(',')
+                .filter_map(|f| {
+                    let f = f.trim();
+                    if f.is_empty() {
+                        None
+                    } else {
+                        Some(f)
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            for exercise in &exercises {
+                let fname = format!("{}", exercise.path.display());
                 let filter_cond = filters
-                    .split(',')
-                    .filter(|f| !f.trim().is_empty())
-                    .any(|f| e.name.contains(f) || fname.contains(f));
-                let status = if e.looks_done() {
+                    .iter()
+                    .any(|f| exercise.name.contains(f) || fname.contains(f));
+                let status = if exercise.looks_done() {
                     exercises_done += 1;
                     "Done"
                 } else {
                     "Pending"
                 };
                 let solve_cond = {
-                    (e.looks_done() && solved)
-                        || (!e.looks_done() && unsolved)
+                    (exercise.looks_done() && solved)
+                        || (!exercise.looks_done() && unsolved)
                         || (!solved && !unsolved)
                 };
                 if solve_cond && (filter_cond || filter.is_none()) {
                     let line = if paths {
                         format!("{fname}\n")
                     } else if names {
-                        format!("{}\n", e.name)
+                        format!("{}\n", exercise.name)
                     } else {
-                        format!("{:<17}\t{fname:<46}\t{status:<7}\n", e.name)
+                        format!("{:<17}\t{fname:<46}\t{status:<7}\n", exercise.name)
                     };
                     // Somehow using println! leads to the binary panicking
                     // when its output is piped.
@@ -168,7 +182,8 @@ fn main() {
                         });
                     }
                 }
-            });
+            }
+
             let percentage_progress = exercises_done as f32 / exercises.len() as f32 * 100.0;
             println!(
                 "Progress: You completed {} / {} exercises ({:.1} %).",

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -224,7 +224,7 @@ fn prompt_for_completion(
         let formatted_line = if context_line.important {
             format!("{}", style(context_line.line).bold())
         } else {
-            context_line.line.to_string()
+            context_line.line
         };
 
         println!(


### PR DESCRIPTION
I started some optimizations :D

I optimized the `list` command. That involved the optimization of the `state` method which checks whether an exercise is done or not.

The most important changes are:
1. Instead of reading the whole file to look for the "I AM NOT DONE" comment, iterate over lines with a `BufReader`.
2. Replaced regex with the `winnow` parser.

There is one difference to the old regex: Instead of allowing multiple spaces between the words of the comment (e.g. "I  AM   NOT     DONE"), I now only allow one space but the comment is caseless. So "I am not done" now also works.
This is not a limitation of `winnow`, I just found it useful. Because during my course, some wanted to add the comment back to experiment a bit, but they had to copy the comment instead of just being able to write it.

Running `list` got a speed up of about 1.6x 🚀
The RAM usage should also be reduced significantly.