### PR TITLE
Improve comment clarity for enums1 exercise

### DIFF
--- a/exercises/08_enums/enums1.rs
+++ b/exercises/08_enums/enums1.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 enum Message {
-    // TODO: Define a few types of messages as used below.
+    // TODO: Define the message types used below.
+    // These are simple enum variants with no data.
 }
 
 fn main() {


### PR DESCRIPTION
This PR updates the comments in enums1.rs to better explain the enum variants and make the exercise instructions clearer for beginners.