### PR TITLE
Mention struct-like variants in enums2 hint instead of anonymous structs

### DIFF
--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -440,7 +440,7 @@ dir = "08_enums"
 test = false
 hint = """
 You can create enumerations that have different variants with different types
-such as struct-like variants, regular structs, a single string, tuples, no data, etc."""
+such as struct-like, tuple-like and unit-only variants."""
 
 [[exercises]]
 name = "enums3"

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -440,7 +440,7 @@ dir = "08_enums"
 test = false
 hint = """
 You can create enumerations that have different variants with different types
-such as anonymous structs, structs, a single string, tuples, no data, etc."""
+such as struct-like variants, regular structs, a single string, tuples, no data, etc."""
 
 [[exercises]]
 name = "enums3"


### PR DESCRIPTION
The current hint of the enums2 exercise uses an outdated term for struct-like enum variants, which is confusing to Rust newbies:

> You can create enumerations that have different variants with different types such as anonymous structs, structs, a single string, tuples, no data, etc.

The term `anonymous struct` seems outdated. It's neither mentioned in the Rust book on [structs](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html) or [enums](https://doc.rust-lang.org/stable/book/ch06-01-defining-an-enum.html#listing-6-2), nor the references on [structs](https://doc.rust-lang.org/stable/reference/items/structs.html) or [enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.constructor).
A web search rather points to [a Rust Forum thread](https://users.rust-lang.org/t/is-the-anonymous-struct-unnamed-struct-still-in-progress/134416) hinting
> Don’t assume that there is such a thing as “the anonymous struct feature” at all

The only place I found this term, is in the Rust docs on [enums](https://doc.rust-lang.org/std/keyword.enum.html), but not in the docs on [structs](https://doc.rust-lang.org/std/keyword.struct.html).
It seems like Rust used this term once, but not anymore. See also #1204 and the 2018 edition [Rust book on enums](https://doc.rust-lang.org/1.30.0/book/2018-edition/ch06-01-defining-an-enum.html).

Instead the [book on enums](https://doc.rust-lang.org/stable/book/ch06-01-defining-an-enum.html#listing-6-2) now calls it `named fields, like a struct`.
The [reference on enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.constructor) uses the term `struct-like enum variant`.

Therefore, I'd suggest updating this hint to `struct-like enum variants`.