### PR TITLE
Change hints of exercises traits4 and traits5 for a better learning experience

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -816,7 +816,7 @@ path = "exercises/15_traits/traits4.rs"
 mode = "test"
 hint = """
 Instead of using concrete types as parameters you can use traits. Try replacing
-the '??' with 'impl <what goes here?>'
+the '??' with 'impl [what goes here?]'
 
 See the documentation at: https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 """
@@ -827,7 +827,7 @@ path = "exercises/15_traits/traits5.rs"
 mode = "compile"
 hint = """
 To ensure a parameter implements multiple traits use the '+ syntax'. Try
-replacing the '??' with 'impl <> + <>'.
+replacing the '??' with 'impl [what goes here?] + [what goes here?]'.
 
 See the documentation at: https://doc.rust-lang.org/book/ch10-02-traits.html#specifying-multiple-trait-bounds-with-the--syntax
 """


### PR DESCRIPTION
This pull request consist of one commit which changes the format of the hints in the exercises 4 and 5 of traits.

In short, it changes the "<" to "[" like this:

``` toml
hint = """
"Instead of using concrete types as parameters you can use traits. Try replacing 
the '??' with 'impl [what goes here?]

See the documentation at: https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
"""
```

The reasoning for changing "<" is that right before you learn about using generics. So one could think that the solution to the exercises is by using generics.
