### PR TITLE
docs : add a comma in structs3.rs file 

### DIFF
--- a/exercises/07_structs/structs3.rs
+++ b/exercises/07_structs/structs3.rs
@@ -1,7 +1,7 @@
 // structs3.rs
 //
 // Structs contain data, but can also have logic. In this exercise we have
-// defined the Package struct and we want to test some logic attached to it.
+// defined the Package struct, and we want to test some logic attached to it.
 // Make the code compile and the tests pass!
 //
 // Execute `rustlings hint structs3` or use the `hint` watch subcommand for a

--- a/exercises/07_structs/structs3.rs
+++ b/exercises/07_structs/structs3.rs
@@ -1,7 +1,7 @@
 // structs3.rs
 //
 // Structs contain data, but can also have logic. In this exercise we have
-// defined the Package struct, and we want to test some logic attached to it.
+// defined the Package struct and we want to test some logic attached to it.
 // Make the code compile and the tests pass!
 //
 // Execute `rustlings hint structs3` or use the `hint` watch subcommand for a

--- a/exercises/11_hashmaps/hashmaps1.rs
+++ b/exercises/11_hashmaps/hashmaps1.rs
@@ -3,7 +3,7 @@
 // A basket of fruits in the form of a hash map needs to be defined. The key
 // represents the name of the fruit and the value represents how many of that
 // particular fruit is in the basket. You have to put at least three different
-// types of fruits (e.g apple, banana, mango) in the basket and the total count
+// types of fruits (e.g. apple, banana, mango) in the basket and the total count
 // of all the fruits should be at least five.
 //
 // Make me compile and pass the tests!


### PR DESCRIPTION
when i use rustRover, and there is a grammar error says "Use a comma before 'and' if it connects two independent clauses (unless they are closely connected and short). ".
So add a comma in structs3.rs file will solve this error.