### PR TITLE
(Solution 1) fix: showing unnecessary `x is never used` warnings

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -207,6 +207,8 @@ panic = "abort"
 unsafe_code = "forbid"
 # You don't need unstable features in Rustlings and shouldn't rely on them while learning Rust
 unstable_features = "forbid"
+# To avoid showing unnecessary `x is never used` warnings
+unused = { level = "allow", priority = -1 }
 
 [lints.clippy]
 # You forgot a `todo!()`


### PR DESCRIPTION
This is the first approach to solve #2104

If accepted the second PR #2106  shall be dropped as is solves the same issue in a different way..