### PR TITLE
docs: clarify stale comment in cow1 owned_mutation test

### DIFF
--- a/exercises/19_smart_pointers/cow1.rs
+++ b/exercises/19_smart_pointers/cow1.rs
@@ -57,9 +57,10 @@ mod tests {
 
     #[test]
     fn owned_mutation() {
-        // Of course this is also the case if a mutation does occur (not all
-        // numbers are absolute). In this case, the call to `to_mut()` in the
-        // `abs_all` function returns a reference to the same data as before.
+        // This is also the case if a mutation does occur (not all numbers are
+        // absolute). Since `input` is already owned here, the call to
+        // `to_mut()` in `abs_all` returns a mutable reference to the existing
+        // owned data instead of cloning it.
         let vec = vec![-1, 0, 1];
         let mut input = Cow::from(vec);
         abs_all(&mut input);


### PR DESCRIPTION
## Summary
- update the stale comment in exercises/19_smart_pointers/cow1.rs
- clarify that 	o_mut() returns a mutable reference to already-owned data here
- remove the misleading implication that bs_all itself returns a reference

Closes #2303

## Validation
- unable to run cargo test owned_mutation --bin rustlings in this environment because Rust tooling (cargo, ustc) is not installed
- verified the change is comment-only and scoped to the referenced exercise text