### PR TITLE
test idempotence of `trim_me` in `strings3.rs`

### DIFF
--- a/exercises/09_strings/strings3.rs
+++ b/exercises/09_strings/strings3.rs
@@ -23,6 +23,7 @@ mod tests {
         assert_eq!(trim_me("Hello!     "), "Hello!");
         assert_eq!(trim_me("  What's up!"), "What's up!");
         assert_eq!(trim_me("   Hola!  "), "Hola!");
+        assert_eq!(trim_me("Hi!"), "Hi!");
     }
 
     #[test]


### PR DESCRIPTION
Technically, this change doesn't directly test for idempotence, as the `fn` is called once instead of being chained. I still believe it adds value, because it can make the challenge "harder" while still being fair.

> [!note]
> The following is just feedback from my recent experience. It can be ignored as "off-topic", but I believe it might be helpful for designing exercises in general.

BTW, when I was solving it, I felt like using `trim` method was "cheating", so I implemented it myself:
```rust
fn trim_me(input: &str) -> &str {
    let l = |c| c != ' ';
    let start = input.find(l).unwrap_or_default();
    // it's easier to let patterns do their job
    // than to handle arithmetic overflows manually,
    // hence the asymmetry
    match input.rfind(l) {
        Some(end) => &input[start..=end],
        _ => &input[start..],
    }
}
```

Originally, the code was this:
```rust
fn trim_me(input: &str) -> &str {
    let l = |c| c != ' ';
    &input[input.find(l).unwrap_or_default()..=input.rfind(l).unwrap_or(input.len() - 1)]
}
```
Aside from being an eyesore, it doesn't work for `""` (`input.len() - 1` is always an invalid index). That's why I added some extra tests locally, as a "challenge" to myself.

Should I add the empty `str` test?