### PR TITLE
grammatical fix on move_semantics2.rs

### DIFF
--- a/exercises/06_move_semantics/move_semantics2.rs
+++ b/exercises/06_move_semantics/move_semantics2.rs
@@ -14,7 +14,7 @@ fn main() {
 mod tests {
     use super::*;
 
-    // TODO: Make both vectors `vec0` and `vec1` accessible at the same time to
+    // TODO: Make both vectors `vec0` and `vec1` are accessible at the same time to
     // fix the compiler error in the test.
     #[test]
     fn move_semantics2() {


### PR DESCRIPTION
// TODO: Make both vectors `vec0` and `vec1` accessible at the same time to
changed to 
// TODO: Make both vectors `vec0` and `vec1` are accessible at the same time to