### PR TITLE
docs: add str and String documentation links

### DIFF
--- a/exercises/09_strings/README.md
+++ b/exercises/09_strings/README.md
@@ -6,4 +6,6 @@ to identify and create them, as well as use them.
 
 ## Further information
 
-- [Strings](https://doc.rust-lang.org/book/ch08-02-strings.html)
+- [Strings (Rust Book)](https://doc.rust-lang.org/book/ch08-02-strings.html)
+- [`str` methods](https://doc.rust-lang.org/std/primitive.str.html)
+- [`String` methods](https://doc.rust-lang.org/std/string/struct.String.html)


### PR DESCRIPTION
Fixes #2338


Along with the Rust Book String chapter link. I also added links to `str` and `String` documentation in the Further information section to help users find methods like `.trim()` and `.replace()`.
