### PR TITLE
Updated name of variable name in hint

### DIFF
--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -890,9 +890,9 @@ hint = """
 `capitalize_first`:
 
 The variable `first` is a `char`. It needs to be capitalized and added to the
-remaining characters in `c` in order to return the correct `String`.
+remaining characters in `chars` in order to return the correct `String`.
 
-The remaining characters in `c` can be viewed as a string slice using the
+The remaining characters in `chars` can be viewed as a string slice using the
 `as_str` method.
 
 The documentation for `char` contains many useful methods.


### PR DESCRIPTION
In the exercise `iterators2`, one variable was renamed from `c` to `chars`. In this PR I reflected this change within the hints for this exercise. 

This is the related exercise:
https://github.com/rust-lang/rustlings/blob/c793416495b3e015cbd4fb5ea23070aad8611614/exercises/18_iterators/iterators2.rs#L6-L12