### PR TITLE
fix: Add clarification to instructions for hashmaps2.rs

### DIFF
--- a/exercises/11_hashmaps/hashmaps2.rs
+++ b/exercises/11_hashmaps/hashmaps2.rs
@@ -5,7 +5,8 @@
 // Apple (4), Mango (2) and Lychee (5) are already in the basket hash map. You
 // must add fruit to the basket so that there is at least one of each kind and
 // more than 11 in total - we have a lot of mouths to feed. You are not allowed
-// to insert any more of these fruits!
+// to insert any more of the fruits that are already in the basket (Apple,
+// Mango, and Lyche).
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
In the instructions for hashmaps2.rs, the last sentence of the include the phrase "these fruits", which refers to fruits that were mentioned two sentences prior.

Having a sentence in between the first sentence in which the fruits were described and a later sentence in which the phrase "these fruits" is used makes this confusing to read, since the phrase "these fruits" does not come immediately after the mention of the fruits that the phrase refers to.

This pull request expands the last sentence to explicitly refer to the fruits being mentioned, in order to add clarity about the requirement of the exercise.