### PR TITLE
Add pending UI

### DIFF
--- a/src/watch/state.rs
+++ b/src/watch/state.rs
@@ -27,6 +27,7 @@ pub struct WatchState<'a> {
     show_hint: bool,
     done_status: DoneStatus,
     manual_run: bool,
+    pending: bool,
 }
 
 impl<'a> WatchState<'a> {
@@ -40,6 +41,7 @@ impl<'a> WatchState<'a> {
             show_hint: false,
             done_status: DoneStatus::Pending,
             manual_run,
+            pending: false,
         }
     }
 
@@ -50,6 +52,10 @@ impl<'a> WatchState<'a> {
 
     pub fn run_current_exercise(&mut self) -> Result<()> {
         self.show_hint = false;
+
+        self.pending = true;
+        self.render()?;
+        self.pending = false; // remove pending UI on next render
 
         let success = self
             .app_state
@@ -163,6 +169,13 @@ When you are done experimenting, enter `n` to move on to the next exercise 🦀"
         )?;
 
         self.show_prompt()?;
+
+        // TODO remove the whole pending logic once this is fixed:
+        // https://github.com/rust-lang/rustlings/issues/2071
+        if self.pending {
+            self.writer
+                .write_all(b"\n\nChecking the exercises...\n\nThank you for your patience...\n")?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This is a POC of [this suggestion](https://github.com/rust-lang/rustlings/issues/2071#issuecomment-2274679885). It's a little hacky, but as far as I understand it will be removed again once the issue with rust-analyzer is fixed. I think removing it is a good idea, because rust-analyzer is working fine for me and the pending UI is only shown for a very short amount of time.

Also, I added the pending UI at the very bottom, because if rust-analyzer isn't running at all the UI becomes very janky if any of the other text changes or moves.