### PR TITLE
Clarify options2 exercise comments

### DIFF
--- a/exercises/12_options/options2.rs
+++ b/exercises/12_options/options2.rs
@@ -9,7 +9,8 @@ mod tests {
         let target = "rustlings";
         let optional_target = Some(target);
 
-        // TODO: Make this an if-let statement whose value is `Some`.
+        // TODO: Use an if-let statement to bind the value inside
+        // `optional_target` to `word`.
         word = optional_target {
             assert_eq!(word, target);
         }
@@ -26,9 +27,16 @@ mod tests {
 
         let mut cursor = range;
 
-        // TODO: Make this a while-let statement. Remember that `Vec::pop()`
-        // adds another layer of `Option`. You can do nested pattern matching
-        // in if-let and while-let statements.
+        // TODO: Make this a while-let statement. The loop should keep popping
+        // integers from the end of the vector until there is no integer left to
+        // check.
+        //
+        // `Vec::pop()` removes the last element from the vector and returns it,
+        // or returns `None` if the vector is empty. Since this vector stores
+        // `Option<i8>` values, a successful pop returns the vector's inner
+        // `Option<i8>` wrapped in another `Option`.
+        // You can use nested pattern matching in if-let and while-let
+        // statements.
         integer = optional_integers.pop() {
             assert_eq!(integer, cursor);
             cursor -= 1;


### PR DESCRIPTION
## Summary

- Clarify that the first TODO should bind the inner `Option` value to `word` with `if let`.
- Explain what `Vec::pop()` does and why popping from `Vec<Option<i8>>` produces nested `Option` values.
- Add a short description of the intended `while let` loop behavior.

## Testing

- `cargo fmt --all --check`

I also tried broader local checks, but they were blocked by unrelated/current local issues: `cargo dev check --require-solutions` stopped on `exercises/03_if/if1.rs` metadata, and `cargo test --workspace` on Windows stopped because `cmd::tests::test_run_cmd` could not find an `echo` program.

## Disclosure

This PR was prepared with assistance from OpenAI Codex.