### PR TITLE
Improvement to "check all exercises"

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -13,4 +13,6 @@ disallowed-methods = [
   # Use `thread::Builder::spawn` instead and handle the error.
   "std::thread::spawn",
   "std::thread::Scope::spawn",
+  # Return `ExitCode` instead.
+  "std::process::exit",
 ]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -417,8 +417,6 @@ impl AppState {
         clear_terminal(stdout)?;
 
         let mut progresses = vec![ExerciseCheckProgress::None; self.exercises.len()];
-        let mut done = 0;
-        let mut pending = 0;
 
         thread::scope(|s| {
             let (exercise_progress_sender, exercise_progress_receiver) = mpsc::channel();
@@ -468,13 +466,6 @@ impl AppState {
 
             while let Ok((exercise_ind, progress)) = exercise_progress_receiver.recv() {
                 progresses[exercise_ind] = progress;
-
-                match progress {
-                    ExerciseCheckProgress::None | ExerciseCheckProgress::Checking => (),
-                    ExerciseCheckProgress::Done => done += 1,
-                    ExerciseCheckProgress::Pending => pending += 1,
-                }
-
                 show_exercises_check_progress(stdout, &progresses, term_width)?;
             }
 
@@ -503,10 +494,8 @@ impl AppState {
                     let exercise = &self.exercises[exercise_ind];
                     let success = exercise.run_exercise(None, &self.cmd_runner)?;
                     if success {
-                        done += 1;
                         progresses[exercise_ind] = ExerciseCheckProgress::Done;
                     } else {
-                        pending += 1;
                         if first_pending_exercise_ind.is_none() {
                             first_pending_exercise_ind = Some(exercise_ind);
                         }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -520,7 +520,6 @@ impl AppState {
         }
 
         self.write()?;
-        stdout.write_all(b"\n")?;
 
         Ok(first_pending_exercise_ind)
     }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -435,7 +435,6 @@ impl AppState {
                             break;
                         };
 
-                        // Notify the progress bar that this exercise is pending.
                         if exercise_progress_sender
                             .send((exercise_ind, ExerciseCheckProgress::Checking))
                             .is_err()
@@ -450,7 +449,6 @@ impl AppState {
                             Err(_) => ExerciseCheckProgress::None,
                         };
 
-                        // Notify the progress bar that this exercise is done.
                         if exercise_progress_sender
                             .send((exercise_ind, progress))
                             .is_err()

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -212,6 +212,11 @@ impl AppState {
     }
 
     #[inline]
+    pub fn n_pending(&self) -> u16 {
+        self.exercises.len() as u16 - self.n_done
+    }
+
+    #[inline]
     pub fn current_exercise(&self) -> &Exercise {
         &self.exercises[self.current_exercise_ind]
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 use anyhow::{bail, Context, Result};
 use app_state::StateFileStatus;
 use clap::{Parser, Subcommand};
-use crossterm::{
-    style::{Color, Print, ResetColor, SetForegroundColor},
-    QueueableCommand,
-};
 use std::{
     io::{self, IsTerminal, Write},
     path::Path,
@@ -157,12 +153,13 @@ fn main() -> Result<ExitCode> {
 
                 let pending = app_state.n_pending();
                 if pending == 1 {
-                    stdout.queue(Print("One exercise pending: "))?;
+                    stdout.write_all(b"One exercise pending: ")?;
                 } else {
-                    stdout.queue(SetForegroundColor(Color::Red))?;
-                    write!(stdout, "{pending}")?;
-                    stdout.queue(ResetColor)?;
-                    stdout.queue(Print(" exercises are pending. The first: "))?;
+                    write!(
+                        stdout,
+                        "{pending}/{} exercises are pending. The first: ",
+                        app_state.exercises().len(),
+                    )?;
                 }
                 app_state
                     .current_exercise()

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,13 +151,15 @@ fn main() -> Result<ExitCode> {
                     app_state.set_current_exercise_ind(first_pending_exercise_ind)?;
                 }
 
+                stdout.write_all(b"\n\n")?;
+
                 let pending = app_state.n_pending();
                 if pending == 1 {
                     stdout.write_all(b"One exercise pending: ")?;
                 } else {
                     write!(
                         stdout,
-                        "{pending}/{} exercises are pending. The first: ",
+                        "{pending}/{} exercises pending. The first: ",
                         app_state.exercises().len(),
                     )?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
         }
         Some(Subcommands::RunAll) => {
             let mut stdout = io::stdout().lock();
-            if let Some(first_fail) = app_state.check_all_exercises(&mut stdout, false)? {
+            if let Some(first_fail) = app_state.check_all_exercises(&mut stdout)? {
                 let pending = app_state
                     .exercises()
                     .iter()
@@ -156,7 +156,6 @@ fn main() -> Result<()> {
                     app_state.set_current_exercise_ind(first_fail)?;
                 }
                 stdout
-                    .queue(Print("\n"))?
                     .queue(SetForegroundColor(Color::Red))?
                     .queue(Print(format!("{pending}")))?
                     .queue(ResetColor)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,6 @@ fn main() -> Result<ExitCode> {
                 }
 
                 stdout.write_all(b"\n\n")?;
-
                 let pending = app_state.n_pending();
                 if pending == 1 {
                     stdout.write_all(b"One exercise pending: ")?;
@@ -167,6 +166,7 @@ fn main() -> Result<ExitCode> {
                     .current_exercise()
                     .terminal_file_link(&mut stdout)?;
                 stdout.write_all(b"\n")?;
+
                 return Ok(ExitCode::FAILURE);
             } else {
                 app_state.render_final_message(&mut stdout)?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -29,6 +29,7 @@ pub fn run(app_state: &mut AppState) -> Result<ExitCode> {
             .current_exercise()
             .terminal_file_link(&mut stdout)?;
         stdout.write_all(b" with errors\n")?;
+
         return Ok(ExitCode::FAILURE);
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,7 +5,7 @@ use crossterm::{
 };
 use std::{
     io::{self, Write},
-    process::exit,
+    process::ExitCode,
 };
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
     exercise::{solution_link_line, RunnableExercise, OUTPUT_CAPACITY},
 };
 
-pub fn run(app_state: &mut AppState) -> Result<()> {
+pub fn run(app_state: &mut AppState) -> Result<ExitCode> {
     let exercise = app_state.current_exercise();
     let mut output = Vec::with_capacity(OUTPUT_CAPACITY);
     let success = exercise.run_exercise(Some(&mut output), app_state.cmd_runner())?;
@@ -29,7 +29,7 @@ pub fn run(app_state: &mut AppState) -> Result<()> {
             .current_exercise()
             .terminal_file_link(&mut stdout)?;
         stdout.write_all(b" with errors\n")?;
-        exit(1);
+        return Ok(ExitCode::FAILURE);
     }
 
     stdout.queue(SetForegroundColor(Color::Green))?;
@@ -55,5 +55,5 @@ pub fn run(app_state: &mut AppState) -> Result<()> {
         ExercisesProgress::AllDone => (),
     }
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -89,34 +89,35 @@ impl<'a> CountedWrite<'a> for StdoutLock<'a> {
     }
 }
 
-/// Simple terminal progress bar
+/// Simple terminal progress bar.
 pub fn progress_bar<'a>(
     writer: &mut impl CountedWrite<'a>,
     progress: u16,
     total: u16,
-    line_width: u16,
+    term_width: u16,
 ) -> io::Result<()> {
-    progress_bar_with_success(writer, 0, 0, progress, total, line_width)
+    progress_bar_with_success(writer, 0, 0, progress, total, term_width)
 }
-/// Terminal progress bar with three states (pending + failed + success)
+
+/// Terminal progress bar with three states (pending + failed + success).
 pub fn progress_bar_with_success<'a>(
     writer: &mut impl CountedWrite<'a>,
     pending: u16,
     failed: u16,
     success: u16,
     total: u16,
-    line_width: u16,
+    term_width: u16,
 ) -> io::Result<()> {
     debug_assert!(total < 1000);
-    debug_assert!((pending + failed + success) <= total);
+    debug_assert!(pending + failed + success <= total);
 
     const PREFIX: &[u8] = b"Progress: [";
     const PREFIX_WIDTH: u16 = PREFIX.len() as u16;
     const POSTFIX_WIDTH: u16 = "] xxx/xxx".len() as u16;
     const WRAPPER_WIDTH: u16 = PREFIX_WIDTH + POSTFIX_WIDTH;
-    const MIN_LINE_WIDTH: u16 = WRAPPER_WIDTH + 4;
+    const MIN_TERM_WIDTH: u16 = WRAPPER_WIDTH + 4;
 
-    if line_width < MIN_LINE_WIDTH {
+    if term_width < MIN_TERM_WIDTH {
         writer.write_ascii(b"Progress: ")?;
         // Integers are in ASCII.
         return writer.write_ascii(format!("{}/{total}", failed + success).as_bytes());
@@ -125,7 +126,7 @@ pub fn progress_bar_with_success<'a>(
     let stdout = writer.stdout();
     stdout.write_all(PREFIX)?;
 
-    let width = line_width - WRAPPER_WIDTH;
+    let width = term_width - WRAPPER_WIDTH;
     let mut failed_end = (width * failed) / total;
     let mut success_end = (width * (failed + success)) / total;
     let mut pending_end = (width * (failed + success + pending)) / total;

--- a/src/term.rs
+++ b/src/term.rs
@@ -164,26 +164,34 @@ pub fn show_exercises_check_progress(
 
     let mut exercise_num = 1;
     for exercise_progress in progresses {
-        let color = match exercise_progress {
-            ExerciseCheckProgress::None => Color::Reset,
-            ExerciseCheckProgress::Checking => Color::Blue,
-            ExerciseCheckProgress::Done => Color::Green,
-            ExerciseCheckProgress::Pending => Color::Red,
-        };
-
-        stdout.queue(SetForegroundColor(color))?;
-        write!(stdout, "{exercise_num:<3}")?;
-
-        if exercise_num % n_cols == 0 {
-            stdout.write_all(b"\n")?;
-        } else {
-            stdout.write_all(b" ")?;
+        match exercise_progress {
+            ExerciseCheckProgress::None => (),
+            ExerciseCheckProgress::Checking => {
+                stdout.queue(SetForegroundColor(Color::Blue))?;
+            }
+            ExerciseCheckProgress::Done => {
+                stdout.queue(SetForegroundColor(Color::Green))?;
+            }
+            ExerciseCheckProgress::Pending => {
+                stdout.queue(SetForegroundColor(Color::Red))?;
+            }
         }
 
-        exercise_num += 1;
+        write!(stdout, "{exercise_num:<3}")?;
+        stdout.queue(ResetColor)?;
+
+        if exercise_num != progresses.len() {
+            if exercise_num % n_cols == 0 {
+                stdout.write_all(b"\n")?;
+            } else {
+                stdout.write_all(b" ")?;
+            }
+
+            exercise_num += 1;
+        }
     }
 
-    stdout.queue(ResetColor)?.flush()
+    stdout.flush()
 }
 
 pub fn clear_terminal(stdout: &mut StdoutLock) -> io::Result<()> {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -103,6 +103,13 @@ fn run_watch(
             WatchEvent::Input(InputEvent::Run) => watch_state.run_current_exercise(&mut stdout)?,
             WatchEvent::Input(InputEvent::Hint) => watch_state.show_hint(&mut stdout)?,
             WatchEvent::Input(InputEvent::List) => return Ok(WatchExit::List),
+            WatchEvent::Input(InputEvent::CheckAll) => match watch_state
+                .check_all_exercises(&mut stdout)?
+            {
+                ExercisesProgress::AllDone => break,
+                ExercisesProgress::NewPending => watch_state.run_current_exercise(&mut stdout)?,
+                ExercisesProgress::CurrentPending => (),
+            },
             WatchEvent::Input(InputEvent::Reset) => watch_state.reset_exercise(&mut stdout)?,
             WatchEvent::Input(InputEvent::Quit) => {
                 stdout.write_all(QUIT_MSG)?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -108,7 +108,7 @@ fn run_watch(
             {
                 ExercisesProgress::AllDone => break,
                 ExercisesProgress::NewPending => watch_state.run_current_exercise(&mut stdout)?,
-                ExercisesProgress::CurrentPending => (),
+                ExercisesProgress::CurrentPending => watch_state.render(&mut stdout)?,
             },
             WatchEvent::Input(InputEvent::Reset) => watch_state.reset_exercise(&mut stdout)?,
             WatchEvent::Input(InputEvent::Quit) => {

--- a/src/watch/state.rs
+++ b/src/watch/state.rs
@@ -281,8 +281,6 @@ impl<'a> WatchState<'a> {
     }
 
     pub fn check_all_exercises(&mut self, stdout: &mut StdoutLock) -> Result<ExercisesProgress> {
-        stdout.write_all(b"\n")?;
-
         if let Some(first_pending_exercise_ind) = self.app_state.check_all_exercises(stdout)? {
             // Only change exercise if the current one is done.
             if self.app_state.current_exercise().done {

--- a/src/watch/terminal_event.rs
+++ b/src/watch/terminal_event.rs
@@ -11,6 +11,7 @@ pub enum InputEvent {
     Run,
     Hint,
     List,
+    CheckAll,
     Reset,
     Quit,
 }
@@ -37,6 +38,7 @@ pub fn terminal_event_handler(
                     KeyCode::Char('r') if manual_run => InputEvent::Run,
                     KeyCode::Char('h') => InputEvent::Hint,
                     KeyCode::Char('l') => break WatchEvent::Input(InputEvent::List),
+                    KeyCode::Char('c') => InputEvent::CheckAll,
                     KeyCode::Char('x') => {
                         if sender.send(WatchEvent::Input(InputEvent::Reset)).is_err() {
                             return;


### PR DESCRIPTION
* Update the state of all the exercises instead of stopping with the first failure (especially given the old code was running all of them anyway, it was just ignoring the result of the later exercises). This allows the user to see all the exercises that needs to be redone instead of having to "fix/see one, run check_all, fix/see another, run check_all, ..."
* Fixed the progress display frozen for a long time if/when the first threads were run after later ones
* Limit the number of threads to the number of CPU cores (avoids spawning 94 cargo instances at the same time, possibly more in the future or in custom exercise sets)
* Show a progress bar instead of an unappealing "Progress: xxx/yyy".
* Add a command to run check all the exercises immediately (useful if they are solved without running `rustlings` in between)