### PR TITLE
Rewrite `project.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +531,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rustlings"
 version = "5.6.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.81"
 clap = { version = "4.5.2", features = ["derive"] }
 console = "0.15.8"
 glob = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 anyhow = "1.0.81"
 clap = { version = "4.5.2", features = ["derive"] }
 console = "0.15.8"
-glob = "0.3.0"
 home = "0.5.9"
 indicatif = "0.17.8"
 notify-debouncer-mini = "0.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,9 +209,7 @@ fn main() -> Result<()> {
                 .exercises_to_json(exercises)
                 .expect("Couldn't parse rustlings exercises files");
 
-            if project.crates.is_empty() {
-                println!("Failed find any exercises, make sure you're in the `rustlings` folder");
-            } else if project.write_to_disk().is_err() {
+            if project.write_to_disk().is_err() {
                 println!("Failed to write rust-project.json to disk for rust-analyzer");
             } else {
                 println!("Successfully generated rust-project.json");

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,10 +204,7 @@ fn main() -> Result<()> {
         }
 
         Subcommands::Lsp => {
-            let mut project = RustAnalyzerProject::new();
-            project
-                .get_sysroot_src()
-                .expect("Couldn't find toolchain path, do you have `rustc` installed?");
+            let mut project = RustAnalyzerProject::build()?;
             project
                 .exercises_to_json()
                 .expect("Couldn't parse rustlings exercises files");

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn main() -> Result<()> {
         Subcommands::Lsp => {
             let mut project = RustAnalyzerProject::build()?;
             project
-                .exercises_to_json()
+                .exercises_to_json(exercises)
                 .expect("Couldn't parse rustlings exercises files");
 
             if project.crates.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use crate::exercise::{Exercise, ExerciseList};
-use crate::project::RustAnalyzerProject;
+use crate::project::write_project_json;
 use crate::run::{reset, run};
 use crate::verify::verify;
 use anyhow::Result;
@@ -204,13 +204,8 @@ fn main() -> Result<()> {
         }
 
         Subcommands::Lsp => {
-            let mut project = RustAnalyzerProject::build()?;
-            project
-                .exercises_to_json(exercises)
-                .expect("Couldn't parse rustlings exercises files");
-
-            if project.write_to_disk().is_err() {
-                println!("Failed to write rust-project.json to disk for rust-analyzer");
+            if let Err(e) = write_project_json(exercises) {
+                println!("Failed to write rust-project.json to disk for rust-analyzer: {e}");
             } else {
                 println!("Successfully generated rust-project.json");
                 println!("rust-analyzer will now parse exercises, restart your language server or editor")

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use crate::exercise::{Exercise, ExerciseList};
 use crate::project::RustAnalyzerProject;
 use crate::run::{reset, run};
 use crate::verify::verify;
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use console::Emoji;
 use notify_debouncer_mini::notify::{self, RecursiveMode};
@@ -84,7 +85,7 @@ enum Subcommands {
     Lsp,
 }
 
-fn main() {
+fn main() -> Result<()> {
     let args = Args::parse();
 
     if args.command.is_none() {
@@ -243,6 +244,8 @@ fn main() {
             }
         },
     }
+
+    Ok(())
 }
 
 fn spawn_watch_shell(

--- a/src/project.rs
+++ b/src/project.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::error::Error;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Contains the structure of resulting rust-project.json file
 /// and functions to build the data required to create the file
@@ -35,6 +35,7 @@ impl RustAnalyzerProject {
         let toolchain = Command::new("rustc")
             .arg("--print")
             .arg("sysroot")
+            .stderr(Stdio::inherit())
             .output()
             .context("Failed to get the sysroot from `rustc`. Do you have `rustc` installed?")?
             .stdout;

--- a/src/project.rs
+++ b/src/project.rs
@@ -3,7 +3,7 @@ use glob::glob;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 /// Contains the structure of resulting rust-project.json file
@@ -45,15 +45,9 @@ impl RustAnalyzerProject {
 
         println!("Determined toolchain: {toolchain}\n");
 
-        let Ok(sysroot_src) = Path::new(toolchain)
-            .join("lib")
-            .join("rustlib")
-            .join("src")
-            .join("rust")
-            .join("library")
-            .into_os_string()
-            .into_string()
-        else {
+        let mut sysroot_src = PathBuf::with_capacity(256);
+        sysroot_src.extend([toolchain, "lib", "rustlib", "src", "rust", "library"]);
+        let Ok(sysroot_src) = sysroot_src.into_os_string().into_string() else {
             bail!("The sysroot path is invalid UTF8");
         };
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -12,7 +12,7 @@ use crate::exercise::Exercise;
 #[derive(Serialize, Deserialize)]
 pub struct RustAnalyzerProject {
     sysroot_src: String,
-    pub crates: Vec<Crate>,
+    crates: Vec<Crate>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/project.rs
+++ b/src/project.rs
@@ -20,6 +20,8 @@ struct Crate {
     edition: &'static str,
     // Not used, but required in the JSON file.
     deps: Vec<()>,
+    // Only `test` is used for all crates.
+    // Therefore, an array is used instead of a `Vec`.
     cfg: [&'static str; 1],
 }
 
@@ -31,7 +33,7 @@ impl RustAnalyzerProject {
                 root_module: exercise.path,
                 edition: "2021",
                 deps: Vec::new(),
-                // This allows rust_analyzer to work inside #[test] blocks
+                // This allows rust_analyzer to work inside `#[test]` blocks
                 cfg: ["test"],
             })
             .collect();
@@ -54,7 +56,6 @@ impl RustAnalyzerProject {
         let toolchain =
             String::from_utf8(toolchain).context("The toolchain path is invalid UTF8")?;
         let toolchain = toolchain.trim_end();
-
         println!("Determined toolchain: {toolchain}\n");
 
         let mut sysroot_src = PathBuf::with_capacity(256);

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::env;
 use std::error::Error;
 use std::path::PathBuf;
@@ -9,13 +9,13 @@ use crate::exercise::Exercise;
 
 /// Contains the structure of resulting rust-project.json file
 /// and functions to build the data required to create the file
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 pub struct RustAnalyzerProject {
     sysroot_src: String,
     crates: Vec<Crate>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 pub struct Crate {
     root_module: String,
     edition: String,

--- a/src/project.rs
+++ b/src/project.rs
@@ -31,10 +31,12 @@ impl RustAnalyzerProject {
 
     /// Write rust-project.json to disk
     pub fn write_to_disk(&self) -> Result<(), std::io::Error> {
-        std::fs::write(
-            "./rust-project.json",
-            serde_json::to_vec(&self).expect("Failed to serialize to JSON"),
-        )?;
+        // Using the capacity 2^14 = 16384 since the file length in bytes is higher than 2^13.
+        // The final length is not known exactly because it depends on the user's sysroot path,
+        // the current number of exercises etc.
+        let mut buf = Vec::with_capacity(16384);
+        serde_json::to_writer(&mut buf, &self).expect("Failed to serialize to JSON");
+        std::fs::write("rust-project.json", buf)?;
         Ok(())
     }
 


### PR DESCRIPTION
The public API of `RustAnalyzerProject` was sub-optimal because `new` constructed an invalid state of the type that is then filled by two other public methods to get to a valid state.
All what is needed to be exposed from the module is one function which writes the file.

Instead of walking the `exercises` directory, I just used the exercise paths from the `info.toml` file and removed the `glob` dependency.

I also avoided allocations here and there :P

I added `anyhow` as the start of doing proper error reporting instead of using `unwrap`, `expect` or printing and exiting with `std::process::exit`.