### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,13 +19,13 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Clippy
         run: cargo clippy -- --deny warnings
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: rustfmt
         run: cargo fmt --all --check
   test:
@@ -34,14 +34,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: swatinem/rust-cache@v2
       - name: cargo test
         run: cargo test --workspace
   dev-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: swatinem/rust-cache@v2
       - name: rustlings dev check
         run: cargo dev check --require-solutions

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install TailwindCSS
         run: npm install
       - name: Build CSS


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/website.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/rust.yml`
