### PR TITLE
docs: add blank line after README H1 for proper markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [Rustlings](https://rustlings.rust-lang.org) 🦀
+Small exercises to get you used to reading and writing Rust code...
 
 Small exercises to get you used to reading and writing [Rust](https://www.rust-lang.org) code - _Recommended in parallel to reading [the official Rust book](https://doc.rust-lang.org/book) 📚️_
 


### PR DESCRIPTION
Added a missing blank line after the top-level README heading.

This improves Markdown rendering and formatting.  
No functional changes included.
