### PR TITLE
Clarify instructions for modules2.rs (issue #1346)

### DIFF
--- a/exercises/10_modules/modules2.rs
+++ b/exercises/10_modules/modules2.rs
@@ -3,6 +3,7 @@
 
 mod delicious_snacks {
     // TODO: Add the following two `use` statements after fixing them.
+    // Hint: private imports require re-exporting.
     // use self::fruits::PEAR as ???;
     // use self::veggies::CUCUMBER as ???;
 


### PR DESCRIPTION
This PR updates the TODO comment in `modules2.rs` to clarify that the `use` items are private and require re-exporting. This addresses the confusion reported in issue #1346.