### PR TITLE
Fix wording in quiz1 to match test condition

### DIFF
--- a/exercises/quizzes/quiz1.rs
+++ b/exercises/quizzes/quiz1.rs
@@ -5,7 +5,7 @@
 //
 // Mary is buying apples. The price of an apple is calculated as follows:
 // - An apple costs 2 rustbucks.
-// - However, if Mary buys more than 40 apples, the price of each apple in the
+// - However, if Mary buys 40 or more apples, the price of each apple in the
 // entire order is reduced to only 1 rustbuck!
 
 // TODO: Write a function that calculates the price of an order of apples given


### PR DESCRIPTION
This change updates the wording in quiz1 to match the test logic. The condition now correctly states "40 or more apples" instead of "more than 40".
Fixes #2326
