### PR TITLE
move_semantics5: change to fix misleading compiler error

### DIFF
--- a/exercises/06_move_semantics/move_semantics5.rs
+++ b/exercises/06_move_semantics/move_semantics5.rs
@@ -18,7 +18,7 @@ fn get_char(data: String) -> char {
 
 // Should take ownership
 fn string_uppercase(mut data: &String) {
-    data = &data.to_uppercase();
+    data = data.to_uppercase();
 
     println!("{data}");
 }


### PR DESCRIPTION
Part of move_semantics5, `string_uppercase` function takes `&String` and intended solution is to change the argument to `String`. However, the compiler error was leading towards a different solution causing confusion. 
```
error[E0716]: temporary value dropped while borrowed
  --> ../exercises/06_move_semantics/move_semantics5.rs:21:13
   |
20 | fn string_uppercase(mut data: &String) {
   |                               - let's call the lifetime of this reference `'1`
21 |     data = &data.to_uppercase();
   |     --------^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
   |     |       |
   |     |       creates a temporary value which is freed while still in use
   |     assignment requires that borrow lasts for `'1`

```
This PR fixes #1963 such that the new compiler error leads to intended solution.
```
error[E0308]: mismatched types
  --> ../exercises/06_move_semantics/move_semantics5.rs:21:12
     |
20 | fn string_uppercase(mut data: &String) {
     |                               ------- expected due to this parameter type
21 |     data = data.to_uppercase();
     |            ^^^^^^^^^^^^^^^^^^^ expected `&String`, found `String`
     |
```