### PR TITLE
Fix possible typo of `icecream` to `ice cream` on `options1.rs`

### DIFF
--- a/exercises/12_options/options1.rs
+++ b/exercises/12_options/options1.rs
@@ -1,8 +1,8 @@
-// This function returns how much icecream there is left in the fridge.
+// This function returns how much ice cream there is left in the fridge.
 // If it's before 22:00 (24-hour system), then 5 scoops are left. At 22:00,
-// someone eats it all, so no icecream is left (value 0). Return `None` if
+// someone eats it all, so no ice cream is left (value 0). Return `None` if
 // `hour_of_day` is higher than 23.
-fn maybe_icecream(hour_of_day: u16) -> Option<u16> {
+fn maybe_ice_cream(hour_of_day: u16) -> Option<u16> {
     // TODO: Complete the function body.
 }
 
@@ -18,19 +18,19 @@ mod tests {
     fn raw_value() {
         // TODO: Fix this test. How do you get the value contained in the
         // Option?
-        let icecreams = maybe_icecream(12);
+        let ice_creams = maybe_ice_cream(12);
 
-        assert_eq!(icecreams, 5); // Don't change this line.
+        assert_eq!(ice_creams, 5); // Don't change this line.
     }
 
     #[test]
-    fn check_icecream() {
-        assert_eq!(maybe_icecream(0), Some(5));
-        assert_eq!(maybe_icecream(9), Some(5));
-        assert_eq!(maybe_icecream(18), Some(5));
-        assert_eq!(maybe_icecream(22), Some(0));
-        assert_eq!(maybe_icecream(23), Some(0));
-        assert_eq!(maybe_icecream(24), None);
-        assert_eq!(maybe_icecream(25), None);
+    fn check_ice_cream() {
+        assert_eq!(maybe_ice_cream(0), Some(5));
+        assert_eq!(maybe_ice_cream(9), Some(5));
+        assert_eq!(maybe_ice_cream(18), Some(5));
+        assert_eq!(maybe_ice_cream(22), Some(0));
+        assert_eq!(maybe_ice_cream(23), Some(0));
+        assert_eq!(maybe_ice_cream(24), None);
+        assert_eq!(maybe_ice_cream(25), None);
     }
 }


### PR DESCRIPTION
If this is intended for any reason, please ignore this PR.

IDE flags them as typo, and I couldn't resist to submit a PR.
I'm using RustRover, if this ever matters.