### PR TITLE
Add explicit ownership check to iterators1.rs

### DIFF
--- a/exercises/18_iterators/iterators1.rs
+++ b/exercises/18_iterators/iterators1.rs
@@ -21,5 +21,8 @@ mod tests {
         assert_eq!(fav_fruits_iterator.next(), todo!()); // TODO: Replace `todo!()`
         assert_eq!(fav_fruits_iterator.next(), Some(&"raspberry"));
         assert_eq!(fav_fruits_iterator.next(), todo!()); // TODO: Replace `todo!()`
+
+        // Ensures `my_fav_fruits` is not consumed by the iterator.
+        assert_eq!(my_fav_fruits.len(), 5);
     }
 }


### PR DESCRIPTION
Closes #2261

This PR adds an explicit check to the array after iterator creation to ensure it was not consumed.
I noticed that while that assert technically passes using `into_iter()` because `&str` implements `Copy`, adding this `len()` check reinforces the intent.