### PR TITLE
Redesign vec1 to avoid confusing array literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `vecs2`: Removed the use of `map` and `collect`, which are only taught later.
 - `structs3`: Rewrote the exercise to make users type method syntax themselves.
 - Rename the exercises for smart pointers and conversions so they're sorted alphabetically. [@foxfromworld](https://github.com/foxfromworld)
+- `vecs1`: Remove array literal. Some learners assumed their task is to convert it to a vector.
 
 ## 6.5.0 (2025-08-21)
 

--- a/exercises/05_vecs/vecs1.rs
+++ b/exercises/05_vecs/vecs1.rs
@@ -1,11 +1,6 @@
-fn array_and_vec() -> ([i32; 4], Vec<i32>) {
-    let a = [10, 20, 30, 40]; // Array
-
-    // TODO: Create a vector called `v` which contains the exact same elements as in the array `a`.
-    // Use the vector macro.
-    // let v = ???;
-
-    (a, v)
+fn elems_to_vec(a: i32, b: i32, c: i32) -> Vec<i32> {
+    // TODO: Return a vector containing the elements a, b and c.
+    // Use the "vec!" macro.
 }
 
 fn main() {
@@ -17,8 +12,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_array_and_vec_similarity() {
-        let (a, v) = array_and_vec();
-        assert_eq!(a, *v);
+    fn test_elems_to_vec() {
+        let (a, b, c) = (2, 7, 12);
+        let v = elems_to_vec(a, b, c);
+        assert_eq!(v[0], a);
+        assert_eq!(v[1], b);
+        assert_eq!(v[2], c);
     }
 }

--- a/exercises/05_vecs/vecs1.rs
+++ b/exercises/05_vecs/vecs1.rs
@@ -1,5 +1,5 @@
 fn elems_to_vec(a: i32, b: i32, c: i32) -> Vec<i32> {
-    // TODO: Return a vector containing the elements a, b and c.
+    // TODO: Return a vector containing the elements a, b and c (in this order).
     // Use the "vec!" macro.
 }
 

--- a/solutions/05_vecs/vecs1.rs
+++ b/solutions/05_vecs/vecs1.rs
@@ -1,10 +1,5 @@
-fn array_and_vec() -> ([i32; 4], Vec<i32>) {
-    let a = [10, 20, 30, 40]; // Array
-
-    // Used the `vec!` macro.
-    let v = vec![10, 20, 30, 40];
-
-    (a, v)
+fn elems_to_vec(a: i32, b: i32, c: i32) -> Vec<i32> {
+    vec![a, b, c]
 }
 
 fn main() {
@@ -16,8 +11,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_array_and_vec_similarity() {
-        let (a, v) = array_and_vec();
-        assert_eq!(a, *v);
+    fn test_elems_to_vec() {
+        let (a, b, c) = (2, 7, 12);
+        let v = elems_to_vec(a, b, c);
+        assert_eq!(v[0], a);
+        assert_eq!(v[1], b);
+        assert_eq!(v[2], c);
     }
 }


### PR DESCRIPTION
Learners were sometimes confused by the literal array. Their assumption was that they are supposed to convert the array to a vector. Duplicating the literal elements was not an intuitive solution.

This redesign avoids putting an identical array literal near the place where learners are supposed to use the vec! macro.