### PR TITLE
fix for a couple of small issues I came accross whilst doing the exercises

### DIFF
--- a/exercises/11_hashmaps/hashmaps2.rs
+++ b/exercises/11_hashmaps/hashmaps2.rs
@@ -46,7 +46,7 @@ mod tests {
     // Don't modify this function!
     fn get_fruit_basket() -> HashMap<Fruit, u32> {
         let content = [(Fruit::Apple, 4), (Fruit::Mango, 2), (Fruit::Lychee, 5)];
-        HashMap::from_iter(content)
+        HashMap::from(content)
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod tests {
 
         for fruit_kind in fruit_kinds {
             let Some(amount) = basket.get(&fruit_kind) else {
-                panic!("Fruit kind {fruit_kind:?} was not found in basket");
+                panic!("Fruit kind {:?} was not found in basket", fruit_kind);
             };
             assert!(*amount > 0);
         }

--- a/solutions/11_hashmaps/hashmaps2.rs
+++ b/solutions/11_hashmaps/hashmaps2.rs
@@ -45,7 +45,7 @@ mod tests {
     // Don't modify this function!
     fn get_fruit_basket() -> HashMap<Fruit, u32> {
         let content = [(Fruit::Apple, 4), (Fruit::Mango, 2), (Fruit::Lychee, 5)];
-        HashMap::from_iter(content)
+        HashMap::from(content)
     }
 
     #[test]
@@ -88,7 +88,7 @@ mod tests {
 
         for fruit_kind in fruit_kinds {
             let Some(amount) = basket.get(&fruit_kind) else {
-                panic!("Fruit kind {fruit_kind:?} was not found in basket");
+                panic!("Fruit kind {:?} was not found in basket", fruit_kind);
             };
             assert!(*amount > 0);
         }


### PR DESCRIPTION
Issue 1:
The error you're encountering is due to the use of HashMap::from_iter, which is not a method directly associated with HashMap. Instead, from_iter is a method provided by the FromIterator trait. To fix this issue, you have two main options:

Option 1: Import the FromIterator trait

You can import the FromIterator trait into your scope, which will allow you to use HashMap::from_iter. Add the following line at the top of your file:

Option 2: Use HashMap::from Instead

A more idiomatic way is to use HashMap::from, which can directly convert an array of key-value pairs into a HashMap. Replace HashMap::from_iter(content) with HashMap::from(content).

Explanation:

Using HashMap::from: This function is designed to create a HashMap from an array of key-value pairs, which is exactly what content is.
Using FromIterator Trait: If you prefer to use from_iter, importing the FromIterator trait brings the method into scope.
Recommendation:

I recommend using Option 2 (HashMap::from) because it's more straightforward and doesn't require importing additional traits. It's also more idiomatic for converting arrays into collections in Rust.

Issue 2:

println! Supports Named Arguments (Rust 1.58+):

If you use println! with named arguments like {name:?}, it works as expected if you provide the arguments or capture them from scope.
panic! Does Not Support Named Arguments:

Always use positional arguments with panic!. Named arguments (e.g., name = value) will cause warnings or runtime issues.
Warnings About Placeholders in panic!:

If the format string in panic! has placeholders but no arguments are provided, the placeholder is treated as a literal. This behavior produces a warning in Rust 2021.
