### PR TITLE
Remove use of `map` in early vecs2 exercise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- `vecs2`: Removed the use of `map` and `collect`, which are only taught later.
+
 ## 6.5.0 (2025-08-21)
 
 ### Added

--- a/exercises/05_vecs/vecs2.rs
+++ b/exercises/05_vecs/vecs2.rs
@@ -9,26 +9,6 @@ fn vec_loop(input: &[i32]) -> Vec<i32> {
     output
 }
 
-fn vec_map_example(input: &[i32]) -> Vec<i32> {
-    // An example of collecting a vector after mapping.
-    // We map each element of the `input` slice to its value plus 1.
-    // If the input is `[1, 2, 3]`, the output is `[2, 3, 4]`.
-    input.iter().map(|element| element + 1).collect()
-}
-
-fn vec_map(input: &[i32]) -> Vec<i32> {
-    // TODO: Here, we also want to multiply each element in the `input` slice
-    // by 2, but with iterator mapping instead of manually pushing into an empty
-    // vector.
-    // See the example in the function `vec_map_example` above.
-    input
-        .iter()
-        .map(|element| {
-            // ???
-        })
-        .collect()
-}
-
 fn main() {
     // You can optionally experiment here.
 }
@@ -41,20 +21,6 @@ mod tests {
     fn test_vec_loop() {
         let input = [2, 4, 6, 8, 10];
         let ans = vec_loop(&input);
-        assert_eq!(ans, [4, 8, 12, 16, 20]);
-    }
-
-    #[test]
-    fn test_vec_map_example() {
-        let input = [1, 2, 3];
-        let ans = vec_map_example(&input);
-        assert_eq!(ans, [2, 3, 4]);
-    }
-
-    #[test]
-    fn test_vec_map() {
-        let input = [2, 4, 6, 8, 10];
-        let ans = vec_map(&input);
         assert_eq!(ans, [4, 8, 12, 16, 20]);
     }
 }

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -318,16 +318,7 @@ of the Rust book to learn more."""
 name = "vecs2"
 dir = "05_vecs"
 hint = """
-In the first function, we create an empty vector and want to push new elements
-to it.
-
-In the second function, we map the values of the input and collect them into
-a vector.
-
-After you've completed both functions, decide for yourself which approach you
-like better.
-
-What do you think is the more commonly used pattern under Rust developers?"""
+Use the `.push()` method on the vector to push new elements to it."""
 
 # MOVE SEMANTICS
 

--- a/solutions/05_vecs/vecs2.rs
+++ b/solutions/05_vecs/vecs2.rs
@@ -8,22 +8,6 @@ fn vec_loop(input: &[i32]) -> Vec<i32> {
     output
 }
 
-fn vec_map_example(input: &[i32]) -> Vec<i32> {
-    // An example of collecting a vector after mapping.
-    // We map each element of the `input` slice to its value plus 1.
-    // If the input is `[1, 2, 3]`, the output is `[2, 3, 4]`.
-    input.iter().map(|element| element + 1).collect()
-}
-
-fn vec_map(input: &[i32]) -> Vec<i32> {
-    // We will dive deeper into iterators, but for now, this is all what you
-    // had to do!
-    // Advanced note: This method is more efficient because it automatically
-    // preallocates enough capacity. This can be done manually in `vec_loop`
-    // using `Vec::with_capacity(input.len())` instead of `Vec::new()`.
-    input.iter().map(|element| 2 * element).collect()
-}
-
 fn main() {
     // You can optionally experiment here.
 }
@@ -36,20 +20,6 @@ mod tests {
     fn test_vec_loop() {
         let input = [2, 4, 6, 8, 10];
         let ans = vec_loop(&input);
-        assert_eq!(ans, [4, 8, 12, 16, 20]);
-    }
-
-    #[test]
-    fn test_vec_map_example() {
-        let input = [1, 2, 3];
-        let ans = vec_map_example(&input);
-        assert_eq!(ans, [2, 3, 4]);
-    }
-
-    #[test]
-    fn test_vec_map() {
-        let input = [2, 4, 6, 8, 10];
-        let ans = vec_map(&input);
         assert_eq!(ans, [4, 8, 12, 16, 20]);
     }
 }


### PR DESCRIPTION
Students do not have the necessary knowledge at this point to understand what's happening with the iterator combinators. This topic is covered well by the dedicated exercises about iterators later.

closes #2102