### PR TITLE
Fix 404 in Lifetimes README.md

### DIFF
--- a/exercises/16_lifetimes/README.md
+++ b/exercises/16_lifetimes/README.md
@@ -18,5 +18,5 @@ learning to write lifetime annotations.
 
 ## Further information
 
-- [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/stable/rust-by-example/scope/lifetime.html)
+- [Lifetimes (in Rust By Example)](https://doc.rust-lang.org/rust-by-example/scope/lifetime.html)
 - [Validating References with Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)


### PR DESCRIPTION
Link to Lifetimes (in Rust By Example) leads to a 404 page.  Removing the "/stable" slug fixes this.