### PR TITLE
fix: remove ambiguous strings4 into example

### DIFF
--- a/exercises/09_strings/strings4.rs
+++ b/exercises/09_strings/strings4.rs
@@ -21,8 +21,6 @@ fn main() {
 
     placeholder("rust is fun!".to_owned());
 
-    placeholder("nice weather".into());
-
     placeholder(format!("Interpolation {}", "Station"));
 
     // WARNING: This is byte indexing, not character indexing.

--- a/solutions/09_strings/strings4.rs
+++ b/solutions/09_strings/strings4.rs
@@ -15,15 +15,6 @@ fn main() {
 
     string("rust is fun!".to_owned());
 
-    // Here, both answers work.
-    // `.into()` converts a type into an expected type.
-    // If it is called where `String` is expected, it will convert `&str` to `String`.
-    string("nice weather".into());
-    // But if it is called where `&str` is expected, then `&str` is kept as `&str` since no conversion is needed.
-    // If you remove the `#[allow(…)]` line, then Clippy will tell you to remove `.into()` below since it is a useless conversion.
-    #[allow(clippy::useless_conversion)]
-    string_slice("nice weather".into());
-
     string(format!("Interpolation {}", "Station"));
 
     // WARNING: This is byte indexing, not character indexing.


### PR DESCRIPTION
## Summary
- remove the ambiguous `"nice weather".into()` prompt from `strings4`
- remove the corresponding solution explanation and `#[allow(clippy::useless_conversion)]` example
- keep `strings4` focused on values that have one clear `String` vs `&str` answer before conversion traits are introduced

Fixes #2190.

## Test Plan
- `cargo fmt --check`
- `cargo check --manifest-path dev/Cargo.toml --bin strings4_sol`
- `cargo clippy --manifest-path dev/Cargo.toml --bin strings4_sol -- -D warnings`
- `cargo test --manifest-path dev/Cargo.toml --bin strings4_sol`
- `cargo test`
