### PR TITLE
Remove redundant enum definition task

### DIFF
--- a/exercises/08_enums/enums3.rs
+++ b/exercises/08_enums/enums3.rs
@@ -4,7 +4,11 @@ struct Point {
 }
 
 enum Message {
-    // TODO: Implement the message variant types based on their usage below.
+    Resize { width: u64, height: u64 },
+    Move(Point),
+    Echo(String),
+    ChangeColor(u8, u8, u8),
+    Quit,
 }
 
 struct State {


### PR DESCRIPTION
The exercise enums2.rs already contains a task where an identical enum has to be defined.