### PR TITLE
docs: updated outdated run command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ When updating an exercise, check if its solution needs to be updated.
 - In the exercise, add a `// TODO: …` comment where user changes are required.
 - Add a solution at `solutions/yourTopic/yourTopicN.rs` with comments explaining it.
 - Add the [metadata for your exercise](#exercise-metadata) in the `rustlings-macros/info.toml` file.
-- Make sure your exercise runs with `rustlings run yourTopicN`.
+- Make sure your exercise runs with `cargo run --bin rustlings --run yourTopicN`.
+To run all tests locally, `use cargo run --bin rustlings -- dev check`.
 - [Open a pull request](#pull-requests).
 
 ### Exercise Metadata


### PR DESCRIPTION
This fixes issue #2415.

The contributing guide previously told developers to use `rustlings run`, which gives an error in version 6. 
I updated it to `cargo run --bin rustlings -- run` for testing single exercises, and added a note about `cargo run --bin rustlings -- dev check` for running all tests locally.