### PR TITLE
Add Third-Party List about rustlings-jp on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Do you want to create your own set of Rustlings exercises to focus on some speci
 Or do you want to translate the original Rustlings exercises?
 Then follow the link to the guide about [third-party exercises](https://github.com/rust-lang/rustlings/blob/main/THIRD_PARTY_EXERCISES.md)!
 
+### Third-Party List
+
+- [日本語版 Rustlings](https://github.com/sotanengel/rustlings-jp)：A Japanese translation of the Rustlings exercise.
+
 ## Uninstalling Rustlings
 
 If you want to remove Rustlings from your system, run the following command:


### PR DESCRIPTION
I have created a third-party repository of Rustlings exercise  and answers translated into Japanese([LINK](https://github.com/sotanengel/rustlings-jp/tree/main)).
The translated Rustlings is the 6.3.0 (2024-08-29) version.

Could you add a link to my translated repository in the Rustlings README?

<img width="400" alt="image" src="https://github.com/user-attachments/assets/cc10e874-2221-4e75-9105-f917f4c53ef6">
