### PR TITLE
fix: standard English grammar/phrasing

### DIFF
--- a/exercises/11_hashmaps/hashmaps3.rs
+++ b/exercises/11_hashmaps/hashmaps3.rs
@@ -2,7 +2,7 @@
 // the form "<team_1_name>,<team_2_name>,<team_1_goals>,<team_2_goals>"
 // Example: "England,France,4,2" (England scored 4 goals, France 2).
 //
-// You have to build a scores table containing the name of the team, the total
+// You have to build a table of scores containing the name of the team, the total
 // number of goals the team scored, and the total number of goals the team
 // conceded.
 
@@ -15,19 +15,19 @@ struct TeamScores {
     goals_conceded: u8,
 }
 
-fn build_scores_table(results: &str) -> HashMap<&str, TeamScores> {
+fn build_score_table(results: &str) -> HashMap<&str, TeamScores> {
     // The name of the team is the key and its associated struct is the value.
     let mut scores = HashMap::<&str, TeamScores>::new();
 
     for line in results.lines() {
         let mut split_iterator = line.split(',');
-        // NOTE: We use `unwrap` because we didn't deal with error handling yet.
+        // NOTE: We use `unwrap` because we haven't dealt with error handling yet.
         let team_1_name = split_iterator.next().unwrap();
         let team_2_name = split_iterator.next().unwrap();
         let team_1_score: u8 = split_iterator.next().unwrap().parse().unwrap();
         let team_2_score: u8 = split_iterator.next().unwrap().parse().unwrap();
 
-        // TODO: Populate the scores table with the extracted details.
+        // TODO: Populate the score table with the extracted details.
         // Keep in mind that goals scored by team 1 will be the number of goals
         // conceded by team 2. Similarly, goals scored by team 2 will be the
         // number of goals conceded by team 1.
@@ -52,7 +52,7 @@ England,Spain,1,0";
 
     #[test]
     fn build_scores() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
 
         assert!(["England", "France", "Germany", "Italy", "Poland", "Spain"]
             .into_iter()
@@ -61,7 +61,7 @@ England,Spain,1,0";
 
     #[test]
     fn validate_team_score_1() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
         let team = scores.get("England").unwrap();
         assert_eq!(team.goals_scored, 6);
         assert_eq!(team.goals_conceded, 4);
@@ -69,7 +69,7 @@ England,Spain,1,0";
 
     #[test]
     fn validate_team_score_2() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
         let team = scores.get("Spain").unwrap();
         assert_eq!(team.goals_scored, 0);
         assert_eq!(team.goals_conceded, 3);

--- a/solutions/11_hashmaps/hashmaps3.rs
+++ b/solutions/11_hashmaps/hashmaps3.rs
@@ -2,7 +2,7 @@
 // the form "<team_1_name>,<team_2_name>,<team_1_goals>,<team_2_goals>"
 // Example: "England,France,4,2" (England scored 4 goals, France 2).
 //
-// You have to build a scores table containing the name of the team, the total
+// You have to build a table of scores containing the name of the team, the total
 // number of goals the team scored, and the total number of goals the team
 // conceded.
 
@@ -15,13 +15,13 @@ struct TeamScores {
     goals_conceded: u8,
 }
 
-fn build_scores_table(results: &str) -> HashMap<&str, TeamScores> {
+fn build_score_table(results: &str) -> HashMap<&str, TeamScores> {
     // The name of the team is the key and its associated struct is the value.
     let mut scores = HashMap::<&str, TeamScores>::new();
 
     for line in results.lines() {
         let mut split_iterator = line.split(',');
-        // NOTE: We use `unwrap` because we didn't deal with error handling yet.
+        // NOTE: We use `unwrap` because we haven't dealt with error handling yet.
         let team_1_name = split_iterator.next().unwrap();
         let team_2_name = split_iterator.next().unwrap();
         let team_1_score: u8 = split_iterator.next().unwrap().parse().unwrap();
@@ -58,7 +58,7 @@ England,Spain,1,0";
 
     #[test]
     fn build_scores() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
 
         assert!(
             ["England", "France", "Germany", "Italy", "Poland", "Spain"]
@@ -69,7 +69,7 @@ England,Spain,1,0";
 
     #[test]
     fn validate_team_score_1() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
         let team = scores.get("England").unwrap();
         assert_eq!(team.goals_scored, 6);
         assert_eq!(team.goals_conceded, 4);
@@ -77,7 +77,7 @@ England,Spain,1,0";
 
     #[test]
     fn validate_team_score_2() {
-        let scores = build_scores_table(RESULTS);
+        let scores = build_score_table(RESULTS);
         let team = scores.get("Spain").unwrap();
         assert_eq!(team.goals_scored, 0);
         assert_eq!(team.goals_conceded, 3);


### PR DESCRIPTION
In `hashmaps3.rs` I always stumble and find the task hard to understand. Being a native English speaker and language nerd I find the nonnative wording in that particular task to be a further distraction from trying to grok the problem.

English noun compounds only use a plural for the adjunct in rare exceptions (though it's becoming more common). "train station", "car park", and "score table" sound more idiomatic than "trains station", "cars park", or "scores table". Though "table of scores" is perhaps even more idiomatic.

There's also a nonnative English use of the simple past referring to a topic we haven't dealt with yet that I may as well fix while I'm here.