### PR TITLE
Fix clippy warnings in quiz3 solution

### DIFF
--- a/exercises/quizzes/quiz2.rs
+++ b/exercises/quizzes/quiz2.rs
@@ -10,7 +10,7 @@
 // is going to be applied to the string. It can either be:
 // - Uppercase the string
 // - Trim the string
-// - Append "bar" to the string a specified amount of times
+// - Append "bar" to the end of the string a specified amount of times
 //
 // The exact form of this will be:
 // - The input is going to be a Vector of 2-length tuples,
@@ -48,6 +48,7 @@ mod tests {
             ("foo".to_string(), Command::Append(1)),
             ("bar".to_string(), Command::Append(5)),
         ];
+
         let output = transformer(input);
 
         assert_eq!(

--- a/solutions/quizzes/quiz3.rs
+++ b/solutions/quizzes/quiz3.rs
@@ -24,7 +24,7 @@ impl<T: Display> ReportCard<T> {
     fn print(&self) -> String {
         format!(
             "{} ({}) - achieved a grade of {}",
-            &self.student_name, &self.student_age, &self.grade,
+            self.student_name, self.student_age, self.grade,
         )
     }
 }


### PR DESCRIPTION
## Description

Fixes clippy warnings in the quiz3 solution caused by unnecessary references in `format!`.

## Changes

- Removed redundant `&` references from `format!` arguments.

## Testing

- `cargo dev check --require-solutions`