### PR TITLE
Fix example in 'primitive_types3' hint

### DIFF
--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -253,7 +253,7 @@ require you to type in 100 items (but you certainly can if you want!).
 
 For example, you can do:
 ```
-let array = ["Are we there yet?"; 10];
+let array = ["Are we there yet?"; 100];
 ```
 
 Bonus: what are some other things you could have that would return `true`


### PR DESCRIPTION
The example provided in the hint for exercise `primitive_types3` does not work

**ACTUAL HINT**
<img width="526" alt="image" src="https://github.com/user-attachments/assets/ee48a2ef-5102-4dba-91e7-1b763e794396">

If you try what the hint suggests, it fails
<img width="576" alt="image" src="https://github.com/user-attachments/assets/2827f383-d4c0-4991-9ba5-553d9f125f22">
<img width="569" alt="image" src="https://github.com/user-attachments/assets/ba88fb1a-9132-4152-824d-0aa55045bf63">

However, if you update the value to be 100, it works (`10` -> `100`)
<img width="544" alt="image" src="https://github.com/user-attachments/assets/e8931510-02ca-4975-b3ce-9d19aa377c05">
<img width="566" alt="image" src="https://github.com/user-attachments/assets/4261a409-0ac2-46f8-917e-b9e5f2c00ad6">


