### PR TITLE
Remove dependency on hashbrown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,6 @@ version = "6.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "hashbrown",
  "notify-debouncer-mini",
  "os_pipe",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ include = [
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.13", features = ["derive"] }
-hashbrown = "0.14.5"
 notify-debouncer-mini = { version = "0.4.1", default-features = false }
 os_pipe = "1.2.1"
 ratatui = { version = "0.27.0", default-features = false, features = ["crossterm"] }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Error, Result};
 use std::{
+    collections::HashSet,
     fs::{self, File},
     io::{Read, StdoutLock, Write},
     path::Path,
@@ -69,7 +70,7 @@ impl AppState {
             return StateFileStatus::NotRead;
         }
 
-        let mut done_exercises = hashbrown::HashSet::with_capacity(self.exercises.len());
+        let mut done_exercises = HashSet::with_capacity(self.exercises.len());
 
         for done_exerise_name in lines {
             if done_exerise_name.is_empty() {

--- a/src/dev/check.rs
+++ b/src/dev/check.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, bail, Context, Error, Result};
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     fs::{self, read_dir, OpenOptions},
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -48,9 +49,9 @@ fn check_cargo_toml(
 }
 
 // Check the info of all exercises and return their paths in a set.
-fn check_info_file_exercises(info_file: &InfoFile) -> Result<hashbrown::HashSet<PathBuf>> {
-    let mut names = hashbrown::HashSet::with_capacity(info_file.exercises.len());
-    let mut paths = hashbrown::HashSet::with_capacity(info_file.exercises.len());
+fn check_info_file_exercises(info_file: &InfoFile) -> Result<HashSet<PathBuf>> {
+    let mut names = HashSet::with_capacity(info_file.exercises.len());
+    let mut paths = HashSet::with_capacity(info_file.exercises.len());
 
     let mut file_buf = String::with_capacity(1 << 14);
     for exercise_info in &info_file.exercises {
@@ -111,10 +112,7 @@ fn check_info_file_exercises(info_file: &InfoFile) -> Result<hashbrown::HashSet<
 // Check `dir` for unexpected files.
 // Only Rust files in `allowed_rust_files` and `README.md` files are allowed.
 // Only one level of directory nesting is allowed.
-fn check_unexpected_files(
-    dir: &str,
-    allowed_rust_files: &hashbrown::HashSet<PathBuf>,
-) -> Result<()> {
+fn check_unexpected_files(dir: &str, allowed_rust_files: &HashSet<PathBuf>) -> Result<()> {
     let unexpected_file = |path: &Path| {
         anyhow!("Found the file `{}`. Only `README.md` and Rust files related to an exercise in `info.toml` are allowed in the `{dir}` directory", path.display())
     };
@@ -253,7 +251,7 @@ fn check_solutions(
             })
             .collect::<Vec<_>>();
 
-        let mut sol_paths = hashbrown::HashSet::with_capacity(info_file.exercises.len());
+        let mut sol_paths = HashSet::with_capacity(info_file.exercises.len());
         let mut fmt_cmd = Command::new("rustfmt");
         fmt_cmd
             .arg("--check")


### PR DESCRIPTION
Hashbrown is already the standard implementation of Hash{Map,Set} in the standard library.