### PR TITLE
Replace hashbrown with ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -244,6 +245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -517,9 +529,9 @@ dependencies = [
 name = "rustlings"
 version = "6.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "clap",
- "hashbrown",
  "notify-debouncer-mini",
  "os_pipe",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ include = [
 ]
 
 [dependencies]
+ahash = "0.8.11"
 anyhow = "1.0.86"
 clap = { version = "4.5.13", features = ["derive"] }
-hashbrown = "0.14.5"
 notify-debouncer-mini = { version = "0.4.1", default-features = false }
 os_pipe = "1.2.1"
 ratatui = { version = "0.27.0", default-features = false, features = ["crossterm"] }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,3 +1,4 @@
+use ahash::{HashSet, HashSetExt};
 use anyhow::{bail, Context, Error, Result};
 use std::{
     fs::{self, File},
@@ -69,7 +70,7 @@ impl AppState {
             return StateFileStatus::NotRead;
         }
 
-        let mut done_exercises = hashbrown::HashSet::with_capacity(self.exercises.len());
+        let mut done_exercises = HashSet::with_capacity(self.exercises.len());
 
         for done_exerise_name in lines {
             if done_exerise_name.is_empty() {

--- a/src/dev/check.rs
+++ b/src/dev/check.rs
@@ -1,3 +1,4 @@
+use ahash::{HashSet, HashSetExt};
 use anyhow::{anyhow, bail, Context, Error, Result};
 use std::{
     cmp::Ordering,
@@ -48,9 +49,9 @@ fn check_cargo_toml(
 }
 
 // Check the info of all exercises and return their paths in a set.
-fn check_info_file_exercises(info_file: &InfoFile) -> Result<hashbrown::HashSet<PathBuf>> {
-    let mut names = hashbrown::HashSet::with_capacity(info_file.exercises.len());
-    let mut paths = hashbrown::HashSet::with_capacity(info_file.exercises.len());
+fn check_info_file_exercises(info_file: &InfoFile) -> Result<HashSet<PathBuf>> {
+    let mut names = HashSet::with_capacity(info_file.exercises.len());
+    let mut paths = HashSet::with_capacity(info_file.exercises.len());
 
     let mut file_buf = String::with_capacity(1 << 14);
     for exercise_info in &info_file.exercises {
@@ -111,10 +112,7 @@ fn check_info_file_exercises(info_file: &InfoFile) -> Result<hashbrown::HashSet<
 // Check `dir` for unexpected files.
 // Only Rust files in `allowed_rust_files` and `README.md` files are allowed.
 // Only one level of directory nesting is allowed.
-fn check_unexpected_files(
-    dir: &str,
-    allowed_rust_files: &hashbrown::HashSet<PathBuf>,
-) -> Result<()> {
+fn check_unexpected_files(dir: &str, allowed_rust_files: &HashSet<PathBuf>) -> Result<()> {
     let unexpected_file = |path: &Path| {
         anyhow!("Found the file `{}`. Only `README.md` and Rust files related to an exercise in `info.toml` are allowed in the `{dir}` directory", path.display())
     };
@@ -253,7 +251,7 @@ fn check_solutions(
             })
             .collect::<Vec<_>>();
 
-        let mut sol_paths = hashbrown::HashSet::with_capacity(info_file.exercises.len());
+        let mut sol_paths = HashSet::with_capacity(info_file.exercises.len());
         let mut fmt_cmd = Command::new("rustfmt");
         fmt_cmd
             .arg("--check")


### PR DESCRIPTION
hashbrown is already used in the standard library, but we want the improved performance of the different hash algorithm. Using ahash directly conveys this intent more clearly.