### PR TITLE
fix: Better test for exercises/10_modules/modules1.rs

### DIFF
--- a/exercises/10_modules/modules1.rs
+++ b/exercises/10_modules/modules1.rs
@@ -14,3 +14,13 @@ mod sausage_factory {
 fn main() {
     sausage_factory::make_sausage();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_sausage() {
+        sausage_factory::make_sausage();
+    }
+}

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -517,7 +517,7 @@ because "blue" is `&str`, not `String`."""
 [[exercises]]
 name = "modules1"
 dir = "10_modules"
-test = false
+test = true
 hint = """
 Everything is private in Rust by default. But there's a keyword we can use
 to make something public!"""

--- a/solutions/10_modules/modules1.rs
+++ b/solutions/10_modules/modules1.rs
@@ -13,3 +13,13 @@ mod sausage_factory {
 fn main() {
     sausage_factory::make_sausage();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_sausage() {
+        sausage_factory::make_sausage();
+    }
+}


### PR DESCRIPTION
Fixes #2339

The `modules1` exercise could be passed by commenting out the call in `main`, since no test enforced that `make_sausage()` must be public. Adds a `#[cfg(test)]` block to `exercises/10_modules/modules1.rs` that calls `sausage_factory::make_sausage()` directly, and sets `test = true` in `rustlings-macros/info.toml` so rustlings actually runs `cargo test` against the exercise.