### PR TITLE
fix: remove ambiguous .into() example from strings4

### DIFF
--- a/exercises/09_strings/strings4.rs
+++ b/exercises/09_strings/strings4.rs
@@ -21,8 +21,6 @@ fn main() {
 
     placeholder("rust is fun!".to_owned());
 
-    placeholder("nice weather".into());
-
     placeholder(format!("Interpolation {}", "Station"));
 
     // WARNING: This is byte indexing, not character indexing.

--- a/solutions/09_strings/strings4.rs
+++ b/solutions/09_strings/strings4.rs
@@ -15,15 +15,6 @@ fn main() {
 
     string("rust is fun!".to_owned());
 
-    // Here, both answers work.
-    // `.into()` converts a type into an expected type.
-    // If it is called where `String` is expected, it will convert `&str` to `String`.
-    string("nice weather".into());
-    // But if it is called where `&str` is expected, then `&str` is kept as `&str` since no conversion is needed.
-    // If you remove the `#[allow(…)]` line, then Clippy will tell you to remove `.into()` below since it is a useless conversion.
-    #[allow(clippy::useless_conversion)]
-    string_slice("nice weather".into());
-
     string(format!("Interpolation {}", "Station"));
 
     // WARNING: This is byte indexing, not character indexing.


### PR DESCRIPTION
## Reproduce

```
gh repo fork rust-lang/rustlings --clone
cd rustlings
```

Toolchain: `cargo 1.90.0`, `rustc 1.90.0`, `clippy 0.1.90`.

Solve `exercises/09_strings/strings4.rs` and, on line 24, choose `string_slice` for the `.into()` value:

```rust
string_slice("nice weather".into());
```

The exercise reports success, yet clippy still warns. Both happen at once, which is the bug in #2190.

## Before (raw clippy log)

```
warning: useless conversion to the same type: `&str`
  --> exercises/09_strings/strings4.rs:24:18
   |
24 |     string_slice("nice weather".into());
   |                  ^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"nice weather"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
   = note: `#[warn(clippy::useless_conversion)]` on by default

warning: 1 warning emitted
```

The exercise nonetheless passes:

```
✓ Successfully ran exercises/09_strings/strings4.rs
```

## After (raw log)

clippy on the solution, no output (no warnings):

```
$ clippy-driver --edition 2021 solutions/09_strings/strings4.rs
```

run still passes:

```
✓ Successfully ran exercises/09_strings/strings4.rs
```

## How

`.into()` on a `&str` literal is satisfiable two ways: it converts to `String` for `string(...)`, or stays `&str` for `string_slice(...)`, and the latter is a `clippy::useless_conversion`. So the line had a hidden second correct-by-the-checker answer that still warns, letting the exercise pass dirty.

Picking the right target requires reasoning about the `From` trait, which rustlings introduces later (the conversions exercises), so the line is out of place here regardless of the warning. Following maintainer @senekor in the issue thread, I removed the `.into()` example from both the exercise and the solution rather than papering over it with `#[allow]`/`#[deny]`. The solution previously used `#[allow(clippy::useless_conversion)]` to hide exactly this warning; that workaround is gone too.

Fixes #2190