### PR TITLE
Clarify how to find return type of error4

### DIFF
--- a/exercises/13_error_handling/errors4.rs
+++ b/exercises/13_error_handling/errors4.rs
@@ -10,6 +10,7 @@ struct PositiveNonzeroInteger(u64);
 impl PositiveNonzeroInteger {
     fn new(value: i64) -> Result<Self, CreationError> {
         // TODO: This function shouldn't always return an `Ok`.
+        // Read the tests below to clarify what should be returned.
         Ok(Self(value as u64))
     }
 }


### PR DESCRIPTION
Makes the "TODO: This function shouldn't always return an `Ok`." in error4 less vague and adds "Read the tests below to clarify what should be returned.". 