### PR TITLE
Clarify TODO comments in options2 exercise

### DIFF
--- a/exercises/12_options/options2.rs
+++ b/exercises/12_options/options2.rs
@@ -9,7 +9,8 @@ mod tests {
         let target = "rustlings";
         let optional_target = Some(target);
 
-        // TODO: Make this an if-let statement whose value is `Some`.
+        // TODO: Complete this if-let statement by adding the missing keywords.
+        // The pattern should match oon 'Some'.
         word = optional_target {
             assert_eq!(word, target);
         }
@@ -26,9 +27,9 @@ mod tests {
 
         let mut cursor = range;
 
-        // TODO: Make this a while-let statement. Remember that `Vec::pop()`
-        // adds another layer of `Option`. You can do nested pattern matching
-        // in if-let and while-let statements.
+        // TODO: Complete this while-let statement by adding the missing keywords.
+        // Remember that `Vec::pop()` adds another layer of `Option`. 
+        // You can do nested pattern matching in if-let and while-let statements.
         integer = optional_integers.pop() {
             assert_eq!(integer, cursor);
             cursor -= 1;


### PR DESCRIPTION
Fixes #1990

## Summary
Clarified TODO comments in options2 exercise to indicate that the code needs to be completed rather than replaced.

## Problem
The current TODO comments say "Make this an if-let statement" and "Make this a while-let statement", which implies the existing code is already a valid statement that needs to be transformed into something else. This caused confusion for many learners who expected to replace valid code with different valid code.

In reality, the code is syntactically incomplete and needs keywords added (`if let` and `while let`) to become valid statements.

## Solution
Updated the TODO comments to explicitly state that learners need to complete the incomplete statements by adding the missing keywords and patterns.