### PR TITLE
Fix incorrect book chapter number

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -22,6 +22,6 @@
 | iterators              | §13.2-4             |
 | smart_pointers         | §15, §16.3          |
 | threads                | §16.1-3             |
-| macros                 | §19.5               |
+| macros                 | §20.5               |
 | clippy                 | §21.4               |
 | conversions            | n/a                 |


### PR DESCRIPTION
Makes the README within the exercises file reference the correct section of the book for macros (20.5, corresponding to [https://doc.rust-lang.org/book/ch20-05-macros.html](https://doc.rust-lang.org/book/ch20-05-macros.html) instead of 19.5).