### PR TITLE
Add errors7 exercise to show full potential of try operator combined with From trait

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -118,6 +118,8 @@ bin = [
   { name = "generics2_sol", path = "../solutions/14_generics/generics2.rs" },
   { name = "traits1", path = "../exercises/15_traits/traits1.rs" },
   { name = "traits1_sol", path = "../solutions/15_traits/traits1.rs" },
+  { name = "errors7", path = "../exercises/13_error_handling/errors7.rs" },
+  { name = "errors7_sol", path = "../solutions/13_error_handling/errors7.rs" },
   { name = "traits2", path = "../exercises/15_traits/traits2.rs" },
   { name = "traits2_sol", path = "../solutions/15_traits/traits2.rs" },
   { name = "traits3", path = "../exercises/15_traits/traits3.rs" },

--- a/exercises/13_error_handling/errors7.rs
+++ b/exercises/13_error_handling/errors7.rs
@@ -1,0 +1,97 @@
+// TODOUsing catch-all error types like `Box<dyn Error>` isn't recommended for
+// library code where callers might want to make decisions based on the error
+// content instead of printing it out or propagating it further. Here, we define
+// a custom error type to make it possible for callers to decide what to do next
+// when our function returns an error.
+
+use std::num::ParseIntError;
+
+#[derive(PartialEq, Debug)]
+enum CreationError {
+    Negative,
+    Zero,
+}
+
+// A custom error type that we will be using in `PositiveNonzeroInteger::parse`.
+#[derive(PartialEq, Debug)]
+enum ParsePosNonzeroError {
+    Creation(CreationError),
+    ParseInt(ParseIntError),
+}
+
+impl ParsePosNonzeroError {
+    fn from_creation(err: CreationError) -> Self {
+        Self::Creation(err)
+    }
+
+    fn from_parse_int(err: ParseIntError) -> Self {
+        Self::ParseInt(err)
+    }
+}
+
+// TODO Implement From trait for ParseIntError and CreationError
+// impl From<ParseIntError> for ParsePosNonzeroError {
+//     fn from(err: ParseIntError) -> Self {
+//        ???
+//     }
+// }
+
+#[derive(PartialEq, Debug)]
+struct PositiveNonzeroInteger(u64);
+
+impl PositiveNonzeroInteger {
+    fn new(value: i64) -> Result<Self, CreationError> {
+        match value {
+            x if x < 0 => Err(CreationError::Negative),
+            0 => Err(CreationError::Zero),
+            x => Ok(Self(x as u64)),
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self, ParsePosNonzeroError> {
+        // Return an appropriate error instead of panicking when `parse()`
+        // returns an error.
+        let x: i64 = s.parse()?;
+        Self::new(x)?
+    }
+}
+
+fn main() {
+    // You can optionally experiment here.
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_error() {
+        assert!(matches!(
+            PositiveNonzeroInteger::parse("not a number"),
+            Err(ParsePosNonzeroError::ParseInt(_)),
+        ));
+    }
+
+    #[test]
+    fn test_negative() {
+        assert_eq!(
+            PositiveNonzeroInteger::parse("-555"),
+            Err(ParsePosNonzeroError::Creation(CreationError::Negative)),
+        );
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(
+            PositiveNonzeroInteger::parse("0"),
+            Err(ParsePosNonzeroError::Creation(CreationError::Zero)),
+        );
+    }
+
+    #[test]
+    fn test_positive() {
+        let x = PositiveNonzeroInteger::new(42).unwrap();
+        assert_eq!(x.0, 42);
+        assert_eq!(PositiveNonzeroInteger::parse("42"), Ok(x));
+    }
+}

--- a/exercises/13_error_handling/errors7.rs
+++ b/exercises/13_error_handling/errors7.rs
@@ -1,8 +1,8 @@
-// TODOUsing catch-all error types like `Box<dyn Error>` isn't recommended for
-// library code where callers might want to make decisions based on the error
-// content instead of printing it out or propagating it further. Here, we define
-// a custom error type to make it possible for callers to decide what to do next
-// when our function returns an error.
+// While defining and using a custom error type in library code is recomended
+// the ergonomics of the map_err approach presented in errors6 is suboptimal.
+// The growing codebase could quickly become obfuscated by error conversions
+// sprinkled here and there. Fortunetly, using traits we just learned about,
+// we can use one more Rust feature to fix that.
 
 use std::num::ParseIntError;
 
@@ -29,12 +29,15 @@ impl ParsePosNonzeroError {
     }
 }
 
-// TODO Implement From trait for ParseIntError and CreationError
+// TODO Implement From trait for ParseIntError
 // impl From<ParseIntError> for ParsePosNonzeroError {
 //     fn from(err: ParseIntError) -> Self {
 //        ???
 //     }
 // }
+
+// TODO Implement From trait for CreationError
+// ...
 
 #[derive(PartialEq, Debug)]
 struct PositiveNonzeroInteger(u64);
@@ -49,9 +52,9 @@ impl PositiveNonzeroInteger {
     }
 
     fn parse(s: &str) -> Result<Self, ParsePosNonzeroError> {
-        // Return an appropriate error instead of panicking when `parse()`
-        // returns an error.
+        // Don't change this line
         let x: i64 = s.parse()?;
+        // Don't change this line
         Self::new(x)?
     }
 }

--- a/exercises/13_error_handling/errors7.rs
+++ b/exercises/13_error_handling/errors7.rs
@@ -55,7 +55,7 @@ impl PositiveNonzeroInteger {
         // Don't change this line
         let x: i64 = s.parse()?;
         // Don't change this line
-        Self::new(x)?
+        Ok(Self::new(x)?)
     }
 }
 

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -760,7 +760,7 @@ The `+` operator can concatenate a `String` with a `&str`."""
 name = "errors7"
 dir = "13_error_handling"
 hint = """
-More about relatio between try operator and From Trait:
+More about relation between try operator and the From trait:
 https://doc.rust-lang.org/std/convert/trait.From.html#examples"""
 
 [[exercises]]

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -721,13 +721,6 @@ can then use the `?` operator to return early.
 Read more about `map_err()` in the `std::result` documentation:
 https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err"""
 
-[[exercises]]
-name = "errors7"
-dir = "13_error_handling"
-hint = """
-TODO Add hint and place after traits exercise
-"""
-
 # Generics
 
 [[exercises]]
@@ -762,6 +755,13 @@ More about traits in The Book:
 https://doc.rust-lang.org/book/ch10-02-traits.html
 
 The `+` operator can concatenate a `String` with a `&str`."""
+
+[[exercises]]
+name = "errors7"
+dir = "13_error_handling"
+hint = """
+More about relatio between try operator and From Trait:
+https://doc.rust-lang.org/std/convert/trait.From.html#examples"""
 
 [[exercises]]
 name = "traits2"

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -725,7 +725,7 @@ https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err"""
 name = "errors7"
 dir = "13_error_handling"
 hint = """
-TODO
+TODO Add hint and place after traits exercise
 """
 
 # Generics

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -721,6 +721,13 @@ can then use the `?` operator to return early.
 Read more about `map_err()` in the `std::result` documentation:
 https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err"""
 
+[[exercises]]
+name = "errors7"
+dir = "13_error_handling"
+hint = """
+TODO
+"""
+
 # Generics
 
 [[exercises]]

--- a/solutions/13_error_handling/errors7.rs
+++ b/solutions/13_error_handling/errors7.rs
@@ -1,8 +1,8 @@
-// Using catch-all error types like `Box<dyn Error>` isn't recommended for
-// library code where callers might want to make decisions based on the error
-// content instead of printing it out or propagating it further. Here, we define
-// a custom error type to make it possible for callers to decide what to do next
-// when our function returns an error.
+// While defining and using a custom error type in library code is recomended
+// the ergonomics of the map_err approach presented in errors6 is suboptimal.
+// The growing codebase could quickly become obfuscated by error conversions
+// sprinkled here and there. Fortunetly, using traits we just learned about,
+// we can use one more Rust feature to fix that.
 
 use std::num::ParseIntError;
 
@@ -54,9 +54,9 @@ impl PositiveNonzeroInteger {
     }
 
     fn parse(s: &str) -> Result<Self, ParsePosNonzeroError> {
-        // Return an appropriate error instead of panicking when `parse()`
-        // returns an error.
+        // Don't change this line
         let x: i64 = s.parse()?;
+        // Don't change this line
         Self::new(x)?
     }
 }

--- a/solutions/13_error_handling/errors7.rs
+++ b/solutions/13_error_handling/errors7.rs
@@ -57,7 +57,7 @@ impl PositiveNonzeroInteger {
         // Don't change this line
         let x: i64 = s.parse()?;
         // Don't change this line
-        Self::new(x)?
+        Ok(Self::new(x)?)
     }
 }
 

--- a/solutions/13_error_handling/errors7.rs
+++ b/solutions/13_error_handling/errors7.rs
@@ -1,0 +1,102 @@
+// Using catch-all error types like `Box<dyn Error>` isn't recommended for
+// library code where callers might want to make decisions based on the error
+// content instead of printing it out or propagating it further. Here, we define
+// a custom error type to make it possible for callers to decide what to do next
+// when our function returns an error.
+
+use std::num::ParseIntError;
+
+#[derive(PartialEq, Debug)]
+enum CreationError {
+    Negative,
+    Zero,
+}
+
+// A custom error type that we will be using in `PositiveNonzeroInteger::parse`.
+#[derive(PartialEq, Debug)]
+enum ParsePosNonzeroError {
+    Creation(CreationError),
+    ParseInt(ParseIntError),
+}
+
+impl ParsePosNonzeroError {
+    fn from_creation(err: CreationError) -> Self {
+        Self::Creation(err)
+    }
+
+    fn from_parse_int(err: ParseIntError) -> Self {
+        Self::ParseInt(err)
+    }
+}
+
+impl From<ParseIntError> for ParsePosNonzeroError {
+    fn from(err: ParseIntError) -> Self {
+        ParsePosNonzeroError::from_parse_int(err)
+    }
+}
+
+impl From<CreationError> for ParsePosNonzeroError {
+    fn from(err: CreationError) -> Self {
+        ParsePosNonzeroError::from_creation(err)
+    }
+}
+
+#[derive(PartialEq, Debug)]
+struct PositiveNonzeroInteger(u64);
+
+impl PositiveNonzeroInteger {
+    fn new(value: i64) -> Result<Self, CreationError> {
+        match value {
+            x if x < 0 => Err(CreationError::Negative),
+            0 => Err(CreationError::Zero),
+            x => Ok(Self(x as u64)),
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self, ParsePosNonzeroError> {
+        // Return an appropriate error instead of panicking when `parse()`
+        // returns an error.
+        let x: i64 = s.parse()?;
+        Self::new(x)?
+    }
+}
+
+fn main() {
+    // You can optionally experiment here.
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_error() {
+        assert!(matches!(
+            PositiveNonzeroInteger::parse("not a number"),
+            Err(ParsePosNonzeroError::ParseInt(_)),
+        ));
+    }
+
+    #[test]
+    fn test_negative() {
+        assert_eq!(
+            PositiveNonzeroInteger::parse("-555"),
+            Err(ParsePosNonzeroError::Creation(CreationError::Negative)),
+        );
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(
+            PositiveNonzeroInteger::parse("0"),
+            Err(ParsePosNonzeroError::Creation(CreationError::Zero)),
+        );
+    }
+
+    #[test]
+    fn test_positive() {
+        let x = PositiveNonzeroInteger::new(42).unwrap();
+        assert_eq!(x.0, 42);
+        assert_eq!(PositiveNonzeroInteger::parse("42"), Ok(x));
+    }
+}


### PR DESCRIPTION
Thanks for creating the Rustlings! I loved it!

While doing them I felt that the user might miss the full potential of the try operator due to the lack of exercise that shows how well custom error types work with it and From trait. This PR adds an exercise focused on that. I placed it after the first trait exercise to be sure that they understand what they are doing.

Only after creating the thing did I find out that I should have created an issue first - sorry for that!


If it goes in let's squash it.