### PR TITLE
Use consistent apostrophes in markdown files

### DIFF
--- a/exercises/01_variables/README.md
+++ b/exercises/01_variables/README.md
@@ -1,7 +1,7 @@
 # Variables
 
 In Rust, variables are immutable by default.
-When a variable is immutable, once a value is bound to a name, you can’t change that value.
+When a variable is immutable, once a value is bound to a name, you can't change that value.
 You can make them mutable by adding `mut` in front of the variable name.
 
 ## Further information

--- a/exercises/08_enums/README.md
+++ b/exercises/08_enums/README.md
@@ -1,7 +1,7 @@
 # Enums
 
 Rust allows you to define types called "enums" which enumerate possible values.
-Enums are a feature in many languages, but their capabilities differ in each language. Rust’s enums are most similar to algebraic data types in functional languages, such as F#, OCaml, and Haskell.
+Enums are a feature in many languages, but their capabilities differ in each language. Rust's enums are most similar to algebraic data types in functional languages, such as F#, OCaml, and Haskell.
 Useful in combination with enums is Rust's "pattern matching" facility, which makes it easy to run different code for different values of an enumeration.
 
 ## Further information

--- a/exercises/13_error_handling/README.md
+++ b/exercises/13_error_handling/README.md
@@ -1,8 +1,8 @@
 # Error handling
 
-Most errors aren’t serious enough to require the program to stop entirely.
-Sometimes, when a function fails, it’s for a reason that you can easily interpret and respond to.
-For example, if you try to open a file and that operation fails because the file doesn’t exist, you might want to create the file instead of terminating the process.
+Most errors aren't serious enough to require the program to stop entirely.
+Sometimes, when a function fails, it's for a reason that you can easily interpret and respond to.
+For example, if you try to open a file and that operation fails because the file doesn't exist, you might want to create the file instead of terminating the process.
 
 ## Further information
 


### PR DESCRIPTION
Very minor issue with consistency of apostrophes in Markdown files. This was probably replaced by a word processor as a smart quote. This change makes them all single quotes.