### PR TITLE
Improve initialization in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +354,12 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -514,6 +536,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustlings"
 version = "6.1.0"
 dependencies = [
@@ -526,6 +561,7 @@ dependencies = [
  "rustlings-macros",
  "serde",
  "serde_json",
+ "tempfile",
  "toml_edit",
 ]
 
@@ -695,6 +731,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ serde_json = "1.0.122"
 serde.workspace = true
 toml_edit.workspace = true
 
+[dev-dependencies]
+tempfile = "3.12.0"
+
 [profile.release]
 panic = "abort"
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -155,28 +155,28 @@ fn hint() {
 
 #[test]
 fn init() {
-    let _ = fs::remove_dir_all("tests/rustlings");
+    let test_dir = tempfile::TempDir::new().unwrap();
+    let initialized_dir = test_dir.path().join("rustlings");
+    let test_dir = test_dir.path().to_str().unwrap();
 
-    Cmd::default().current_dir("tests").fail();
+    Cmd::default().current_dir(test_dir).fail();
 
     Cmd::default()
-        .current_dir("tests")
+        .current_dir(test_dir)
         .args(&["init"])
         .success();
 
     // Running `init` after a successful initialization.
     Cmd::default()
-        .current_dir("tests")
+        .current_dir(test_dir)
         .args(&["init"])
         .output(PartialStderr("`cd rustlings`"))
         .fail();
 
     // Running `init` in the initialized directory.
     Cmd::default()
-        .current_dir("tests/rustlings")
+        .current_dir(initialized_dir.to_str().unwrap())
         .args(&["init"])
         .output(PartialStderr("already initialized"))
         .fail();
-
-    fs::remove_dir_all("tests/rustlings").unwrap();
 }


### PR DESCRIPTION
- Detect if we are in a cargo project more reliably. (e.g. if `rustlings init` is run in the `src/` directory)

- Refuse to initialize rustlings in a non-workspace cargo project.

- Automatically populate the `workspace.members` field if `rustlings init` is run in a workspace.

  This may be considered risky, as there is no guarantee that's what the user wanted to do. However, it is consistent with the behavior of `cargo new`. Also, newcomers to Rust are unlikely to accidentally be in a cargo workspace, as they won't know how to create one in the first place.

  The use case for initialization in a workspace is when a workshop organizer wants to use rustlings alongside other exerices and provide a single repository with everything in one place.