### PR TITLE
Use slice instead of array in iterator1

### DIFF
--- a/exercises/18_iterators/iterators1.rs
+++ b/exercises/18_iterators/iterators1.rs
@@ -10,9 +10,9 @@ fn main() {
 mod tests {
     #[test]
     fn iterators() {
-        let my_fav_fruits = ["banana", "custard apple", "avocado", "peach", "raspberry"];
+        let my_fav_fruits = &["banana", "custard apple", "avocado", "peach", "raspberry"];
 
-        // TODO: Create an iterator over the array.
+        // TODO: Create an iterator over the slice.
         let mut fav_fruits_iterator = todo!();
 
         assert_eq!(fav_fruits_iterator.next(), Some(&"banana"));

--- a/solutions/18_iterators/iterators1.rs
+++ b/solutions/18_iterators/iterators1.rs
@@ -10,9 +10,9 @@ fn main() {
 mod tests {
     #[test]
     fn iterators() {
-        let my_fav_fruits = ["banana", "custard apple", "avocado", "peach", "raspberry"];
+        let my_fav_fruits = &["banana", "custard apple", "avocado", "peach", "raspberry"];
 
-        // Create an iterator over the array.
+        // Create an iterator over the slice.
         let mut fav_fruits_iterator = my_fav_fruits.iter();
 
         assert_eq!(fav_fruits_iterator.next(), Some(&"banana"));


### PR DESCRIPTION
This avoids confusion between `.into_iter()` and `.iter()`. On a slice, both methods do the same (correct) thing. Using `.into_iter()` will result in a clippy warning about the slice not being consumed.

closes #2261