### PR TITLE
Reading the `info.toml` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -618,18 +618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
-name = "toml"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ notify-debouncer-mini = "0.4.1"
 regex = "1.10.3"
 serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }
-toml = "0.8.10"
+toml_edit = { version = "0.22.9", default-features = false, features = ["parse", "serde"] }
 
 [[bin]]
 name = "rustlings"

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,15 +91,6 @@ fn main() {
         println!("\n{WELCOME}\n");
     }
 
-    if !Path::new("info.toml").exists() {
-        println!(
-            "{} must be run from the rustlings directory",
-            std::env::current_exe().unwrap().to_str().unwrap()
-        );
-        println!("Try `cd rustlings/`!");
-        std::process::exit(1);
-    }
-
     if !rustc_exists() {
         println!("We cannot find `rustc`.");
         println!("Try running `rustc --version` to diagnose your problem.");
@@ -107,7 +98,15 @@ fn main() {
         std::process::exit(1);
     }
 
-    let info_file = fs::read_to_string("info.toml").unwrap();
+    let info_file = fs::read_to_string("info.toml").unwrap_or_else(|e| {
+        match e.kind() {
+            io::ErrorKind::NotFound => println!(
+                "The program must be run from the rustlings directory\nTry `cd rustlings/`!",
+            ),
+            _ => println!("Failed to read the info.toml file: {e}"),
+        }
+        std::process::exit(1);
+    });
     let exercises = toml_edit::de::from_str::<ExerciseList>(&info_file)
         .unwrap()
         .exercises;

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,10 @@ fn main() {
         std::process::exit(1);
     }
 
-    let toml_str = &fs::read_to_string("info.toml").unwrap();
-    let exercises = toml::from_str::<ExerciseList>(toml_str).unwrap().exercises;
+    let info_file = fs::read_to_string("info.toml").unwrap();
+    let exercises = toml_edit::de::from_str::<ExerciseList>(&info_file)
+        .unwrap()
+        .exercises;
     let verbose = args.nocapture;
 
     let command = args.command.unwrap_or_else(|| {


### PR DESCRIPTION
I replaced the `toml` crate with `toml_edit`. The `toml` crate uses `toml_edit` under the hood anyway (see https://epage.github.io/blog/2023/01/toml-vs-toml-edit by the author of both crates).
There is one change caused by this move: The `display` feature of `toml_edit` is not enabled now which means that we only activate what we use (`serde` and `parse`).

I also made handling the case of `info.toml` not existing in the current directory part of the error handling when trying to read the file. This eliminates a redundant syscall and the usage of `unwrap`.