### PR TITLE
Fix rust-book links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Greetings and welcome to Rustlings.
 This project contains small exercises to get you used to reading and writing Rust code.
 This includes reading and responding to compiler messages!
 
-It is recommended to do the Rustlings exercises in parallel to reading [the official Rust book](https://doc.rust-lang.org/book/), the most comprehensive resource for learning Rust 📚️
+It is recommended to do the Rustlings exercises in parallel to reading [the official Rust book](https://doc.rust-lang.org/stable/book/), the most comprehensive resource for learning Rust 📚️
 
 [Rust By Example](https://doc.rust-lang.org/rust-by-example/) is another recommended resource that you might find helpful.
 It contains code examples and exercises similar to Rustlings, but online.

--- a/exercises/01_variables/README.md
+++ b/exercises/01_variables/README.md
@@ -6,4 +6,4 @@ You can make them mutable by adding `mut` in front of the variable name.
 
 ## Further information
 
-- [Variables and Mutability](https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html)
+- [Variables and Mutability](https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html)

--- a/exercises/02_functions/README.md
+++ b/exercises/02_functions/README.md
@@ -5,4 +5,4 @@ in more complex code.
 
 ## Further information
 
-- [How Functions Work](https://doc.rust-lang.org/book/ch03-03-how-functions-work.html)
+- [How Functions Work](https://doc.rust-lang.org/stable/book/ch03-03-how-functions-work.html)

--- a/exercises/03_if/README.md
+++ b/exercises/03_if/README.md
@@ -4,4 +4,4 @@
 
 ## Further information
 
-- [Control Flow - if expressions](https://doc.rust-lang.org/book/ch03-05-control-flow.html#if-expressions)
+- [Control Flow - if expressions](https://doc.rust-lang.org/stable/book/ch03-05-control-flow.html#if-expressions)

--- a/exercises/04_primitive_types/README.md
+++ b/exercises/04_primitive_types/README.md
@@ -5,5 +5,5 @@ compiler. In this section, we'll go through the most important ones.
 
 ## Further information
 
-- [Data Types](https://doc.rust-lang.org/book/ch03-02-data-types.html)
-- [The Slice Type](https://doc.rust-lang.org/book/ch04-03-slices.html)
+- [Data Types](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html)
+- [The Slice Type](https://doc.rust-lang.org/stable/book/ch04-03-slices.html)

--- a/exercises/05_vecs/README.md
+++ b/exercises/05_vecs/README.md
@@ -12,6 +12,6 @@ the other useful data structure, hash maps, later.
 
 ## Further information
 
-- [Storing Lists of Values with Vectors](https://doc.rust-lang.org/book/ch08-01-vectors.html)
+- [Storing Lists of Values with Vectors](https://doc.rust-lang.org/stable/book/ch08-01-vectors.html)
 - [`iter_mut`](https://doc.rust-lang.org/std/primitive.slice.html#method.iter_mut)
 - [`map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map)

--- a/exercises/06_move_semantics/README.md
+++ b/exercises/06_move_semantics/README.md
@@ -6,5 +6,5 @@ These exercises are adapted from [pnkfelix](https://github.com/pnkfelix)'s [Rust
 
 For this section, the book links are especially important.
 
-- [Ownership](https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html)
-- [Reference and borrowing](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html)
+- [Ownership](https://doc.rust-lang.org/stable/book/ch04-01-what-is-ownership.html)
+- [Reference and borrowing](https://doc.rust-lang.org/stable/book/ch04-02-references-and-borrowing.html)

--- a/exercises/07_structs/README.md
+++ b/exercises/07_structs/README.md
@@ -4,5 +4,5 @@ Rust has three struct types: a classic C struct, a tuple struct, and a unit stru
 
 ## Further information
 
-- [Structures](https://doc.rust-lang.org/book/ch05-01-defining-structs.html)
-- [Method Syntax](https://doc.rust-lang.org/book/ch05-03-method-syntax.html)
+- [Structures](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html)
+- [Method Syntax](https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html)

--- a/exercises/08_enums/README.md
+++ b/exercises/08_enums/README.md
@@ -6,5 +6,5 @@ Useful in combination with enums is Rust's "pattern matching" facility, which ma
 
 ## Further information
 
-- [Enums](https://doc.rust-lang.org/book/ch06-00-enums.html)
-- [Pattern syntax](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html)
+- [Enums](https://doc.rust-lang.org/stable/book/ch06-00-enums.html)
+- [Pattern syntax](https://doc.rust-lang.org/stable/book/ch18-03-pattern-syntax.html)

--- a/exercises/09_strings/README.md
+++ b/exercises/09_strings/README.md
@@ -6,4 +6,4 @@ to identify and create them, as well as use them.
 
 ## Further information
 
-- [Strings](https://doc.rust-lang.org/book/ch08-02-strings.html)
+- [Strings](https://doc.rust-lang.org/stable/book/ch08-02-strings.html)

--- a/exercises/10_modules/README.md
+++ b/exercises/10_modules/README.md
@@ -4,4 +4,4 @@ In this section we'll give you an introduction to Rust's module system.
 
 ## Further information
 
-- [The Module System](https://doc.rust-lang.org/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)
+- [The Module System](https://doc.rust-lang.org/stable/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)

--- a/exercises/11_hashmaps/README.md
+++ b/exercises/11_hashmaps/README.md
@@ -9,4 +9,4 @@ talking about Vecs.
 
 ## Further information
 
-- [Storing Keys with Associated Values in Hash Maps](https://doc.rust-lang.org/book/ch08-03-hash-maps.html)
+- [Storing Keys with Associated Values in Hash Maps](https://doc.rust-lang.org/stable/book/ch08-03-hash-maps.html)

--- a/exercises/12_options/README.md
+++ b/exercises/12_options/README.md
@@ -14,7 +14,7 @@ Option types are very common in Rust code, as they have a number of uses:
 
 ## Further Information
 
-- [Option Enum Format](https://doc.rust-lang.org/book/ch10-01-syntax.html#in-enum-definitions)
+- [Option Enum Format](https://doc.rust-lang.org/stable/book/ch10-01-syntax.html#in-enum-definitions)
 - [Option Module Documentation](https://doc.rust-lang.org/std/option/)
 - [Option Enum Documentation](https://doc.rust-lang.org/std/option/enum.Option.html)
 - [if let](https://doc.rust-lang.org/rust-by-example/flow_control/if_let.html)

--- a/exercises/13_error_handling/README.md
+++ b/exercises/13_error_handling/README.md
@@ -6,7 +6,7 @@ For example, if you try to open a file and that operation fails because the file
 
 ## Further information
 
-- [Error Handling](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html)
-- [Generics](https://doc.rust-lang.org/book/ch10-01-syntax.html)
+- [Error Handling](https://doc.rust-lang.org/stable/book/ch09-02-recoverable-errors-with-result.html)
+- [Generics](https://doc.rust-lang.org/stable/book/ch10-01-syntax.html)
 - [Result](https://doc.rust-lang.org/rust-by-example/error/result.html)
 - [Boxing errors](https://doc.rust-lang.org/rust-by-example/error/multiple_error_types/boxing_errors.html)

--- a/exercises/14_generics/README.md
+++ b/exercises/14_generics/README.md
@@ -7,5 +7,5 @@ The simplest and most common use of generics is for type parameters.
 
 ## Further information
 
-- [Generic Data Types](https://doc.rust-lang.org/book/ch10-01-syntax.html)
+- [Generic Data Types](https://doc.rust-lang.org/stable/book/ch10-01-syntax.html)
 - [Bounds](https://doc.rust-lang.org/rust-by-example/generics/bounds.html)

--- a/exercises/15_traits/README.md
+++ b/exercises/15_traits/README.md
@@ -16,4 +16,4 @@ Because traits indicate shared behavior between data types, they are useful when
 
 ## Further information
 
-- [Traits](https://doc.rust-lang.org/book/ch10-02-traits.html)
+- [Traits](https://doc.rust-lang.org/stable/book/ch10-02-traits.html)

--- a/exercises/16_lifetimes/README.md
+++ b/exercises/16_lifetimes/README.md
@@ -19,4 +19,4 @@ learning to write lifetime annotations.
 ## Further information
 
 - [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/stable/rust-by-example/scope/lifetime.html)
-- [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
+- [Validating References with Lifetimes](https://doc.rust-lang.org/stable/book/ch10-03-lifetime-syntax.html)

--- a/exercises/17_tests/README.md
+++ b/exercises/17_tests/README.md
@@ -4,4 +4,4 @@ Going out of order from the book to cover tests -- many of the following exercis
 
 ## Further information
 
-- [Writing Tests](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
+- [Writing Tests](https://doc.rust-lang.org/stable/book/ch11-01-writing-tests.html)

--- a/exercises/18_iterators/README.md
+++ b/exercises/18_iterators/README.md
@@ -4,5 +4,5 @@ This section will teach you about Iterators.
 
 ## Further information
 
-- [Iterator](https://doc.rust-lang.org/book/ch13-02-iterators.html)
+- [Iterator](https://doc.rust-lang.org/stable/book/ch13-02-iterators.html)
 - [Iterator documentation](https://doc.rust-lang.org/stable/std/iter/)

--- a/exercises/19_smart_pointers/README.md
+++ b/exercises/19_smart_pointers/README.md
@@ -5,8 +5,8 @@ Smart pointers in Rust often own the data they point to, while references only b
 
 ## Further Information
 
-- [Smart Pointers](https://doc.rust-lang.org/book/ch15-00-smart-pointers.html)
-- [Using Box to Point to Data on the Heap](https://doc.rust-lang.org/book/ch15-01-box.html)
-- [Rc\<T\>, the Reference Counted Smart Pointer](https://doc.rust-lang.org/book/ch15-04-rc.html)
-- [Shared-State Concurrency](https://doc.rust-lang.org/book/ch16-03-shared-state.html)
+- [Smart Pointers](https://doc.rust-lang.org/stable/book/ch15-00-smart-pointers.html)
+- [Using Box to Point to Data on the Heap](https://doc.rust-lang.org/stable/book/ch15-01-box.html)
+- [Rc\<T\>, the Reference Counted Smart Pointer](https://doc.rust-lang.org/stable/book/ch15-04-rc.html)
+- [Shared-State Concurrency](https://doc.rust-lang.org/stable/book/ch16-03-shared-state.html)
 - [Cow Documentation](https://doc.rust-lang.org/std/borrow/enum.Cow.html)

--- a/exercises/20_threads/README.md
+++ b/exercises/20_threads/README.md
@@ -6,5 +6,5 @@ Within your program, you can also have independent parts that run simultaneously
 ## Further information
 
 - [Dining Philosophers example](https://doc.rust-lang.org/1.4.0/book/dining-philosophers.html)
-- [Using Threads to Run Code Simultaneously](https://doc.rust-lang.org/book/ch16-01-threads.html)
-- [Using Message Passing to Transfer Data Between Threads](https://doc.rust-lang.org/book/ch16-02-message-passing.html)
+- [Using Threads to Run Code Simultaneously](https://doc.rust-lang.org/stable/book/ch16-01-threads.html)
+- [Using Message Passing to Transfer Data Between Threads](https://doc.rust-lang.org/stable/book/ch16-02-message-passing.html)

--- a/exercises/21_macros/README.md
+++ b/exercises/21_macros/README.md
@@ -10,5 +10,5 @@ of exercises to Rustlings, but is all about learning to write Macros.
 
 ## Further information
 
-- [Macros](https://doc.rust-lang.org/book/ch19-06-macros.html)
+- [Macros](https://doc.rust-lang.org/stable/book/ch19-06-macros.html)
 - [The Little Book of Rust Macros](https://veykril.github.io/tlborm/)

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -112,7 +112,7 @@ you are just converting values to different types like in this exercise.
 Fortunately Rust has a powerful solution to this problem: 'Shadowing'!
 You can read more about 'Shadowing' in the book's section 'Variables and
 Mutability':
-https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#shadowing
+https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html#shadowing
 
 Try to solve this exercise afterwards using this technique."""
 
@@ -131,7 +131,7 @@ The type of Constants must always be annotated.
 
 Read more about constants and the differences between variables and constants
 under 'Constants' in the book's section 'Variables and Mutability':
-https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#constants"""
+https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html#constants"""
 
 # FUNCTIONS
 
@@ -266,7 +266,7 @@ name = "primitive_types4"
 dir = "04_primitive_types"
 hint = """
 Take a look at the 'Understanding Ownership -> Slices -> Other Slices' section
-of the book: https://doc.rust-lang.org/book/ch04-03-slices.html and use the
+of the book: https://doc.rust-lang.org/stable/book/ch04-03-slices.html and use the
 starting and ending (plus one) indices of the items in the array that you want
 to end up in the slice.
 
@@ -281,7 +281,7 @@ dir = "04_primitive_types"
 test = false
 hint = """
 Take a look at the 'Data Types -> The Tuple Type' section of the book:
-https://doc.rust-lang.org/book/ch03-02-data-types.html#the-tuple-type
+https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type
 Particularly the part about destructuring (second to last example in the
 section).
 
@@ -295,7 +295,7 @@ hint = """
 While you could use a destructuring `let` for the tuple here, try
 indexing into it instead, as explained in the last example of the
 'Data Types -> The Tuple Type' section of the book:
-https://doc.rust-lang.org/book/ch03-02-data-types.html#the-tuple-type
+https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type
 Now, you have another tool in your toolbox!"""
 
 # VECS
@@ -311,7 +311,7 @@ In Rust, there are two ways to define a Vector.
    inside the square brackets. This way is simpler when you exactly know
    the initial values.
 
-Check this chapter: https://doc.rust-lang.org/book/ch08-01-vectors.html
+Check this chapter: https://doc.rust-lang.org/stable/book/ch08-01-vectors.html
 of the Rust book to learn more."""
 
 [[exercises]]
@@ -374,7 +374,7 @@ scope. Does it help to update the value of `x` immediately after
 the mutable reference is taken?
 Read more about 'Mutable References' in the book's section 'References and
 Borrowing':
-https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references."""
+https://doc.rust-lang.org/stable/book/ch04-02-references-and-borrowing.html#mutable-references."""
 
 [[exercises]]
 name = "move_semantics5"
@@ -382,7 +382,7 @@ dir = "06_move_semantics"
 test = false
 hint = """
 To find the answer, you can consult the book section "References and Borrowing":
-https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+https://doc.rust-lang.org/stable/book/ch04-02-references-and-borrowing.html
 
 The first problem is that `get_char` is taking ownership of the string. So
 `data` is moved and can't be used for `string_uppercase`. `data` is moved to
@@ -409,7 +409,7 @@ Finally, unit structs. These don't have any fields and are useful for generics.
 
 In this exercise, you need to complete and implement one of each kind.
 Read more about structs in The Book:
-https://doc.rust-lang.org/book/ch05-01-defining-structs.html"""
+https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html"""
 
 [[exercises]]
 name = "structs2"
@@ -420,7 +420,7 @@ to its fields.
 
 There are however some shortcuts that can be taken when instantiating structs.
 Have a look in The Book to find out more:
-https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax"""
+https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax"""
 
 [[exercises]]
 name = "structs3"
@@ -433,7 +433,7 @@ For `get_fees`: This method takes an additional argument, is there a field in
 the `Package` struct that this relates to?
 
 Have a look in The Book to find out more about method implementations:
-https://doc.rust-lang.org/book/ch05-03-method-syntax.html"""
+https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html"""
 
 # ENUMS
 
@@ -491,7 +491,7 @@ to add one character to the `if` statement, though, that will coerce the
 Side note: If you're interested in learning about how this kind of reference
 conversion works, you can jump ahead in the book and read this part in the
 smart pointers chapter:
-https://doc.rust-lang.org/book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods"""
+https://doc.rust-lang.org/stable/book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods"""
 
 [[exercises]]
 name = "strings3"
@@ -542,7 +542,7 @@ and associated constants). Complete the `use` statements to fit the uses in
 `main` and find the one keyword missing for both constants.
 
 Learn more in The Book:
-https://doc.rust-lang.org/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#re-exporting-names-with-pub-use"""
+https://doc.rust-lang.org/stable/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#re-exporting-names-with-pub-use"""
 
 [[exercises]]
 name = "modules3"
@@ -569,7 +569,7 @@ hint = """
 Use the `entry()` and `or_insert()` methods of `HashMap` to achieve this.
 
 Learn more in The Book:
-https://doc.rust-lang.org/book/ch08-03-hash-maps.html#only-inserting-a-value-if-the-key-has-no-value"""
+https://doc.rust-lang.org/stable/book/ch08-03-hash-maps.html#only-inserting-a-value-if-the-key-has-no-value"""
 
 [[exercises]]
 name = "hashmaps3"
@@ -582,7 +582,7 @@ Hint 2: If there is already an entry for a given key, the value returned by
         `entry()` can be updated based on the existing value.
 
 Learn more in The Book:
-https://doc.rust-lang.org/book/ch08-03-hash-maps.html#updating-a-value-based-on-the-old-value"""
+https://doc.rust-lang.org/stable/book/ch08-03-hash-maps.html#updating-a-value-based-on-the-old-value"""
 
 # QUIZ 2
 
@@ -660,7 +660,7 @@ This pattern is very common in Rust, though, so there's the `?` operator that
 does pretty much what you would make that match statement do for you!
 
 Take a look at this section of the "Error Handling" chapter:
-https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator"""
+https://doc.rust-lang.org/stable/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator"""
 
 [[exercises]]
 name = "errors3"
@@ -698,7 +698,7 @@ is polymorphic, and since all errors implement the `Error` trait, we can capture
 lots of different errors in one `Box` object.
 
 Check out this section of The Book:
-https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
+https://doc.rust-lang.org/stable/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
 
 Read more about boxing errors:
 https://doc.rust-lang.org/stable/rust-by-example/error/multiple_error_types/boxing_errors.html
@@ -743,7 +743,7 @@ name = "generics2"
 dir = "14_generics"
 hint = """
 Related section in The Book:
-https://doc.rust-lang.org/book/ch10-01-syntax.html#in-method-definitions"""
+https://doc.rust-lang.org/stable/book/ch10-01-syntax.html#in-method-definitions"""
 
 # TRAITS
 
@@ -752,7 +752,7 @@ name = "traits1"
 dir = "15_traits"
 hint = """
 More about traits in The Book:
-https://doc.rust-lang.org/book/ch10-02-traits.html
+https://doc.rust-lang.org/stable/book/ch10-02-traits.html
 
 The `+` operator can concatenate a `String` with a `&str`."""
 
@@ -775,7 +775,7 @@ implement the trait can then use the default version of these functions
 if they choose not to implement the function themselves.
 
 Related section in The Book:
-https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations"""
+https://doc.rust-lang.org/stable/book/ch10-02-traits.html#default-implementations"""
 
 [[exercises]]
 name = "traits4"
@@ -785,7 +785,7 @@ Instead of using concrete types as parameters you can use traits. Try replacing
 `???` with `impl [what goes here?]`.
 
 Related section in The Book:
-https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters"""
+https://doc.rust-lang.org/stable/book/ch10-02-traits.html#traits-as-parameters"""
 
 [[exercises]]
 name = "traits5"
@@ -795,7 +795,7 @@ To ensure a parameter implements multiple traits use the '+ syntax'. Try
 replacing `???` with 'impl [what goes here?] + [what goes here?]'.
 
 Related section in The Book:
-https://doc.rust-lang.org/book/ch10-02-traits.html#specifying-multiple-trait-bounds-with-the--syntax"""
+https://doc.rust-lang.org/stable/book/ch10-02-traits.html#specifying-multiple-trait-bounds-with-the--syntax"""
 
 # QUIZ 3
 
@@ -805,7 +805,7 @@ dir = "quizzes"
 hint = """
 To find the best solution to this challenge, you need to recall your knowledge
 of traits, specifically "Trait Bound Syntax":
-https://doc.rust-lang.org/book/ch10-02-traits.html#trait-bound-syntax
+https://doc.rust-lang.org/stable/book/ch10-02-traits.html#trait-bound-syntax
 
 Here is how to specify a trait bound for an implementation block:
 `impl<T: Trait1 + Trait2 + …> for Foo<T> { … }`
@@ -820,7 +820,7 @@ name = "lifetimes1"
 dir = "16_lifetimes"
 hint = """
 Let the compiler guide you. Also take a look at The Book if you need help:
-https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html"""
+https://doc.rust-lang.org/stable/book/ch10-03-lifetime-syntax.html"""
 
 [[exercises]]
 name = "lifetimes2"
@@ -875,7 +875,7 @@ We expect the method `Rectangle::new` to panic for negative values.
 To handle that, you need to add a special attribute to the test function.
 
 You can refer to the docs:
-https://doc.rust-lang.org/book/ch11-01-writing-tests.html#checking-for-panics-with-should_panic"""
+https://doc.rust-lang.org/stable/book/ch11-01-writing-tests.html#checking-for-panics-with-should_panic"""
 
 # STANDARD LIBRARY TYPES
 
@@ -971,7 +971,7 @@ actual type when working with recursive types, we need to store a reference
 (pointer) to its value.
 
 We should, therefore, place our `List` inside a `Box`. More details in The Book:
-https://doc.rust-lang.org/book/ch15-01-box.html#enabling-recursive-types-with-boxes
+https://doc.rust-lang.org/stable/book/ch15-01-box.html#enabling-recursive-types-with-boxes
 
 Creating an empty list should be fairly straightforward (Hint: Read the tests).
 
@@ -992,7 +992,7 @@ reference count goes down.
 
 In the end, the `Sun` only has one reference again, to itself.
 
-See more at: https://doc.rust-lang.org/book/ch15-04-rc.html
+See more at: https://doc.rust-lang.org/stable/book/ch15-04-rc.html
 
 Unfortunately, Pluto is no longer considered a planet :("""
 
@@ -1011,7 +1011,7 @@ thread-local copy of the numbers.
 This is a simple exercise if you understand the underlying concepts, but if this
 is too much of a struggle, consider reading through all of Chapter 16 in The
 Book:
-https://doc.rust-lang.org/book/ch16-00-concurrency.html"""
+https://doc.rust-lang.org/stable/book/ch16-00-concurrency.html"""
 
 [[exercises]]
 name = "cow1"
@@ -1035,7 +1035,7 @@ https://doc.rust-lang.org/std/thread/fn.spawn.html
 
 A challenge with multi-threaded applications is that the main thread can
 finish before the spawned threads are done.
-https://doc.rust-lang.org/book/ch16-01-threads.html#waiting-for-all-threads-to-finish-using-join-handles
+https://doc.rust-lang.org/stable/book/ch16-01-threads.html#waiting-for-all-threads-to-finish-using-join-handles
 
 Use the `JoinHandle`s to wait for each thread to finish and collect their
 results.
@@ -1051,7 +1051,7 @@ hint = """
 to **immutable** data. But we want to *change* the number of `jobs_done` so
 we'll need to also use another type that will only allow one thread to mutate
 the data at a time. Take a look at this section of the book:
-https://doc.rust-lang.org/book/ch16-03-shared-state.html#atomic-reference-counting-with-arct
+https://doc.rust-lang.org/stable/book/ch16-03-shared-state.html#atomic-reference-counting-with-arct
 
 Keep reading if you'd like more hints :)
 
@@ -1061,7 +1061,7 @@ let status = Arc::new(Mutex::new(JobStatus { jobs_done: 0 }));
 ```
 
 Similar to the code in the following example in The Book:
-https://doc.rust-lang.org/book/ch16-03-shared-state.html#sharing-a-mutext-between-multiple-threads"""
+https://doc.rust-lang.org/stable/book/ch16-03-shared-state.html#sharing-a-mutext-between-multiple-threads"""
 
 [[exercises]]
 name = "threads3"
@@ -1077,7 +1077,7 @@ Multiple producers are possible by using `clone()` to create a duplicate of the
 original sending end.
 
 Related section in The Book:
-https://doc.rust-lang.org/book/ch16-02-message-passing.html"""
+https://doc.rust-lang.org/stable/book/ch16-02-message-passing.html"""
 
 # MACROS
 

--- a/solutions/01_variables/variables5.rs
+++ b/solutions/01_variables/variables5.rs
@@ -3,7 +3,7 @@ fn main() {
     println!("Spell a number: {}", number);
 
     // Using variable shadowing
-    // https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#shadowing
+    // https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html#shadowing
     let number = 3;
     println!("Number plus two is: {}", number + 2);
 }


### PR DESCRIPTION
Update rust-book links to use `https://doc.rust-lang.org/stable/book` instead of `https://dosc.rust-lang.org/book` as URL