### PR TITLE
clarified the comment in exercise

### DIFF
--- a/exercises/09_strings/strings2.rs
+++ b/exercises/09_strings/strings2.rs
@@ -1,4 +1,5 @@
 // TODO: Fix the compiler error in the `main` function without changing this function.
+
 fn is_a_color_word(attempt: &str) -> bool {
     attempt == "green" || attempt == "blue" || attempt == "red"
 }


### PR DESCRIPTION
This Pull request fixes #2230 
Replaced `this` with the actual name of the function `is_a_color_word` which was causing confusion for the users
