### PR TITLE
A clearer description of the original problem

### DIFF
--- a/exercises/05_vecs/vecs1.rs
+++ b/exercises/05_vecs/vecs1.rs
@@ -1,9 +1,13 @@
 fn array_and_vec() -> ([i32; 4], Vec<i32>) {
-    let a = [10, 20, 30, 40]; // Array
+    // You can define an array with the intitial values 10, 20, 30 and 40 like
+    // this:
+    let a = [10, 20, 30, 40]; // Array. Do not change!
 
-    // TODO: Create a vector called `v` which contains the exact same elements as in the array `a`.
-    // Use the vector macro.
-    // let v = ???;
+    // There is a similar way you can define a vector with initial values:
+    let v = vec![20, 30, 40]; // Vector. Needs to be fixed
+
+    // TODO: Adjust the vector definition above so that `a` and `v` have the
+    // same contents.
 
     (a, v)
 }

--- a/exercises/05_vecs/vecs1.rs
+++ b/exercises/05_vecs/vecs1.rs
@@ -4,7 +4,7 @@ fn array_and_vec() -> ([i32; 4], Vec<i32>) {
     let a = [10, 20, 30, 40]; // Array. Do not change!
 
     // There is a similar way you can define a vector with initial values:
-    let v = vec![20, 30, 40]; // Vector. Needs to be fixed
+    // let v = vec![10, 20, ???]; // Vector. Needs to be fixed
 
     // TODO: Adjust the vector definition above so that `a` and `v` have the
     // same contents.


### PR DESCRIPTION
The original excercise instructs the learner to use the vector macro. It is easy to assume that the code needs to read from `a` which is not what is intended.

The updated excercise introduces the syntax for initial array and vector contents and lets the learner figure out how to tweak initial values of a vector. This learning seems to be the original intent of the excercise.