### PR TITLE
fix: typo in `exercises/23_conversions/from_str.rs` 

### DIFF
--- a/exercises/23_conversions/from_str.rs
+++ b/exercises/23_conversions/from_str.rs
@@ -25,7 +25,7 @@ enum ParsePersonError {
     ParseInt(ParseIntError),
 }
 
-// TODO: Complete this `From` implementation to be able to parse a `Person`
+// TODO: Complete this `FromStr` implementation to be able to parse a `Person`
 // out of a string in the form of "Mark,20".
 // Note that you'll need to parse the age component into a `u8` with something
 // like `"4".parse::<u8>()`.


### PR DESCRIPTION
Changed the typo "`From`" to "`FromStr"`

The implementation name is `FromStr`, not `From`.

Additionally someone opened an issue about this here: https://github.com/rust-lang/rustlings/issues/2123