### PR TITLE
fix(clippy3): separate initialisation and resizing of vec

### DIFF
--- a/exercises/22_clippy/clippy3.rs
+++ b/exercises/22_clippy/clippy3.rs
@@ -17,7 +17,8 @@ fn main() {
     ];
     println!("My array! Here it is: {my_arr:?}");
 
-    let my_empty_vec = vec![1, 2, 3, 4, 5].resize(0, 5);
+    let my_empty_vec = vec![1, 2, 3, 4, 5];
+    my_empty_vec.resize(0,5);
     println!("This Vec is empty, see? {my_empty_vec:?}");
 
     let mut value_a = 45;


### PR DESCRIPTION
Hi rustlings team! Thank you all for maintaining this amazing resource for learning Rust.

I had recently gone through the clippy exercises and I noticed that in clippy3 one of the things clippy is supposed to pick up on is to suggest `clear`ing a `Vec` instead of `resize`ing it to len 0 (at least judging from the current example solution for the exercise). In the current form of the exercise, clippy actually doesn't do this and instead just tells you to not initialise a `Vec` and then immediately resize it to len 0 (it is currently all done in one line) (tbf that is fair advice by clippy!).

But if you would like the intended advice of "you should use clear instead", you can get that by separating the initialisation and the resizing. This is a tiny PR just doing that.