### PR TITLE
Fix clippy warnings in quiz3 solution

### DIFF
--- a/solutions/quizzes/quiz3.rs
+++ b/solutions/quizzes/quiz3.rs
@@ -24,7 +24,7 @@ impl<T: Display> ReportCard<T> {
     fn print(&self) -> String {
         format!(
             "{} ({}) - achieved a grade of {}",
-            &self.student_name, &self.student_age, &self.grade,
+            self.student_name, self.student_age, self.grade,
         )
     }
 }


### PR DESCRIPTION
## Description

Fixes clippy warnings in the quiz3 solution caused by unnecessary references in `format!`.

## Changes

- Removed redundant `&` references from `format!` arguments.