### PR TITLE
chore: Fix snakecase convention in errors6.rs

### DIFF
--- a/exercises/13_error_handling/errors6.rs
+++ b/exercises/13_error_handling/errors6.rs
@@ -25,7 +25,7 @@ impl ParsePosNonzeroError {
     }
 
     // TODO: Add another error conversion function here.
-    // fn from_parseint(???) -> Self { ??? }
+    // fn from_parse_int(???) -> Self { ??? }
 }
 
 #[derive(PartialEq, Debug)]

--- a/solutions/13_error_handling/errors6.rs
+++ b/solutions/13_error_handling/errors6.rs
@@ -24,7 +24,7 @@ impl ParsePosNonzeroError {
         Self::Creation(err)
     }
 
-    fn from_parseint(err: ParseIntError) -> Self {
+    fn from_parse_int(err: ParseIntError) -> Self {
         Self::ParseInt(err)
     }
 }
@@ -44,7 +44,7 @@ impl PositiveNonzeroInteger {
     fn parse(s: &str) -> Result<Self, ParsePosNonzeroError> {
         // Return an appropriate error instead of panicking when `parse()`
         // returns an error.
-        let x: i64 = s.parse().map_err(ParsePosNonzeroError::from_parseint)?;
+        let x: i64 = s.parse().map_err(ParsePosNonzeroError::from_parse_int)?;
         //                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         Self::new(x).map_err(ParsePosNonzeroError::from_creation)
     }


### PR DESCRIPTION
Exercise errors6.rs prompts the user to add a method named `from_parseint`. This commit changes the method name to the corrected snakecase format, `from_parse_int`.