### PR TITLE
fix: mapping typo in the exercieses README.md

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -9,7 +9,7 @@
 | vecs                   | §8.1                |
 | move_semantics         | §4.1-2              |
 | structs                | §5.1, §5.3          |
-| enums                  | §6, §18.3           |
+| enums                  | §6, §19.3           |
 | strings                | §8.2                |
 | modules                | §7                  |
 | hashmaps               | §8.3                |


### PR DESCRIPTION
The `exercises/README.md` maps the [Implementing an Object-Oriented Design Pattern | 18.3](https://doc.rust-lang.org/book/ch18-03-oo-design-patterns.html) chapter of the book to the enums exercise.

The `exercises/08_enums/README.md` links to the - [Pattern syntax | 19.3](https://doc.rust-lang.org/book/ch19-03-pattern-syntax.html) chapter.

The latter makes more sense, so I guess the first one is a typo.