### PR TITLE
doc: enchane string3 exercise hint

### DIFF
--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -498,7 +498,11 @@ some of them:
 https://doc.rust-lang.org/std/string/struct.String.html#method.trim
 
 For the `compose_me` method: You can either use the `format!` macro, or convert
-the string slice into an owned string, which you can then freely extend."""
+the string slice into an owned string, which you can then freely extend.
+
+For the `replace_me` method: You can reference:
+https://doc.rust-lang.org/std/string/struct.String.html#method.replace
+"""
 
 [[exercises]]
 name = "strings4"


### PR DESCRIPTION
enhance string3 exercise' hint

Add a `replace_method` hint; I think it would be more helpful for beginners.

- before
<img width="675" alt="Screenshot 2024-07-17 at 12 27 32 AM" src="https://github.com/user-attachments/assets/67978149-c1be-4cbe-bc51-5693f952d971">


- after
<img width="675" alt="Screenshot 2024-07-17 at 12 28 12 AM" src="https://github.com/user-attachments/assets/62ee79d3-5d25-4834-8e19-e120db764c11">

- string3 exercise
```rust
fn trim_me(input: &str) -> &str {
    // TODO: Remove whitespace from both ends of a string.
}

fn compose_me(input: &str) -> String {
    // TODO: Add " world!" to the string! There are multiple ways to do this.
}

fn replace_me(input: &str) -> String {
    // TODO: Replace "cars" in the string with "balloons".
}
```
