### PR TITLE
Fix stale exercise references

### DIFF
--- a/exercises/18_iterators/iterators5.rs
+++ b/exercises/18_iterators/iterators5.rs
@@ -27,7 +27,7 @@ fn count_for(map: &HashMap<String, Progress>, value: Progress) -> usize {
 // of a `for` loop.
 fn count_iterator(map: &HashMap<String, Progress>, value: Progress) -> usize {
     // `map` is a hash map with `String` keys and `Progress` values.
-    // map = { "variables1": Complete, "from_str": None, … }
+    // map = { "variables1": Complete, "conversions3": None, … }
 }
 
 fn count_collection_for(collection: &[HashMap<String, Progress>], value: Progress) -> usize {
@@ -46,7 +46,7 @@ fn count_collection_for(collection: &[HashMap<String, Progress>], value: Progres
 // iterator instead of a `for` loop.
 fn count_collection_iterator(collection: &[HashMap<String, Progress>], value: Progress) -> usize {
     // `collection` is a slice of hash maps.
-    // collection = [{ "variables1": Complete, "from_str": None, … },
+    // collection = [{ "variables1": Complete, "conversions3": None, … },
     //               { "variables2": Complete, … }, … ]
 }
 
@@ -64,10 +64,10 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(String::from("variables1"), Complete);
         map.insert(String::from("functions1"), Complete);
-        map.insert(String::from("hashmap1"), Complete);
-        map.insert(String::from("arc1"), Some);
-        map.insert(String::from("as_ref_mut"), None);
-        map.insert(String::from("from_str"), None);
+        map.insert(String::from("hashmaps1"), Complete);
+        map.insert(String::from("smart_pointers3"), Some);
+        map.insert(String::from("conversions5"), None);
+        map.insert(String::from("conversions3"), None);
 
         map
     }
@@ -81,8 +81,8 @@ mod tests {
         other.insert(String::from("variables2"), Complete);
         other.insert(String::from("functions2"), Complete);
         other.insert(String::from("if1"), Complete);
-        other.insert(String::from("from_into"), None);
-        other.insert(String::from("try_from_into"), None);
+        other.insert(String::from("conversions2"), None);
+        other.insert(String::from("conversions4"), None);
 
         vec![map, other]
     }

--- a/exercises/23_conversions/conversions3.rs
+++ b/exercises/23_conversions/conversions3.rs
@@ -1,7 +1,7 @@
 // In this exercise, we'll implement `FromStr` and return errors instead of
-// falling back to a default value. Upon implementing `FromStr`, you can use the
-// `parse` method on strings to generate an object of the implementor type.
-// You can read more about it in the documentation:
+// falling back to a default value. Additionally, upon implementing `FromStr`,
+// you can use the `parse` method on strings to generate an object of the
+// implementor type. You can read more about it in the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;

--- a/exercises/23_conversions/conversions3.rs
+++ b/exercises/23_conversions/conversions3.rs
@@ -1,8 +1,7 @@
-// This is similar to the previous `from_into` exercise. But this time, we'll
-// implement `FromStr` and return errors instead of falling back to a default
-// value. Additionally, upon implementing `FromStr`, you can use the `parse`
-// method on strings to generate an object of the implementor type. You can read
-// more about it in the documentation:
+// In this exercise, we'll implement `FromStr` and return errors instead of
+// falling back to a default value. Upon implementing `FromStr`, you can use the
+// `parse` method on strings to generate an object of the implementor type.
+// You can read more about it in the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;

--- a/exercises/23_conversions/conversions3.rs
+++ b/exercises/23_conversions/conversions3.rs
@@ -1,7 +1,9 @@
-// In this exercise, we'll implement `FromStr` and return errors instead of
-// falling back to a default value. Additionally, upon implementing `FromStr`,
-// you can use the `parse` method on strings to generate an object of the
-// implementor type. You can read more about it in the documentation:
+// In this exercise, we'll implement `FromStr` to convert data stored as a
+// string into a structured type. Unlike the `From` trait, the conversion
+// expressed by `FromStr` can fail, so it returns a `Result`. Additionally,
+// upon implementing `FromStr`, you can use the `parse` method on strings to
+// generate an object of the implementor type. You can read more about it in
+// the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;

--- a/rustlings-macros/info.toml
+++ b/rustlings-macros/info.toml
@@ -1186,9 +1186,6 @@ hint = """
 The implementation of `FromStr` should return an `Ok` with a `Person` object,
 or an `Err` with an error if the string is not valid.
 
-This is almost like the previous `from_into` exercise, but returning errors
-instead of falling back to a default value.
-
 Another hint: You can use the `map_err` method of `Result` with a function or a
 closure to wrap the error from `parse::<u8>`.
 

--- a/solutions/18_iterators/iterators5.rs
+++ b/solutions/18_iterators/iterators5.rs
@@ -25,7 +25,7 @@ fn count_for(map: &HashMap<String, Progress>, value: Progress) -> usize {
 
 fn count_iterator(map: &HashMap<String, Progress>, value: Progress) -> usize {
     // `map` is a hash map with `String` keys and `Progress` values.
-    // map = { "variables1": Complete, "from_str": None, … }
+    // map = { "variables1": Complete, "conversions3": None, … }
     map.values().filter(|val| **val == value).count()
 }
 
@@ -39,7 +39,7 @@ fn count_collection_for(collection: &[HashMap<String, Progress>], value: Progres
 
 fn count_collection_iterator(collection: &[HashMap<String, Progress>], value: Progress) -> usize {
     // `collection` is a slice of hash maps.
-    // collection = [{ "variables1": Complete, "from_str": None, … },
+    // collection = [{ "variables1": Complete, "conversions3": None, … },
     //               { "variables2": Complete, … }, … ]
     collection
         .iter()
@@ -55,7 +55,7 @@ fn count_collection_iterator_flat(
     value: Progress,
 ) -> usize {
     // `collection` is a slice of hash maps.
-    // collection = [{ "variables1": Complete, "from_str": None, … },
+    // collection = [{ "variables1": Complete, "conversions3": None, … },
     //               { "variables2": Complete, … }, … ]
     collection
         .iter()
@@ -77,10 +77,10 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(String::from("variables1"), Complete);
         map.insert(String::from("functions1"), Complete);
-        map.insert(String::from("hashmap1"), Complete);
-        map.insert(String::from("arc1"), Some);
-        map.insert(String::from("as_ref_mut"), None);
-        map.insert(String::from("from_str"), None);
+        map.insert(String::from("hashmaps1"), Complete);
+        map.insert(String::from("smart_pointers3"), Some);
+        map.insert(String::from("conversions5"), None);
+        map.insert(String::from("conversions3"), None);
 
         map
     }
@@ -92,8 +92,8 @@ mod tests {
         other.insert(String::from("variables2"), Complete);
         other.insert(String::from("functions2"), Complete);
         other.insert(String::from("if1"), Complete);
-        other.insert(String::from("from_into"), None);
-        other.insert(String::from("try_from_into"), None);
+        other.insert(String::from("conversions2"), None);
+        other.insert(String::from("conversions4"), None);
 
         vec![map, other]
     }

--- a/solutions/23_conversions/conversions3.rs
+++ b/solutions/23_conversions/conversions3.rs
@@ -1,7 +1,7 @@
 // In this exercise, we'll implement `FromStr` and return errors instead of
-// falling back to a default value. Upon implementing `FromStr`, you can use the
-// `parse` method on strings to generate an object of the implementor type.
-// You can read more about it in the documentation:
+// falling back to a default value. Additionally, upon implementing `FromStr`,
+// you can use the `parse` method on strings to generate an object of the
+// implementor type. You can read more about it in the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;

--- a/solutions/23_conversions/conversions3.rs
+++ b/solutions/23_conversions/conversions3.rs
@@ -1,8 +1,7 @@
-// This is similar to the previous `from_into` exercise. But this time, we'll
-// implement `FromStr` and return errors instead of falling back to a default
-// value. Additionally, upon implementing `FromStr`, you can use the `parse`
-// method on strings to generate an object of the implementor type. You can read
-// more about it in the documentation:
+// In this exercise, we'll implement `FromStr` and return errors instead of
+// falling back to a default value. Upon implementing `FromStr`, you can use the
+// `parse` method on strings to generate an object of the implementor type.
+// You can read more about it in the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;

--- a/solutions/23_conversions/conversions3.rs
+++ b/solutions/23_conversions/conversions3.rs
@@ -1,7 +1,9 @@
-// In this exercise, we'll implement `FromStr` and return errors instead of
-// falling back to a default value. Additionally, upon implementing `FromStr`,
-// you can use the `parse` method on strings to generate an object of the
-// implementor type. You can read more about it in the documentation:
+// In this exercise, we'll implement `FromStr` to convert data stored as a
+// string into a structured type. Unlike the `From` trait, the conversion
+// expressed by `FromStr` can fail, so it returns a `Result`. Additionally,
+// upon implementing `FromStr`, you can use the `parse` method on strings to
+// generate an object of the implementor type. You can read more about it in
+// the documentation:
 // https://doc.rust-lang.org/std/str/trait.FromStr.html
 
 use std::num::ParseIntError;


### PR DESCRIPTION
## Summary

- Update stale exercise names in `iterators5`.
- Remove outdated references to the former `from_into` exercise from `conversions3`.

The stale names do not affect the `iterators5` test results, but its maps represent exercise progress and should use current identifiers.

`from_into` was renamed to `conversions2`, which was later redesigned and is no longer a valid comparison for `conversions3`.

No exercise behavior was changed.

## Testing

- `cargo fmt --all --check`
- `cargo clippy -- --deny warnings`
- `cargo test --workspace`
- `cargo dev check --require-solutions`
