### PR TITLE
fix: Match solution files with exercise files

### DIFF
--- a/solutions/09_strings/strings4.rs
+++ b/solutions/09_strings/strings4.rs
@@ -19,7 +19,7 @@ fn main() {
     // `.into()` converts a type into an expected type.
     // If it is called where `String` is expected, it will convert `&str` to `String`.
     string("nice weather".into());
-    // But if it is called where `&str` is expected, then `&str` is kept `&str` since no conversion is needed.
+    // But if it is called where `&str` is expected, then `&str` is kept as `&str` since no conversion is needed.
     // If you remove the `#[allow(…)]` line, then Clippy will tell you to remove `.into()` below since it is a useless conversion.
     #[allow(clippy::useless_conversion)]
     string_slice("nice weather".into());

--- a/solutions/11_hashmaps/hashmaps1.rs
+++ b/solutions/11_hashmaps/hashmaps1.rs
@@ -1,7 +1,7 @@
 // A basket of fruits in the form of a hash map needs to be defined. The key
 // represents the name of the fruit and the value represents how many of that
 // particular fruit is in the basket. You have to put at least 3 different
-// types of fruits (e.g apple, banana, mango) in the basket and the total count
+// types of fruits (e.g. apple, banana, mango) in the basket and the total count
 // of all the fruits should be at least 5.
 
 use std::collections::HashMap;

--- a/solutions/12_options/options1.rs
+++ b/solutions/12_options/options1.rs
@@ -1,8 +1,8 @@
-// This function returns how much icecream there is left in the fridge.
+// This function returns how much ice cream there is left in the fridge.
 // If it's before 22:00 (24-hour system), then 5 scoops are left. At 22:00,
-// someone eats it all, so no icecream is left (value 0). Return `None` if
+// someone eats it all, so no ice cream is left (value 0). Return `None` if
 // `hour_of_day` is higher than 23.
-fn maybe_icecream(hour_of_day: u16) -> Option<u16> {
+fn maybe_ice_cream(hour_of_day: u16) -> Option<u16> {
     match hour_of_day {
         0..=21 => Some(5),
         22..=23 => Some(0),
@@ -21,19 +21,19 @@ mod tests {
     #[test]
     fn raw_value() {
         // Using `unwrap` is fine in a test.
-        let icecreams = maybe_icecream(12).unwrap();
+        let ice_creams = maybe_ice_cream(12).unwrap();
 
-        assert_eq!(icecreams, 5);
+        assert_eq!(ice_creams, 5);
     }
 
     #[test]
-    fn check_icecream() {
-        assert_eq!(maybe_icecream(0), Some(5));
-        assert_eq!(maybe_icecream(9), Some(5));
-        assert_eq!(maybe_icecream(18), Some(5));
-        assert_eq!(maybe_icecream(22), Some(0));
-        assert_eq!(maybe_icecream(23), Some(0));
-        assert_eq!(maybe_icecream(24), None);
-        assert_eq!(maybe_icecream(25), None);
+    fn check_ice_cream() {
+        assert_eq!(maybe_ice_cream(0), Some(5));
+        assert_eq!(maybe_ice_cream(9), Some(5));
+        assert_eq!(maybe_ice_cream(18), Some(5));
+        assert_eq!(maybe_ice_cream(22), Some(0));
+        assert_eq!(maybe_ice_cream(23), Some(0));
+        assert_eq!(maybe_ice_cream(24), None);
+        assert_eq!(maybe_ice_cream(25), None);
     }
 }

--- a/solutions/13_error_handling/errors5.rs
+++ b/solutions/13_error_handling/errors5.rs
@@ -6,7 +6,7 @@
 //
 // In short, this particular use case for boxes is for when you want to own a
 // value and you care only that it is a type which implements a particular
-// trait. To do so, The `Box` is declared as of type `Box<dyn Trait>` where
+// trait. To do so, the `Box` is declared as of type `Box<dyn Trait>` where
 // `Trait` is the trait the compiler looks for on any value used in that
 // context. For this exercise, that context is the potential errors which
 // can be returned in a `Result`.

--- a/solutions/16_lifetimes/lifetimes2.rs
+++ b/solutions/16_lifetimes/lifetimes2.rs
@@ -4,7 +4,7 @@ fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
 
 fn main() {
     let string1 = String::from("long string is long");
-    // Solution1: You can move `strings2` out of the inner block so that it is
+    // Solution 1: You can move `strings2` out of the inner block so that it is
     // not dropped before the print statement.
     let string2 = String::from("xyz");
     let result;
@@ -21,7 +21,7 @@ fn main() {
     {
         let string2 = String::from("xyz");
         result = longest(&string1, &string2);
-        // Solution2: You can move the print statement into the inner block so
+        // Solution 2: You can move the print statement into the inner block so
         // that it is executed before `string2` is dropped.
         println!("The longest string is '{result}'");
         // `string2` dropped here (end of the inner scope).

--- a/solutions/21_macros/macros3.rs
+++ b/solutions/21_macros/macros3.rs
@@ -1,4 +1,4 @@
-// Added the attribute `macro_use` attribute.
+// Added the `macro_use` attribute.
 #[macro_use]
 mod macros {
     macro_rules! my_macro {


### PR DESCRIPTION
This PR updates comments within `solutions` directory to match with the ones in `exercise`.

- No functional changes

### Changes Made

**Matching exercise files**

- **hashmaps1.rs**: Replaced "e.g apple" with "e.g. apple"
- **errors5.rs**: Fixed capitalization - "To do so, The" -> "To do so, the"
- **options1.rs**: Renamed `maybe_icecream` to `maybe_ice_cream`

**Other changes**

- **strings4.rs**: Fixed grammar - "kept `&str`" -> "kept as `&str`"
- **macros3.rs**: Removed redundant word - "attribute `macro_use` attribute" -> "`macro_use` attribute"
- **lifetimes2.rs**: Added spaces - "Solution1/2" -> "Solution 1/2". This follows the convention used in another file.