### PR TITLE
Do not use `.as_bytes().len()` on strings

### DIFF
--- a/exercises/23_conversions/as_ref_mut.rs
+++ b/exercises/23_conversions/as_ref_mut.rs
@@ -2,10 +2,11 @@
 // about them at https://doc.rust-lang.org/std/convert/trait.AsRef.html and
 // https://doc.rust-lang.org/std/convert/trait.AsMut.html, respectively.
 
-// Obtain the number of bytes (not characters) in the given argument.
+// Obtain the number of bytes (not characters) in the given argument
+// (`.len()` returns the number of bytes in a string).
 // TODO: Add the `AsRef` trait appropriately as a trait bound.
 fn byte_counter<T>(arg: T) -> usize {
-    arg.as_ref().as_bytes().len()
+    arg.as_ref().len()
 }
 
 // Obtain the number of characters (not bytes) in the given argument.

--- a/solutions/23_conversions/as_ref_mut.rs
+++ b/solutions/23_conversions/as_ref_mut.rs
@@ -2,9 +2,10 @@
 // about them at https://doc.rust-lang.org/std/convert/trait.AsRef.html and
 // https://doc.rust-lang.org/std/convert/trait.AsMut.html, respectively.
 
-// Obtain the number of bytes (not characters) in the given argument.
+// Obtain the number of bytes (not characters) in the given argument
+// (`.len()` returns the number of bytes in a string).
 fn byte_counter<T: AsRef<str>>(arg: T) -> usize {
-    arg.as_ref().as_bytes().len()
+    arg.as_ref().len()
 }
 
 // Obtain the number of characters (not bytes) in the given argument.


### PR DESCRIPTION
`.len()` already returns the length in bytes when used on a `String` or a `str`. As this might be counter-intuitive for beginners, I've also added an extra comment. This has the benefit of preparing them to a proper use of `.len()` on a string.