### PR TITLE
docs: mention offline rustup docs in intro

### DIFF
--- a/exercises/00_intro/README.md
+++ b/exercises/00_intro/README.md
@@ -4,5 +4,9 @@ Rust uses the `print!` and `println!` macros to print text to the console.
 
 ## Further information
 
+If you installed Rust with `rustup`, you can also open local, offline copies of
+Rust's documentation with commands such as `rustup doc --book`,
+`rustup doc --std` and `rustup doc --rust-by-example`.
+
 - [Hello World](https://doc.rust-lang.org/rust-by-example/hello.html)
 - [Formatted print](https://doc.rust-lang.org/rust-by-example/hello/print.html)


### PR DESCRIPTION
## Summary
- Add a short note to the intro exercise README explaining that rustup users can open offline copies of the Book, standard library docs, and Rust by Example.

Closes #1501

## Verification
- cargo fmt --check
- cargo test

## Risk
- Documentation-only change; no runtime behavior changes.