### PR TITLE
Add warning about `rust-analyzer` not working if you clone and use the repo directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ rustlings
 Our general recommendation is [VS Code](https://code.visualstudio.com/) with the [rust-analyzer plugin](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
 But any editor that supports [rust-analyzer](https://rust-analyzer.github.io/) should be enough for working on the exercises.
 
+<details>
+<summary><strong>If you cloned the repository and <code>rust-analyzer</code> isn't working…</strong> (<em>click to expand</em>)</summary>
+
+The intended way to run Rustlings is to install the binary and run `rustlings init` as described above. This generates a `Cargo.toml` (different than what you see in the repository) that includes the each excersise as a separate binary target which is enough for `rust-analyzer` to work.
+
+If you just clone the repository and try to run and edit the exercises directly, the language server will not work. This is one downside of the current approach. But this only affects developing exercises.
+
+</details>
+
 ### Terminal
 
 While working with Rustlings, please use a modern terminal for the best user experience.


### PR DESCRIPTION
Add warning about `rust-analyzer` not working if you clone and use the repo directly.

> Yes, you are right, if you just clone the repository and try to edit the exercises, the language server will not work. This is one downside of the current approach. But this only affects developing exercises.
>
> The new method of doing Rustlings is to install Rustlings using `cargo install rustlings` (not published yet), then running `rustlings init`. No repo cloning happens. Instead, the directory `rustlings/` will be created where you find the exercises. The language server works there out of the box :)
>
> I need to add a warning when people try to work on the exercises from the repository. Thanks pointing this out.
>
> -- @mo8it, https://github.com/rust-lang/rustlings/issues/1935#issuecomment-2067664066


### Reproduction steps

Personally, I also fell into this trap since I prefer to just run the thing from source than install something on my system.

 1. Clone the repo: `git clone git@github.com:rust-lang/rustlings.git`
 1. Start Rustlings: `cargo run` 
 1. Open VSCode and notice that `rust-analyzer` and lsp hints don't pop up
 1. Google and find [StackOverflow answers](https://stackoverflow.com/questions/75272113/rust-analyzer-in-vscode-does-not-work-in-rustlings-workspace) that mention `rustlings lsp` to setup lsp support
 1. But `rustlings lsp` doesn't exist anymore and the [changelog mentions that it should be supported out of the box](https://github.com/rust-lang/rustlings/blob/0432e07864d5ee4d2bac1954c965b2077c0447c6/CHANGELOG.md#lsp-support-out-of-the-box). It's also confusing because the `rustlings` repo has it's own `Cargo.toml` with `include = [... "/exercises/", ...]` which to my newbie Rust eyes, seems like it might cover it and makes me think, this is supposed to work.
 1. Eventually, I saw https://github.com/rust-lang/rustlings/issues/1935 linked somewhere and it mentions this exact problem


### Dev notes

 - Previous `rustlings lsp` command: https://github.com/rust-lang/rustlings/pull/1026
 - The changelog says "LSP support out of the box", https://github.com/rust-lang/rustlings/blob/main/CHANGELOG.md#lsp-support-out-of-the-box