### PR TITLE
Fix workspace detection with windows line endings

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -74,7 +74,7 @@ pub fn init() -> Result<()> {
 
         let workspace_manifest_content = fs::read_to_string(&workspace_manifest)
             .with_context(|| format!("Failed to read the file {}", workspace_manifest.display()))?;
-        if !workspace_manifest_content.contains("[workspace]\n")
+        if !workspace_manifest_content.contains("[workspace]")
             && !workspace_manifest_content.contains("workspace.")
         {
             bail!(


### PR DESCRIPTION
Some cargo workspaces may contain windows line endings. Even if the file is stored in a repo with unix line endings, users may have some setting activated that automatically translates them to windows line endings when working locally.