### PR TITLE
fix: un-solve clippy1

### DIFF
--- a/exercises/22_clippy/clippy1.rs
+++ b/exercises/22_clippy/clippy1.rs
@@ -4,11 +4,9 @@
 // For these exercises, the code will fail to compile when there are Clippy
 // warnings. Check Clippy's suggestions from the output to solve the exercise.
 
-use std::f32::consts::PI;
-
 fn main() {
     // Use the more accurate `PI` constant.
-    let pi = PI;
+    let pi = 3.141592;
     let radius: f32 = 5.0;
 
     let area = pi * radius.powi(2);


### PR DESCRIPTION
I was working through these as a refresher with the newest release (thanks!), and noticed that clippy1 is already solved (the diff with the solution is empty, so it feels like this must be a mistake).

This small PR breaks the code in the way I imagine would be intended, where the clippy hint provides the expected solution.