### PR TITLE
chore: Update errors5.rs exercise to be consistent with solution

### DIFF
--- a/exercises/13_error_handling/errors5.rs
+++ b/exercises/13_error_handling/errors5.rs
@@ -39,8 +39,8 @@ struct PositiveNonzeroInteger(u64);
 impl PositiveNonzeroInteger {
     fn new(value: i64) -> Result<PositiveNonzeroInteger, CreationError> {
         match value {
-            0 => Err(CreationError::Zero),
             x if x < 0 => Err(CreationError::Negative),
+            0 => Err(CreationError::Zero),
             x => Ok(PositiveNonzeroInteger(x as u64)),
         }
     }


### PR DESCRIPTION
In errors5.rs, there are two lines of a pattern matching block for which the order is reversed between the exercise file and the solution file. Since these lines are not changed as part of the exercise, this commit updates the exercise to make the order of the lines consistent with the solution, so that users will focus only on the lines that change between the exercise and the solution.